### PR TITLE
007 forecast msg cleanup

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,23 @@
 <!--
 SYNC IMPACT REPORT
 ==================
+[2026-03-04 — New feature addition: constitution validation pass]
+  - Constitution reused as-is; no new principles required for incremental feature work.
+  - Session intent: validate constitution readiness before beginning a new SpecKit feature
+    on an already-existing codebase.
+  - All placeholder tokens remain resolved; no bracket tokens present.
+  - Version 1.1.0 footer consistent with all sections.
+  - Templates confirmed aligned:
+      ✅ .specify/templates/plan-template.md    — Constitution Check gate is dynamic ("based
+           on constitution file"), no hardcoded principle list; no changes needed.
+      ✅ .specify/templates/spec-template.md    — generic structure; no stale references.
+      ✅ .specify/templates/tasks-template.md   — phase structure generic; aligns with I–VII.
+      ✅ .specify/templates/agent-file-template.md — all generic placeholders; no stale names.
+      ✅ .specify/templates/checklist-template.md  — not in scope for this pass; no issues.
+  - No stale agent-specific references detected.
+  - No version bump required; Last Amended date remains 2026-03-03 (no content amendments).
+  - No deferred TODOs.
+
 [2026-03-04 — Session reuse: behavior correction]
   - Constitution reused as-is from previous session (no principle amendments).
   - Session intent: identify and correct a bug / incorrect runtime behavior in the application.

--- a/specs/001-forecast-msg-cleanup/spec.md
+++ b/specs/001-forecast-msg-cleanup/spec.md
@@ -1,0 +1,190 @@
+# Feature Specification: Forecast Channel Message Cleanup
+
+**Feature Branch**: `001-forecast-msg-cleanup`  
+**Created**: 2026-03-04  
+**Status**: Draft  
+**Input**: User description: "Before posting the Phase 2 output message for a given round and division, delete the Phase 1 output message for that same round and division. Before posting the Phase 3 output message, delete the Phase 2 output message. 24 hours after a round starts, delete the Phase 3 output message. This keeps forecast channels tidy and easy to read."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Phase Transition Replaces Previous Forecast (Priority: P1)
+
+A league member opens the division's weather forecast channel before a race weekend.
+Instead of seeing a growing stack of Phase 1, Phase 2, and Phase 3 messages from the same
+round, they see only the most recent phase message. When Phase 2 is posted, Phase 1 is gone.
+When Phase 3 is posted, Phase 2 is gone.
+
+**Why this priority**: This is the core requirement. Without phase-to-phase cleanup the channel
+becomes cluttered with superseded forecasts, which is the primary pain the feature addresses.
+
+**Independent Test**: Can be fully tested by triggering Phase 1 posting for a round, then
+triggering Phase 2 for the same round, and confirming that only the Phase 2 message exists
+in the forecast channel for that round and division.
+
+**Acceptance Scenarios**:
+
+1. **Given** Phase 1 has been posted for Round R in Division D, **When** Phase 2 is posted
+   for Round R / Division D, **Then** the Phase 1 message no longer exists in the Division D
+   forecast channel and the Phase 2 message is present.
+2. **Given** Phase 2 has been posted for Round R in Division D, **When** Phase 3 is posted
+   for Round R / Division D, **Then** the Phase 2 message no longer exists in the Division D
+   forecast channel and the Phase 3 message is present.
+3. **Given** Phase 1 has been posted for Round R in Division D **and** Phase 1 has been
+   posted for Round S in Division D, **When** Phase 2 is posted for Round R / Division D,
+   **Then** only the Phase 1 message for Round R is deleted; Round S Phase 1 message is
+   unaffected.
+4. **Given** Phase 1 has been posted for Round R in Division A **and** Phase 1 has been
+   posted for Round R in Division B, **When** Phase 2 is posted for Round R / Division A,
+   **Then** only Division A's Phase 1 message is deleted; Division B's Phase 1 message is
+   unaffected.
+
+---
+
+### User Story 2 - Post-Race Forecast Expiry (Priority: P2)
+
+After a race weekend has concluded, a league member opens the forecast channel and sees a
+clean state with no old Phase 3 message still pinned there. The Phase 3 message automatically
+disappears 24 hours after the round's scheduled start time.
+
+**Why this priority**: Completes the full cleanup lifecycle. Without this, Phase 3 messages
+accumulate across rounds and the channel still becomes cluttered over a season.
+
+**Independent Test**: Can be fully tested by verifying that a Phase 3 message previously
+present in the channel is absent when checked 24 hours (± a short scheduling tolerance) after
+the round's scheduled start time.
+
+**Acceptance Scenarios**:
+
+1. **Given** Phase 3 has been posted for Round R in Division D and the round's scheduled
+   start time has passed, **When** exactly 24 hours after the scheduled start time elapses,
+   **Then** the Phase 3 message for Round R / Division D no longer exists in the forecast
+   channel.
+2. **Given** Phase 3 has been posted for Round R in Division D, **When** only 23 hours have
+   elapsed since the scheduled start time, **Then** the Phase 3 message is still present in
+   the forecast channel.
+3. **Given** Phase 3 messages exist for multiple rounds across multiple divisions,
+   **When** the 24-hour expiry fires for one specific round/division combination, **Then**
+   only that specific Phase 3 message is deleted; all others remain.
+
+---
+
+### User Story 3 - Resilient Deletion (Priority: P3)
+
+The bot attempts to delete a forecast message that has already been manually removed by a
+server administrator. The bot handles this gracefully: it logs the situation and continues
+posting the next phase message without failing or generating a visible error.
+
+**Why this priority**: Defensive behavior that prevents a missing message from breaking
+the pipeline. Less critical than the happy path but necessary for production reliability.
+
+**Independent Test**: Can be fully tested by manually deleting a Phase 1 message from the
+channel, then triggering Phase 2, and confirming that Phase 2 posts successfully and the bot
+does not error out.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Phase 1 message for Round R / Division D has been manually deleted from the
+   channel before Phase 2 fires, **When** Phase 2 runs for Round R / Division D, **Then**
+   Phase 2 is posted successfully, the missing message is logged, and no error is surfaced
+   to users.
+2. **Given** the bot does not have permission to delete messages in the forecast channel,
+   **When** a phase transition or 24-hour expiry fires, **Then** the deletion failure is
+   logged, the next phase message is still posted (for phase transitions), and no error
+   is surfaced to users.
+
+---
+
+### Edge Cases
+
+- What happens when a round is amended and a phase is invalidated after its message was
+  already posted? The stored message ID for the invalidated phase must be cleared and the
+  message deleted (or recorded as already-gone) before the re-run phase posts a fresh
+  message.
+- What happens when the bot restarts between when a phase was posted and when the deletion
+  should occur? Stored message IDs are persisted in durable storage, so the scheduled
+  deletion must be able to recover on restart.
+- What happens when a round is postponed after Phase 3 was already posted? If Phase 3 was
+  invalidated by the postponement amendment, its cleanup follows amendment-invalidation
+  rules. The 24-hour post-round expiry, if rescheduled, applies to the new start time.
+- What happens when a round is cancelled after a phase message has been posted? The message
+  should be deleted as part of the cancellation's amendment-invalidation flow, not left
+  waiting for the 24-hour timer.
+- What happens for Mystery Rounds? No phase messages are ever posted, so no cleanup actions
+  are needed or triggered.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: For every non-Mystery round, the system MUST record the channel message ID of
+  the Phase 1 forecast message immediately after it is successfully posted, keyed by round
+  identifier and division identifier, and persist it to durable storage.
+- **FR-002**: For every non-Mystery round, the system MUST record the channel message ID of
+  the Phase 2 forecast message immediately after it is successfully posted, keyed by round
+  identifier and division identifier, and persist it to durable storage.
+- **FR-003**: For every non-Mystery round, the system MUST record the channel message ID of
+  the Phase 3 forecast message immediately after it is successfully posted, keyed by round
+  identifier and division identifier, and persist it to durable storage.
+- **FR-004**: Before posting the Phase 2 forecast message for a given round and division,
+  the system MUST attempt to delete the stored Phase 1 forecast message for that round and
+  division from the division's weather forecast channel.
+- **FR-005**: Before posting the Phase 3 forecast message for a given round and division,
+  the system MUST attempt to delete the stored Phase 2 forecast message for that round and
+  division from the division's weather forecast channel.
+- **FR-006**: Exactly 24 hours after a round's scheduled start time, the system MUST
+  attempt to delete the stored Phase 3 forecast message for that round and division from
+  the division's weather forecast channel.
+- **FR-007**: The 24-hour post-start deletion MUST be scheduled using the same scheduler
+  mechanism used to trigger weather phases (i.e., as a persistent scheduled job tied to the
+  round's start time), so that it survives bot restarts.
+- **FR-008**: If the forecast message targeted for deletion no longer exists in the channel
+  (e.g., it was manually deleted), the system MUST treat this as a non-error, log the
+  situation, and continue without interrupting any pending pipeline operation.
+- **FR-009**: If the bot lacks permission to delete a forecast message, the system MUST log
+  the failure and continue without interrupting any pending pipeline operation.
+- **FR-010**: After a deletion attempt (successful, missing, or permission-denied), the
+  stored message ID for that phase/round/division MUST be cleared from durable storage.
+- **FR-011**: When a round amendment triggers phase-output invalidation per the existing
+  amendment rules, the stored message IDs for the invalidated phases MUST be cleared and
+  the corresponding messages deleted (subject to FR-008 and FR-009) as part of the
+  invalidation flow, before the re-run phase posts its new message.
+- **FR-012**: Deletion actions MUST NOT be attempted for Mystery Rounds (which have no
+  phase messages).
+- **FR-013**: A deletion attempt for Round R / Division A MUST NOT affect any message
+  belonging to a different round or a different division.
+
+### Key Entities
+
+- **Forecast Message Record**: Represents a posted phase forecast message. Attributes:
+  round identifier, division identifier, phase number (1, 2, or 3), channel message ID,
+  posted timestamp. One record per round/division/phase combination at any given time.
+
+## Assumptions
+
+- The "round's scheduled start time" used as the T=0 reference for the 24-hour expiry is
+  the same timestamp already used as T=0 for phase-horizon scheduling (T−5d, T−2d, T−2h).
+- If a round is cancelled, the amendment-invalidation flow (FR-011) handles message
+  deletion; no separate 24-hour expiry job is fired for cancelled rounds.
+- The bot has the necessary channel permissions to delete its own messages in the
+  division forecast channel. Lack of permission is treated as a degraded-but-non-fatal
+  condition (FR-009).
+- Only the most recently posted message ID for a given round/division/phase is tracked at
+  any one time. If a phase is invalidated and re-run (amendment flow), the new message ID
+  replaces the old one in storage after FR-011 clears the prior record.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After Phase 2 is posted for any round, the Phase 1 forecast message for that
+  round and division is absent from the division's weather forecast channel.
+- **SC-002**: After Phase 3 is posted for any round, the Phase 2 forecast message for that
+  round and division is absent from the division's weather forecast channel.
+- **SC-003**: 24 hours (within a scheduling tolerance of ±5 minutes) after a round's
+  scheduled start time, the Phase 3 forecast message for that round and division is absent
+  from the division's weather forecast channel.
+- **SC-004**: A forecast channel that has completed a full round lifecycle (all three phases
+  posted and the 24-hour expiry fired) contains no messages from that round.
+- **SC-005**: A failed deletion attempt (missing message or permission error) does not
+  prevent the next phase message from being posted and is recorded in the calculation log
+  channel.

--- a/specs/007-forecast-msg-cleanup/checklists/requirements.md
+++ b/specs/007-forecast-msg-cleanup/checklists/requirements.md
@@ -1,0 +1,41 @@
+# Specification Quality Checklist: Forecast Channel Message Cleanup
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-04
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Initial validation pass: all items passed.
+- Second pass (2026-03-04): US4 (test mode suppression + flush), FR-014, FR-015, SC-006,
+  updated edge cases, and quickstart test-mode table added. All checklist items continue
+  to pass; no [NEEDS CLARIFICATION] markers introduced.
+- Scope boundary note updated: `test_mode_cog.py` is now in scope for a one-line call to
+  `flush_pending_deletions` on toggle-off. No changes to test mode toggle logic itself.
+- FR-011 / amendment-invalidation atomicity note carried forward: plan phase should confirm
+  that the deletion step does not break the existing single-transaction guarantee.

--- a/specs/007-forecast-msg-cleanup/data-model.md
+++ b/specs/007-forecast-msg-cleanup/data-model.md
@@ -1,0 +1,111 @@
+# Data Model: Forecast Channel Message Cleanup
+
+**Feature**: `007-forecast-msg-cleanup`  
+**Phase**: 1 — Design  
+**Date**: 2026-03-04
+
+---
+
+## New Entity: Forecast Message Record
+
+Represents the Discord message ID of a phase forecast currently posted in a division's
+weather forecast channel. At most one record exists per `(round_id, division_id,
+phase_number)` combination at any time. Records are cleared after the corresponding
+deletion is attempted (successful, not-found, or permission-denied).
+
+### Table: `forecast_messages`
+
+```sql
+CREATE TABLE IF NOT EXISTS forecast_messages (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    round_id     INTEGER NOT NULL REFERENCES rounds(id),
+    division_id  INTEGER NOT NULL REFERENCES divisions(id),
+    phase_number INTEGER NOT NULL CHECK (phase_number IN (1, 2, 3)),
+    message_id   INTEGER NOT NULL,   -- Discord message snowflake
+    posted_at    TEXT    NOT NULL    -- ISO-8601 UTC timestamp
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_forecast_messages_round_div_phase
+    ON forecast_messages(round_id, division_id, phase_number);
+```
+
+### Fields
+
+| Field | Type | Description |
+|-------|------|-------------|
+| `id` | `INTEGER PK` | Surrogate key |
+| `round_id` | `INTEGER FK → rounds.id` | The round this forecast belongs to |
+| `division_id` | `INTEGER FK → divisions.id` | The division this forecast was posted for |
+| `phase_number` | `INTEGER (1\|2\|3)` | Which phase posted the message |
+| `message_id` | `INTEGER` | Discord message snowflake, stored as `INTEGER` consistent with all other Discord ID columns in this schema |
+| `posted_at` | `TEXT` | ISO-8601 UTC timestamp recorded when the message was posted |
+
+### Constraints
+
+- `UNIQUE (round_id, division_id, phase_number)` — enforced via unique index; an
+  `INSERT OR REPLACE` (or `DELETE` then `INSERT`) is used when a phase is re-run after
+  amendment invalidation.
+- No record for Mystery rounds — the application enforces FR-012 by never inserting for
+  Mystery rounds.
+
+### Lifecycle
+
+```
+Phase N posts message
+        │
+        ▼
+INSERT INTO forecast_messages (round_id, division_id, phase_number, message_id, posted_at)
+
+        │  (Phase N+1 fires, or 24h expiry fires, or amendment invalidates)
+        ▼
+Attempt DELETE message via Discord API
+        │
+        ▼
+DELETE FROM forecast_messages WHERE round_id=? AND division_id=? AND phase_number=?
+```
+
+The row is removed after the deletion attempt regardless of whether the Discord API call
+succeeded, failed with NotFound, or failed with Forbidden (FR-010).
+
+**Test mode exception** (FR-014/FR-015): when test mode is active for a server, the
+deletion step is skipped entirely. The row stays in `forecast_messages`. When test mode is
+disabled, `flush_pending_deletions` queries all rows belonging to that server via a
+three-table JOIN and processes them in one pass:
+
+```sql
+SELECT fm.id, fm.round_id, fm.division_id, fm.phase_number, fm.message_id,
+       d.forecast_channel_id
+FROM forecast_messages fm
+JOIN rounds   r ON r.id  = fm.round_id
+JOIN divisions d ON d.id = fm.division_id
+JOIN seasons   s ON s.id = d.season_id
+WHERE s.server_id = ?
+```
+
+The `forecast_messages` table itself does not store `server_id` — it is derived via the JOIN,
+consistent with the rest of the schema's normalisation approach.
+
+---
+
+## Affected Entities (no schema changes)
+
+| Entity | Table | Change |
+|--------|-------|--------|
+| Round | `rounds` | None — `phase1_done` / `phase2_done` / `phase3_done` flags continue unchanged |
+| Phase result | `phase_results` | None — INVALIDATED status semantics unchanged |
+| Session | `sessions` | None |
+
+---
+
+## Migration File
+
+**`src/db/migrations/004_forecast_messages.sql`** — applied automatically by
+`run_migrations()` on bot startup. No destructive changes to existing tables.
+
+### Validation rules
+
+- `phase_number` is constrained to `{1, 2, 3}` at the DB level via `CHECK`.
+- `message_id` is `NOT NULL`; a record is only inserted after a successful `send()`.
+- The unique constraint prevents duplicate records if a phase fires more than once
+  (the application guards with `phaseN_done` flags, but a belt-and-suspenders DB
+  constraint avoids silent double-insertion).

--- a/specs/007-forecast-msg-cleanup/plan.md
+++ b/specs/007-forecast-msg-cleanup/plan.md
@@ -1,0 +1,138 @@
+# Implementation Plan: Forecast Channel Message Cleanup
+
+**Branch**: `007-forecast-msg-cleanup` | **Date**: 2026-03-04 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/007-forecast-msg-cleanup/spec.md`
+
+**Reuses plan**: See [`specs/001-league-weather-bot/plan.md`](../001-league-weather-bot/plan.md)
+for the full tech stack, structural decisions, and base data model. Everything in that plan
+applies unchanged. Only the files listed in the Scope table below require edits or creation.
+
+## Summary
+
+When Phase 2 is posted for a round the bot deletes the Phase 1 forecast message for that
+same round and division; when Phase 3 is posted it deletes Phase 2. Twenty-four hours after
+a round's scheduled start time the bot deletes the Phase 3 message. **Exception**: while
+test mode is active for a server, all deletions are suppressed so the admin can inspect all
+phase outputs simultaneously; when test mode is disabled every stored forecast message for
+that server is immediately flushed. This keeps the per-division forecast channel to at most
+one active forecast message per round at any time during live operation.
+
+**Technical approach**: Extend `OutputRouter.post_forecast` to return the posted
+`discord.Message` so phase services can persist the message ID to a new `forecast_messages`
+table. Each phase service loads the previous phase's stored message ID and deletes it before
+posting (suppressed while test mode is active). A new `forecast_cleanup_service.py` houses
+`delete_forecast_message` (test-mode guard + FR-008/FR-009 error handling),
+`flush_pending_deletions` (server-scoped bulk delete called when test mode is disabled), and
+`run_post_race_cleanup` (the coroutine triggered by a new 24-hour APScheduler job,
+`cleanup_r{id}` pattern, module-level callable `_forecast_cleanup_job` following existing
+pickling conventions). `AmendmentService.amend_round` calls `delete_forecast_message` for
+all phases as part of its existing phase-invalidation step. `TestModeCog.toggle` calls
+`flush_pending_deletions` when toggling off. One new DB migration adds the
+`forecast_messages` table.
+
+## Technical Context
+
+**Language/Version**: Python 3.13.2 (targets 3.8+)
+**Primary Dependencies**: discord.py 2.7.1, aiosqlite ≥ 0.19, APScheduler ≥ 3.10
+**Storage**: SQLite via aiosqlite — one new migration (`004_forecast_messages.sql`)
+**Testing**: pytest 9.0.2 + pytest-asyncio (`asyncio_mode = auto`); `pythonpath = src`
+**Target Platform**: Any host running Python 3.8+ with a Discord bot token
+**Project Type**: Discord bot (event-driven, async)
+**Performance Goals**: Deletion completes before the next phase message is posted (negligible latency — single Discord API call)
+**Constraints**: No new slash commands; deletion failures MUST NOT block phase posting; atomicity of amendment invalidation must be preserved
+**Scale/Scope**: One cleanup job and up to three stored message IDs per active round; bounded by season/division scale
+
+## Constitution Check
+
+*GATE — evaluated before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Requirement | Status |
+|-----------|-------------|--------|
+| I — Trusted Configuration Authority | No new commands; no access tier changes | ✅ PASS |
+| II — Multi-Division Isolation | Forecast message records are keyed by `(round_id, division_id, phase_number)`; deletion is scoped to a single round/division pair; no cross-division reads or writes | ✅ PASS |
+| III — Resilient Schedule Management | Cleanup job follows the same `replace_existing=True` / misfire semantics as phase jobs; amendment invalidation clears stored IDs before re-running phases | ✅ PASS |
+| IV — Three-Phase Weather Pipeline | Deletion happens outside the phase computation path; phase logic is unchanged; amendment invalidation clears messages atomically alongside phase results | ✅ PASS |
+| V — Observability & Change Audit Trail | Deletion failures are logged to the calculation log channel (SC-005); successful deletions do not need audit trail entries (no config mutation, no computation) | ✅ PASS |
+| VI — Simplicity & Focused Scope | Change is additive and strictly bounded; no new commands, no new user-facing behaviour | ✅ PASS |
+| VII — Output Channel Discipline | Deletion targets only the per-division forecast channel where the message was originally posted; no posts to other channels | ✅ PASS |
+
+**Constitution Check result: PASS — no violations, no Complexity Tracking entries required.**
+
+*Re-check post-design*: All principles confirmed. No violations introduced by Phase 1 data model.
+
+## Scope
+
+| File | Change |
+|------|--------|
+| `src/db/migrations/004_forecast_messages.sql` | **New** — `forecast_messages` table + unique index (FR-001–FR-003, FR-010) |
+| `src/utils/output_router.py` | `post_forecast` returns `discord.Message \| None`; `_send` returns last sent message object (FR-001–FR-003) |
+| `src/services/forecast_cleanup_service.py` | **New** — `delete_forecast_message` (checks test_mode before deleting), `flush_pending_deletions`, `run_post_race_cleanup` (FR-004–FR-010, FR-013–FR-015) |
+| `src/services/phase1_service.py` | Capture `post_forecast` return value and store message ID via `forecast_cleanup_service` (FR-001) |
+| `src/services/phase2_service.py` | Delete Phase 1 message before posting; store Phase 2 message ID (FR-002, FR-004) |
+| `src/services/phase3_service.py` | Delete Phase 2 message before posting; store Phase 3 message ID (FR-003, FR-005) |
+| `src/services/scheduler_service.py` | Add `_forecast_cleanup_job`, `register_forecast_cleanup_callback`, `schedule_forecast_cleanup`, `cancel_forecast_cleanup`; update `schedule_round` and `cancel_round` (FR-006, FR-007) |
+| `src/services/amendment_service.py` | Call `delete_forecast_message` for all three phases in the invalidation step (FR-011) |
+| `src/cogs/test_mode_cog.py` | Call `flush_pending_deletions` when toggling off (FR-015) |
+| `src/bot.py` | Register forecast cleanup callback in `on_ready` (FR-007) |
+| `tests/unit/test_forecast_cleanup.py` | **New** — unit tests (US1–US4 acceptance scenarios) |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/007-forecast-msg-cleanup/
+├── plan.md              ← this file
+├── spec.md              ← feature specification
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+└── tasks.md             ← Phase 2 output (/speckit.tasks — NOT created here)
+```
+
+No `contracts/` directory — this feature adds no new commands or external interfaces.
+
+### Source Code additions/edits
+
+```text
+src/
+├── db/
+│   └── migrations/
+│       └── 004_forecast_messages.sql     ← new
+├── services/
+│   ├── forecast_cleanup_service.py       ← new (delete_forecast_message checks test_mode;
+│   │                                          flush_pending_deletions; run_post_race_cleanup)
+│   ├── phase1_service.py                 ← modify: store message ID
+│   ├── phase2_service.py                 ← modify: delete Phase 1 msg, store Phase 2 msg ID
+│   ├── phase3_service.py                 ← modify: delete Phase 2 msg, store Phase 3 msg ID
+│   ├── scheduler_service.py              ← modify: cleanup job support
+│   └── amendment_service.py             ← modify: delete forecast msgs on invalidation
+├── cogs/
+│   └── test_mode_cog.py                  ← modify: flush on toggle-off
+├── utils/
+│   └── output_router.py                  ← modify: post_forecast returns Message | None
+└── bot.py                                ← modify: register cleanup callback
+
+tests/
+└── unit/
+    └── test_forecast_cleanup.py          ← new
+```
+
+---
+
+## Phase 0: Research
+
+See [research.md](research.md) for full findings.
+
+---
+
+## Phase 1: Design
+
+See [data-model.md](data-model.md) for the `forecast_messages` schema.
+
+No external contracts are defined — this feature adds no new slash commands or user-facing
+interfaces. See [quickstart.md](quickstart.md) for an overview of the automated behaviour.
+
+## Complexity Tracking
+
+> No Constitution violations — table not applicable.

--- a/specs/007-forecast-msg-cleanup/quickstart.md
+++ b/specs/007-forecast-msg-cleanup/quickstart.md
@@ -1,0 +1,73 @@
+# Quickstart: Forecast Channel Message Cleanup
+
+**Feature**: `007-forecast-msg-cleanup`  
+**Phase**: 1 — Design  
+**Date**: 2026-03-04
+
+---
+
+## Overview
+
+This feature is **fully automatic** — no new slash commands are added. Administrators and
+league members do not need to do anything differently. The bot manages the forecast channel
+messages on its own as the weather pipeline progresses.
+
+---
+
+## What happens automatically
+
+### During a normal race weekend
+
+| Trigger | What the bot does |
+|---------|------------------|
+| Phase 1 fires (T − 5 days) | Posts Phase 1 forecast. Stores the message ID. |
+| Phase 2 fires (T − 2 days) | **Deletes Phase 1 message**, then posts Phase 2 forecast. Stores Phase 2 message ID. |
+| Phase 3 fires (T − 2 hours) | **Deletes Phase 2 message**, then posts Phase 3 forecast. Stores Phase 3 message ID. |
+| T + 24 hours | **Deletes Phase 3 message**. No new message is posted. |
+
+At any point during the weekend, the forecast channel shows at most one message per round
+per division.
+
+### During test mode
+
+| Trigger | What the bot does |
+|---------|------------------|
+| Phase 2/3 fires while test mode **active** | Posts the new phase message. **Does NOT delete** the previous phase message. |
+| 24-hour expiry fires while test mode **active** | **Does NOT delete** the Phase 3 message. The message ID is retained for later. |
+| Test mode **disabled** | **Immediately deletes all stored forecast messages** for that server across all rounds and divisions. |
+
+This lets admins inspect all phase outputs simultaneously during a test session, while
+guaranteeing the channel is cleaned up the moment live operation resumes.
+
+### During an amendment
+
+When a round amendment triggers phase invalidation (track change, postponement, format
+change, cancellation), the bot:
+
+1. Deletes any posted Phase 1, Phase 2, and/or Phase 3 forecast messages for that round
+   and division as part of the existing invalidation flow.
+2. Posts the invalidation notice (existing behaviour, unchanged).
+3. Re-executes any phases whose horizon has already passed and posts fresh forecast
+   messages (existing behaviour). Stores the new message IDs.
+
+### Error handling
+
+If a forecast message has been manually deleted by a server administrator before the bot
+attempts cleanup, the bot logs the situation and continues without error. If the bot lacks
+permission to delete a message (misconfigured channel permissions), the bot logs the failure
+to the calculation log channel and still posts the next phase message.
+
+---
+
+## No setup required
+
+The `forecast_messages` table is created automatically by the migration runner (`004_forecast_messages.sql`) on next bot startup. No manual database changes or configuration
+commands are needed.
+
+---
+
+## Observability
+
+Deletion failures are surfaced to the **calculation log channel** (configured at bot setup),
+not to the forecast channel. Successful deletions are not logged — they are expected routine
+behaviour.

--- a/specs/007-forecast-msg-cleanup/research.md
+++ b/specs/007-forecast-msg-cleanup/research.md
@@ -1,0 +1,173 @@
+# Research: Forecast Channel Message Cleanup
+
+**Feature**: `007-forecast-msg-cleanup`  
+**Phase**: 0 — Outline & Research  
+**Date**: 2026-03-04
+
+All NEEDS CLARIFICATION items from the Technical Context are resolved below.
+
+---
+
+## R-001 — Capturing the Discord message ID after posting
+
+**Question**: `OutputRouter.post_forecast` currently returns `None`. The phase services need
+the Discord message ID immediately after posting so it can be persisted. What is the minimal
+change to `OutputRouter` that satisfies this without breaking existing callers?
+
+**Findings**:
+- `discord.abc.Messageable.send()` returns a `discord.Message` object. The current
+  `_send` loop discards it (`await channel.send(chunk)` result is unused).
+- Phase messages are well under 2 000 characters. The chunking path
+  (`_chunk_message`) only fires for anomalously long content, which never occurs in
+  practice for phase outputs.
+- Decision: change `_send` to capture and return the last `discord.Message` sent (or
+  `None` on failure); change `post_forecast` signature to `-> discord.Message | None`.
+  All existing call sites that ignore the return value continue to work unmodified.
+
+**Decision**: Widen `_send` return type from `bool` to `discord.Message | None` — `None`
+still signals failure. Update `post_forecast` to `-> discord.Message | None`. All other
+`post_log` callers (which chain to `_send` but only need success/fail) retain `bool`
+semantics via an internal overload — simplest approach is to have `post_log` continue
+using `_send` and not surface the `Message`.
+
+**Alternatives considered**: Separate `send_and_capture` method alongside existing `_send`
+(avoided — unnecessary duplication); adding a `capture: bool` keyword arg (avoided —
+awkward caller API).
+
+---
+
+## R-002 — Deleting a Discord message by stored ID
+
+**Question**: Given only a channel ID and a message ID stored as a string, what is the
+most efficient discord.py pattern to delete the message while correctly handling
+"message already gone" and "missing permissions"?
+
+**Findings**:
+- `channel.get_partial_message(int(message_id)).delete()` creates a stub `PartialMessage`
+  with no API call for the fetch step, then issues one `DELETE /channels/{id}/messages/{id}`
+  call. This is cheaper than `channel.fetch_message(id).delete()` (which issues two calls).
+- `discord.NotFound` (HTTP 404) is raised when the message no longer exists — maps to FR-008.
+- `discord.Forbidden` (HTTP 403) is raised when the bot lacks delete permission — maps to
+  FR-009.
+- Both exceptions must be caught; any other `discord.HTTPException` should also be caught
+  and logged.
+
+**Decision**: Use `channel.get_partial_message(int(message_id)).delete()` inside a
+`try/except (discord.NotFound, discord.Forbidden, discord.HTTPException)` block that logs
+the outcome and does not re-raise. Store message IDs in the DB as `TEXT` (see R-004).
+
+**Alternatives considered**: `channel.fetch_message(id)` then `.delete()` (two API calls,
+unnecessary for deletion); bulk `channel.delete_messages(...)` (requires `manage_messages`
+permission even for own messages in some configurations, not appropriate here).
+
+---
+
+## R-003 — 24-hour post-race cleanup scheduler job
+
+**Question**: The existing scheduler pattern uses module-level async callables with
+`_GLOBAL_SERVICE` to avoid APScheduler / SQLAlchemyJobStore pickle failures. Does a new
+cleanup job need anything beyond the established pattern?
+
+**Findings**:
+- The pattern established for `_phase_job`, `_mystery_notice_job`, and `_season_end_job`
+  is consistent: module-level coroutine with named kwargs, `_GLOBAL_SERVICE` sentinel,
+  registered callback injected via `register_*_callback`.
+- A new `_forecast_cleanup_job(round_id: int)` follows this exactly:
+  - Callable registered at module level (picklable).
+  - Job ID: `cleanup_r{round_id}` — unique, follows naming convention.
+  - Trigger: `DateTrigger(run_date = scheduled_at + timedelta(hours=24))`.
+  - `misfire_grace_time = _GRACE_SECONDS` (5 min) — consistent with phase jobs.
+  - `replace_existing=True` — safe to re-schedule after a postponement amendment.
+  - Added in `schedule_round` for non-Mystery rounds alongside the three phase jobs.
+  - Removed in `cancel_round` alongside phase jobs and mystery notice job.
+- Callback signature: `async def run_post_race_cleanup(round_id: int, bot: Bot) -> None`
+  (matches phase callback shape).
+
+**Decision**: Add `_forecast_cleanup_job`, `_forecast_cleanup_callback`, and
+`register_forecast_cleanup_callback` following the exact `_mystery_notice_job` pattern.
+Schedule the `cleanup_r{id}` job at `scheduled_at + timedelta(hours=24)` inside
+`schedule_round` for non-Mystery rounds.
+
+**Alternatives considered**: Scheduling the 24h job from inside `run_phase3` after Phase 3
+completes (rejected — not resilient to restarts before Phase 3 fires; the scheduler must
+know about the job from round-scheduling time, not phase-execution time; also violates the
+clean separation between phase services and the scheduler).
+
+---
+
+## R-004 — Storing Discord message snowflakes in SQLite
+
+**Question**: Discord message IDs are 64-bit unsigned integers (up to ~9.2 × 10¹⁸).
+SQLite's `INTEGER` type is signed 64-bit (max ~9.2 × 10¹⁸ signed). Is `INTEGER` safe, or
+should `TEXT` be used?
+
+**Findings**:
+- Discord snowflakes are generated with epoch 2015-01-01. The theoretical maximum in the
+  near future fits within signed 64-bit range, but relying on this is fragile.
+- The existing codebase stores all Discord IDs (channel IDs, role IDs, user IDs) as
+  `INTEGER` in the schema (see `001_initial.sql`). This is consistent with Python's
+  `int` type, which handles arbitrarily large integers; aiosqlite correctly round-trips
+  large integers via `INTEGER`.
+- Using `INTEGER` is consistent with the rest of the schema and avoids casting overhead.
+
+**Decision**: Store `message_id` as `INTEGER NOT NULL` in `forecast_messages`, consistent
+with how all other Discord snowflakes are stored in this codebase. Handle as Python `int`
+throughout (no string casting needed).
+
+**Alternatives considered**: `TEXT` (avoids overflow concern but inconsistent with rest of
+schema and adds unnecessary casting); `REAL` (lossy — rejected immediately).
+
+---
+
+## R-005 — Test mode interaction: suppression and flush
+
+**Question**: When test mode is active, deletions must be suppressed. When test mode is
+disabled, all stored forecast messages for the server must be bulk-deleted. What is the
+clearest, least-invasive hook point for these two behaviours given the existing architecture?
+
+**Findings**:
+
+**Suppression (FR-014)**:
+- `delete_forecast_message` in `forecast_cleanup_service` is the single chokepoint for all
+  deletion attempts (phase-transition and 24h expiry). Adding a `test_mode_active` check
+  at the top of this function — queried via `bot.config_service.get_server_config(server_id)` —
+  is sufficient. The `server_id` is reachable via `round_id → divisions → seasons.server_id`
+  with one DB query.
+- The APScheduler `cleanup_r{id}` job fires regardless; the suppression is applied inside
+  the service, not at the scheduler level. This preserves restart-resilience: if the bot
+  restarts after test mode is disabled, the job has already fired (record still in DB) and
+  the flush covers it.
+
+**Flush (FR-015)**:
+- `toggle_test_mode` in `test_mode_service` already returns `bool` (new state). The cog
+  (`TestModeCog.toggle`) receives this value and is the natural hook: if `new_state is False`,
+  `await flush_pending_deletions(server_id, bot)` is called before sending the confirmation
+  message. This keeps `test_mode_service` free of Discord API dependencies.
+- `flush_pending_deletions(server_id, bot)` queries `forecast_messages` joined to seasons
+  (see data-model.md), calls `channel.get_partial_message(id).delete()` for each result,
+  and clears each record. FR-008/FR-009 error handling applies per-row; one failure does not
+  abort the rest.
+
+**Decision**:
+- `delete_forecast_message`: add server_id lookup + `if test_mode_active: return` guard
+  before any Discord API call.
+- `flush_pending_deletions(server_id, bot)`: new function in `forecast_cleanup_service`;
+  called from `TestModeCog.toggle` when new state is `False`.
+- `test_mode_service.toggle_test_mode`: signature unchanged.
+
+**Alternatives considered**: Storing `server_id` directly on `forecast_messages` table
+(rejected — redundant, breaks normalisation); hooking into `toggle_test_mode` itself
+(rejected — would require passing `bot` into the service, introducing a Discord API
+dependency into a data-layer function); scheduler-level suppression (rejected — fragile
+across restarts).
+
+## Summary of Decisions
+
+| Decision | Chosen approach |
+|----------|----------------|
+| Capture message ID from OutputRouter | Widen `_send`/`post_forecast` return type to `discord.Message \| None` |
+| Delete message by stored ID | `channel.get_partial_message(int(id)).delete()` with `NotFound`/`Forbidden` handling |
+| 24h cleanup scheduler job | Module-level `_forecast_cleanup_job` following `_mystery_notice_job` pattern |
+| SQLite storage type for message IDs | `INTEGER NOT NULL` — consistent with existing Discord ID columns |
+| Test mode suppression | Guard in `delete_forecast_message`; record retained in DB while test mode active |
+| Flush on test mode disable | `flush_pending_deletions(server_id, bot)` called from `TestModeCog.toggle` when `new_state is False` |

--- a/specs/007-forecast-msg-cleanup/spec.md
+++ b/specs/007-forecast-msg-cleanup/spec.md
@@ -1,0 +1,238 @@
+# Feature Specification: Forecast Channel Message Cleanup
+
+**Feature Branch**: `007-forecast-msg-cleanup`  
+**Created**: 2026-03-04  
+**Status**: Draft  
+**Input**: User description: "Before posting the Phase 2 output message for a given round and division, delete the Phase 1 output message for that same round and division. Before posting the Phase 3 output message, delete the Phase 2 output message. 24 hours after a round starts, delete the Phase 3 output message. This keeps forecast channels tidy and easy to read."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 - Phase Transition Replaces Previous Forecast (Priority: P1)
+
+A league member opens the division's weather forecast channel before a race weekend.
+Instead of seeing a growing stack of Phase 1, Phase 2, and Phase 3 messages from the same
+round, they see only the most recent phase message. When Phase 2 is posted, Phase 1 is gone.
+When Phase 3 is posted, Phase 2 is gone.
+
+**Why this priority**: This is the core requirement. Without phase-to-phase cleanup the channel
+becomes cluttered with superseded forecasts, which is the primary pain the feature addresses.
+
+**Independent Test**: Can be fully tested by triggering Phase 1 posting for a round, then
+triggering Phase 2 for the same round, and confirming that only the Phase 2 message exists
+in the forecast channel for that round and division.
+
+**Acceptance Scenarios**:
+
+1. **Given** Phase 1 has been posted for Round R in Division D, **When** Phase 2 is posted
+   for Round R / Division D, **Then** the Phase 1 message no longer exists in the Division D
+   forecast channel and the Phase 2 message is present.
+2. **Given** Phase 2 has been posted for Round R in Division D, **When** Phase 3 is posted
+   for Round R / Division D, **Then** the Phase 2 message no longer exists in the Division D
+   forecast channel and the Phase 3 message is present.
+3. **Given** Phase 1 has been posted for Round R in Division D **and** Phase 1 has been
+   posted for Round S in Division D, **When** Phase 2 is posted for Round R / Division D,
+   **Then** only the Phase 1 message for Round R is deleted; Round S Phase 1 message is
+   unaffected.
+4. **Given** Phase 1 has been posted for Round R in Division A **and** Phase 1 has been
+   posted for Round R in Division B, **When** Phase 2 is posted for Round R / Division A,
+   **Then** only Division A's Phase 1 message is deleted; Division B's Phase 1 message is
+   unaffected.
+
+---
+
+### User Story 2 - Post-Race Forecast Expiry (Priority: P2)
+
+After a race weekend has concluded, a league member opens the forecast channel and sees a
+clean state with no old Phase 3 message still pinned there. The Phase 3 message automatically
+disappears 24 hours after the round's scheduled start time.
+
+**Why this priority**: Completes the full cleanup lifecycle. Without this, Phase 3 messages
+accumulate across rounds and the channel still becomes cluttered over a season.
+
+**Independent Test**: Can be fully tested by verifying that a Phase 3 message previously
+present in the channel is absent when checked 24 hours (± a short scheduling tolerance) after
+the round's scheduled start time.
+
+**Acceptance Scenarios**:
+
+1. **Given** Phase 3 has been posted for Round R in Division D and the round's scheduled
+   start time has passed, **When** exactly 24 hours after the scheduled start time elapses,
+   **Then** the Phase 3 message for Round R / Division D no longer exists in the forecast
+   channel.
+2. **Given** Phase 3 has been posted for Round R in Division D, **When** only 23 hours have
+   elapsed since the scheduled start time, **Then** the Phase 3 message is still present in
+   the forecast channel.
+3. **Given** Phase 3 messages exist for multiple rounds across multiple divisions,
+   **When** the 24-hour expiry fires for one specific round/division combination, **Then**
+   only that specific Phase 3 message is deleted; all others remain.
+
+---
+
+### User Story 3 - Resilient Deletion (Priority: P3)
+
+The bot attempts to delete a forecast message that has already been manually removed by a
+server administrator. The bot handles this gracefully: it logs the situation and continues
+posting the next phase message without failing or generating a visible error.
+
+**Why this priority**: Defensive behavior that prevents a missing message from breaking
+the pipeline. Less critical than the happy path but necessary for production reliability.
+
+**Independent Test**: Can be fully tested by manually deleting a Phase 1 message from the
+channel, then triggering Phase 2, and confirming that Phase 2 posts successfully and the bot
+does not error out.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Phase 1 message for Round R / Division D has been manually deleted from the
+   channel before Phase 2 fires, **When** Phase 2 runs for Round R / Division D, **Then**
+   Phase 2 is posted successfully, the missing message is logged, and no error is surfaced
+   to users.
+2. **Given** the bot does not have permission to delete messages in the forecast channel,
+   **When** a phase transition or 24-hour expiry fires, **Then** the deletion failure is
+   logged, the next phase message is still posted (for phase transitions), and no error
+   is surfaced to users.
+
+---
+
+### User Story 4 - Test Mode Suppresses Deletions (Priority: P2)
+
+A league admin is running through phase advancement in test mode to verify weather outputs
+before the season goes live. Multiple Phase 1, Phase 2, and Phase 3 messages accumulate in
+the forecast channel across several rounds during the test session — deletions are suppressed
+so the admin can inspect all outputs simultaneously. When the admin disables test mode, every
+stored forecast message for that server is immediately cleaned up, leaving the channel in the
+same tidy state it would have been in during live operation.
+
+**Why this priority**: Test mode is a first-class feature of this bot (feature 002). Silently
+deleting messages mid-session would disrupt the verification workflow the admin is performing.
+Flushing all messages on disable restores the cleanup guarantee the moment normal operation
+resumes.
+
+**Independent Test**: Can be fully tested by enabling test mode, advancing Phase 1 and Phase 2
+for a round, confirming both messages are still present in the forecast channel, then disabling
+test mode and confirming both messages have been deleted.
+
+**Acceptance Scenarios**:
+
+1. **Given** test mode is active for a server, **When** Phase 2 is posted for Round R /
+   Division D, **Then** the bot does NOT delete the Phase 1 message; both Phase 1 and Phase 2
+   messages remain in the forecast channel.
+2. **Given** test mode is active for a server, **When** 24 hours elapses after a round's
+   scheduled start time, **Then** the bot does NOT delete the Phase 3 message; the Phase 3
+   message remains in the forecast channel.
+3. **Given** test mode is active and forecast messages exist for multiple rounds and divisions,
+   **When** test mode is disabled, **Then** the bot immediately attempts to delete all stored
+   forecast messages for that server and clears their records from storage.
+4. **Given** test mode is disabled while some forecast messages have already been manually
+   removed from the channel, **When** the flush runs, **Then** the already-gone messages are
+   treated as non-errors (FR-008 semantics apply) and all remaining messages are still deleted.
+
+---
+
+### Edge Cases
+
+- What happens when a round is amended and a phase is invalidated after its message was
+  already posted? The stored message ID for the invalidated phase must be cleared and the
+  message deleted (or recorded as already-gone) before the re-run phase posts a fresh
+  message.
+- What happens when the bot restarts between when a phase was posted and when the deletion
+  should occur? Stored message IDs are persisted in durable storage, so the scheduled
+  deletion must be able to recover on restart.
+- What happens when a round is postponed after Phase 3 was already posted? If Phase 3 was
+  invalidated by the postponement amendment, its cleanup follows amendment-invalidation
+  rules. The 24-hour post-round expiry, if rescheduled, applies to the new start time.
+- What happens when a round is cancelled after a phase message has been posted? The message
+  should be deleted as part of the cancellation's amendment-invalidation flow, not left
+  waiting for the 24-hour timer.
+- What happens for Mystery Rounds? No phase messages are ever posted, so no cleanup actions
+  are needed or triggered.
+- What happens to the 24-hour APScheduler job that fired while test mode was active? The
+  deletion was skipped but the `forecast_messages` record was not cleared, so the message ID
+  is still available when test mode is disabled and the flush runs.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: For every non-Mystery round, the system MUST record the channel message ID of
+  the Phase 1 forecast message immediately after it is successfully posted, keyed by round
+  identifier and division identifier, and persist it to durable storage.
+- **FR-002**: For every non-Mystery round, the system MUST record the channel message ID of
+  the Phase 2 forecast message immediately after it is successfully posted, keyed by round
+  identifier and division identifier, and persist it to durable storage.
+- **FR-003**: For every non-Mystery round, the system MUST record the channel message ID of
+  the Phase 3 forecast message immediately after it is successfully posted, keyed by round
+  identifier and division identifier, and persist it to durable storage.
+- **FR-004**: Before posting the Phase 2 forecast message for a given round and division,
+  the system MUST attempt to delete the stored Phase 1 forecast message for that round and
+  division from the division's weather forecast channel.
+- **FR-005**: Before posting the Phase 3 forecast message for a given round and division,
+  the system MUST attempt to delete the stored Phase 2 forecast message for that round and
+  division from the division's weather forecast channel.
+- **FR-006**: Exactly 24 hours after a round's scheduled start time, the system MUST
+  attempt to delete the stored Phase 3 forecast message for that round and division from
+  the division's weather forecast channel.
+- **FR-007**: The 24-hour post-start deletion MUST be scheduled using the same scheduler
+  mechanism used to trigger weather phases (i.e., as a persistent scheduled job tied to the
+  round's start time), so that it survives bot restarts.
+- **FR-008**: If the forecast message targeted for deletion no longer exists in the channel
+  (e.g., it was manually deleted), the system MUST treat this as a non-error, log the
+  situation, and continue without interrupting any pending pipeline operation.
+- **FR-009**: If the bot lacks permission to delete a forecast message, the system MUST log
+  the failure and continue without interrupting any pending pipeline operation.
+- **FR-010**: After a deletion attempt (successful, missing, or permission-denied), the
+  stored message ID for that phase/round/division MUST be cleared from durable storage.
+- **FR-011**: When a round amendment triggers phase-output invalidation per the existing
+  amendment rules, the stored message IDs for the invalidated phases MUST be cleared and
+  the corresponding messages deleted (subject to FR-008 and FR-009) as part of the
+  invalidation flow, before the re-run phase posts its new message.
+- **FR-012**: Deletion actions MUST NOT be attempted for Mystery Rounds (which have no
+  phase messages).
+- **FR-013**: A deletion attempt for Round R / Division A MUST NOT affect any message
+  belonging to a different round or a different division.
+- **FR-014**: While test mode is active for a given server, the system MUST skip all
+  deletion attempts (phase-transition deletions and 24-hour expiry deletions) for rounds
+  belonging to that server. The corresponding `forecast_messages` record MUST be retained
+  in durable storage so the message can be deleted later.
+- **FR-015**: When test mode is disabled for a server, the system MUST immediately attempt
+  to delete every forecast message currently stored in `forecast_messages` for any round
+  belonging to that server's active season, across all divisions, and MUST clear each
+  record after the deletion attempt (FR-008 and FR-009 semantics apply).
+
+### Key Entities
+
+- **Forecast Message Record**: Represents a posted phase forecast message. Attributes:
+  round identifier, division identifier, phase number (1, 2, or 3), channel message ID,
+  posted timestamp. One record per round/division/phase combination at any given time.
+
+## Assumptions
+
+- The "round's scheduled start time" used as the T=0 reference for the 24-hour expiry is
+  the same timestamp already used as T=0 for phase-horizon scheduling (T−5d, T−2d, T−2h).
+- If a round is cancelled, the amendment-invalidation flow (FR-011) handles message
+  deletion; no separate 24-hour expiry job is fired for cancelled rounds.
+- The bot has the necessary channel permissions to delete its own messages in the
+  division forecast channel. Lack of permission is treated as a degraded-but-non-fatal
+  condition (FR-009).
+- Only the most recently posted message ID for a given round/division/phase is tracked at
+  any one time. If a phase is invalidated and re-run (amendment flow), the new message ID
+  replaces the old one in storage after FR-011 clears the prior record.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: After Phase 2 is posted for any round, the Phase 1 forecast message for that
+  round and division is absent from the division's weather forecast channel.
+- **SC-002**: After Phase 3 is posted for any round, the Phase 2 forecast message for that
+  round and division is absent from the division's weather forecast channel.
+- **SC-003**: 24 hours (within a scheduling tolerance of ±5 minutes) after a round's
+  scheduled start time, the Phase 3 forecast message for that round and division is absent
+  from the division's weather forecast channel.
+- **SC-004**: A forecast channel that has completed a full round lifecycle (all three phases
+  posted and the 24-hour expiry fired) contains no messages from that round.
+- **SC-005**: A failed deletion attempt (missing message or permission error) does not
+  prevent the next phase message from being posted and is recorded in the calculation log
+  channel.
+- **SC-006**: Immediately after test mode is disabled, the division forecast channels for
+  that server contain no stored forecast messages from any round of the active season.

--- a/specs/007-forecast-msg-cleanup/tasks.md
+++ b/specs/007-forecast-msg-cleanup/tasks.md
@@ -1,0 +1,135 @@
+# Tasks: Forecast Channel Message Cleanup
+
+**Input**: Design documents from `specs/007-forecast-msg-cleanup/`
+**Prerequisites**: plan.md ✅ spec.md ✅ research.md ✅ data-model.md ✅ quickstart.md ✅
+
+**Organization**: Tasks are grouped by user story to enable independent implementation and
+testing of each story.
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no unmet dependencies on incomplete tasks)
+- **[Story]**: Which user story this task belongs to (US1–US4)
+- No story label on Setup, Foundational, and Polish phase tasks
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Database schema — must land before any service code can be written or tested.
+
+- [X] T001 Add migration `src/db/migrations/004_forecast_messages.sql` — `forecast_messages` table with `id`, `round_id` (FK), `division_id` (FK), `phase_number CHECK (1|2|3)`, `message_id INTEGER NOT NULL`, `posted_at TEXT NOT NULL`; unique index `uq_forecast_messages_round_div_phase` on `(round_id, division_id, phase_number)` — per data-model.md
+
+**Checkpoint**: Migration file present — Foundational work can begin.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Two changes that every user-story phase depends on: the `OutputRouter` must
+return a `Message` object, and `forecast_cleanup_service.py` must exist with its
+storage helper.
+
+**⚠️ CRITICAL**: No user-story phase work can begin until T002 and T003 are both complete.
+
+- [X] T002 Widen `OutputRouter._send` to capture and return the last `discord.Message` sent (or `None` on failure) and update `post_forecast` signature to `-> discord.Message | None` in `src/utils/output_router.py` — per research.md R-001; all `post_log` call sites unchanged
+- [X] T003 [P] Create `src/services/forecast_cleanup_service.py` with module docstring and `store_forecast_message(round_id, division_id, phase_number, message, db_path)` async helper using `INSERT OR REPLACE INTO forecast_messages` — per data-model.md
+
+**Checkpoint**: Foundation ready — all user-story phases can now begin.
+
+---
+
+## Phase 3: User Story 1 — Phase Transition Replaces Previous Forecast (P1) 🎯 MVP
+
+**Goal**: When Phase 2 posts, the Phase 1 forecast message is deleted first. When Phase 3
+posts, the Phase 2 message is deleted first. Deletion failures (missing or forbidden) are
+handled gracefully and logged without blocking phase posting. (User Story 3 resilience is
+built into this phase's core function.)
+
+**Independent Test**: Trigger Phase 1 for a round, then trigger Phase 2 for the same
+round/division; confirm only the Phase 2 message exists in the forecast channel.
+
+- [X] T004 [US1] Implement `delete_forecast_message(round_id, division_id, phase_number, bot)` in `src/services/forecast_cleanup_service.py` — load stored `message_id` + `forecast_channel_id` via DB join; call `channel.get_partial_message(id).delete()`; catch `discord.NotFound` (log, non-error), `discord.Forbidden` (log to calc-log channel, non-error), `discord.HTTPException` (log, non-error); `DELETE FROM forecast_messages` after attempt regardless of outcome — FR-008, FR-009, FR-010, FR-012, FR-013
+- [X] T005 [P] [US1] Update `src/services/phase1_service.py` to capture the `discord.Message` returned by `bot.output_router.post_forecast` and call `store_forecast_message` immediately after — FR-001
+- [X] T006 [P] [US1] Update `src/services/phase2_service.py` to call `delete_forecast_message(round_id, division_id, phase_number=1, bot)` before posting, then capture the returned `Message` and call `store_forecast_message` for phase 2 — FR-002, FR-004
+- [X] T007 [P] [US1] Update `src/services/phase3_service.py` to call `delete_forecast_message(round_id, division_id, phase_number=2, bot)` before posting, then capture the returned `Message` and call `store_forecast_message` for phase 3 — FR-003, FR-005
+
+---
+
+## Phase 4: User Story 2 — Post-Race Forecast Expiry (P2)
+
+**Goal**: 24 hours after a round's scheduled start time, the Phase 3 forecast message is
+automatically deleted. The job is scheduled alongside phase jobs and survives bot restarts.
+
+**Independent Test**: Confirm a `cleanup_r{id}` APScheduler job is present after a round
+is scheduled; confirm that when fired it calls deletion for Phase 3 only.
+
+- [X] T008 [US2] Add to `src/services/scheduler_service.py`: module-level `_forecast_cleanup_job(round_id: int)` async callable (mirrors `_mystery_notice_job` pattern), `_forecast_cleanup_callback` attribute on `SchedulerService`, and `register_forecast_cleanup_callback(callback)` method — per research.md R-003
+- [X] T009 [US2] Update `SchedulerService.schedule_round` in `src/services/scheduler_service.py` to add a `cleanup_r{rnd.id}` `DateTrigger` job at `scheduled_at + timedelta(hours=24)` for non-Mystery rounds; update `cancel_round` to also remove `cleanup_r{round_id}` — FR-006, FR-007
+- [X] T010 [US2] Implement `run_post_race_cleanup(round_id, bot)` coroutine in `src/services/forecast_cleanup_service.py` — calls `delete_forecast_message` for `phase_number=3`; used as the `_forecast_cleanup_callback` target — FR-006, FR-008, FR-009
+- [X] T011 [US2] Register forecast cleanup callback in `src/bot.py` `on_ready` — call `bot.scheduler_service.register_forecast_cleanup_callback(lambda rid: run_post_race_cleanup(rid, bot))` alongside the existing phase and mystery notice registrations — FR-007
+
+---
+
+## Phase 5: User Story 4 — Test Mode Suppresses Deletions (P2)
+
+**Goal**: While test mode is active, no deletion attempts run; records are preserved.
+When test mode is disabled, all stored forecast messages for that server are flushed
+immediately.
+
+**Independent Test**: Enable test mode, advance Phase 1 and Phase 2 for a round; confirm
+both messages remain in the forecast channel. Disable test mode; confirm both are deleted.
+
+- [X] T012 [US4] Add test-mode guard to `delete_forecast_message` in `src/services/forecast_cleanup_service.py` — lookup `server_id` via `round_id → rounds → divisions → seasons`; call `bot.config_service.get_server_config(server_id)`; if `test_mode_active` is True, return immediately without deleting or clearing the record — FR-014
+- [X] T013 [US4] Implement `flush_pending_deletions(server_id, bot)` in `src/services/forecast_cleanup_service.py` — execute the server-scoped JOIN query from data-model.md; for each row call `channel.get_partial_message(message_id).delete()` with FR-008/FR-009 handling; `DELETE FROM forecast_messages WHERE id = ?` after each attempt — FR-015
+- [X] T014 [US4] Update `TestModeCog.toggle` in `src/cogs/test_mode_cog.py` to call `await flush_pending_deletions(interaction.guild_id, self.bot)` when `new_state is False`, before sending the confirmation message — FR-015
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Amendment integration (FR-011) and the unit test file. These have no story
+label because they span multiple user stories or are infrastructure-level.
+
+- [X] T015 Update `AmendmentService.amend_round` in `src/services/amendment_service.py` to call `delete_forecast_message` for `phase_number` 1, 2, and 3 within the existing invalidation step (after `UPDATE phase_results SET status = 'INVALIDATED'`, before re-running phases) — FR-011
+- [X] T016 [P] Write `tests/unit/test_forecast_cleanup.py` covering: US1 phase-transition deletion (happy path and cross-round/cross-division isolation), US2 24h expiry invokes Phase 3 deletion only, US3 NotFound → non-error + log, Forbidden → non-error + log, US4 suppression when test_mode active + flush-on-disable clears all records
+
+---
+
+## Dependencies (story completion order)
+
+```
+T001 (migration)
+  └─▶ T002 (OutputRouter) ──┐
+  └─▶ T003 (service skeleton)┘
+            │
+            ▼ (both complete)
+    T004 (delete_forecast_message)
+      ├─▶ T005 [P] (phase1_service)   ┐  all independent of
+      ├─▶ T006 [P] (phase2_service)   │  each other → US1 done
+      └─▶ T007 [P] (phase3_service)   ┘
+    T008 (scheduler callables)
+      └─▶ T009 (schedule_round/cancel_round)
+    T003 + T008 ──▶ T010 (run_post_race_cleanup)
+    T008 + T010 ──▶ T011 (bot.py callback)  → US2 done
+    T004 ──▶ T012 (test_mode guard)
+    T003 ──▶ T013 (flush_pending_deletions)
+    T013 ──▶ T014 (TestModeCog.toggle)       → US4 done
+    T004 + T005–T007 ──▶ T015 (AmendmentService)
+    T004–T014 ──▶ T016 [P] (unit tests)
+```
+
+## Parallel execution opportunities
+
+| Story | Parallel group (after prerequisites met) |
+|-------|------------------------------------------|
+| US1 | T005, T006, T007 — three different files, no inter-dependencies |
+| US2 | T008 and T003 can proceed in parallel with US1; T010 and T011 after T008 |
+| US4 | T012 modifies forecast_cleanup_service.py; can be drafted while T013 is written |
+| Polish | T015 and T016 can be done in parallel (different files) |
+
+## Implementation strategy
+
+**MVP = US1 only (T001 → T002 → T003 → T004 → T005 + T006 + T007)**. This delivers the
+core channel-cleanup guarantee (phase transition replaces forecast) with full resilience.
+US2, US4, and amendment integration can follow as independent increments.

--- a/src/bot.py
+++ b/src/bot.py
@@ -83,6 +83,14 @@ async def main() -> None:
 
         bot.scheduler_service.register_mystery_notice_callback(_mystery_notice_cb)
 
+        # Register post-race forecast cleanup callback
+        from services.forecast_cleanup_service import run_post_race_cleanup
+
+        async def _forecast_cleanup_cb(round_id: int) -> None:
+            await run_post_race_cleanup(round_id, bot)
+
+        bot.scheduler_service.register_forecast_cleanup_callback(_forecast_cleanup_cb)
+
         # Register season-end callback (stored in _GLOBAL_SERVICE so the
         # module-level _season_end_job can reach it without pickling a closure)
         from services.season_end_service import execute_season_end as _execute_season_end

--- a/src/cogs/test_mode_cog.py
+++ b/src/cogs/test_mode_cog.py
@@ -62,12 +62,17 @@ class TestModeCog(commands.Cog):
                 "Use `/test-mode advance` to step through phases, "
                 "or `/test-mode review` to inspect season status."
             )
+            await interaction.response.send_message(msg, ephemeral=True)
         else:
+            # Defer so the flush (multiple Discord API calls) has time to complete
+            await interaction.response.defer(ephemeral=True)
+            from services.forecast_cleanup_service import flush_pending_deletions
+            await flush_pending_deletions(interaction.guild_id, self.bot)  # type: ignore[attr-defined]
             msg = (
                 "✅ Test mode **disabled**. "
                 "The scheduler will resume normal operation for any remaining pending phases."
             )
-        await interaction.response.send_message(msg, ephemeral=True)
+            await interaction.followup.send(msg, ephemeral=True)
 
     # ------------------------------------------------------------------
     # /test-mode advance

--- a/src/db/migrations/004_forecast_messages.sql
+++ b/src/db/migrations/004_forecast_messages.sql
@@ -1,0 +1,17 @@
+-- Migration 004: Add forecast_messages table for per-phase Discord message ID tracking.
+-- Stores the Discord message snowflake of each phase forecast posted to a division's
+-- forecast channel, keyed by (round_id, division_id, phase_number). Used by
+-- forecast_cleanup_service to delete superseded forecast messages before posting the
+-- next phase output and to purge Phase 3 messages 24 hours after round start.
+
+CREATE TABLE IF NOT EXISTS forecast_messages (
+    id           INTEGER PRIMARY KEY AUTOINCREMENT,
+    round_id     INTEGER NOT NULL REFERENCES rounds(id),
+    division_id  INTEGER NOT NULL REFERENCES divisions(id),
+    phase_number INTEGER NOT NULL CHECK (phase_number IN (1, 2, 3)),
+    message_id   INTEGER NOT NULL,
+    posted_at    TEXT    NOT NULL
+);
+
+CREATE UNIQUE INDEX IF NOT EXISTS uq_forecast_messages_round_div_phase
+    ON forecast_messages(round_id, division_id, phase_number);

--- a/src/services/amendment_service.py
+++ b/src/services/amendment_service.py
@@ -143,6 +143,15 @@ class AmendmentService:
         if updated_round.format != RoundFormat.MYSTERY or now < p1_horizon:
             bot.scheduler_service.schedule_round(updated_round)
 
+        # Erase stored forecast messages for all phases (FR-011).
+        # delete_forecast_message respects the test-mode guard; any skipped
+        # deletions will be handled by flush_pending_deletions on toggle-off.
+        if any_phase_done:
+            from services.forecast_cleanup_service import delete_forecast_message
+            division_id: int = row["division_id"]
+            for phase_num in (1, 2, 3):
+                await delete_forecast_message(round_id, division_id, phase_num, bot)
+
         # 6. Invalidation broadcast
         if any_phase_done:
             from utils.message_builder import invalidation_message

--- a/src/services/forecast_cleanup_service.py
+++ b/src/services/forecast_cleanup_service.py
@@ -1,0 +1,254 @@
+"""ForecastCleanupService — track and delete per-phase forecast messages.
+
+Feature 007: Forecast Message Cleanup.
+
+Constitution Principle VII: Every channel write goes through OutputRouter.
+Deletes are the inverse of writes; they use the same channel references stored
+at write time.
+
+Public API:
+  store_forecast_message  — persist a message ID after posting
+  delete_forecast_message — delete a stored message (with test-mode guard)
+  run_post_race_cleanup   — delete Phase 3 message 24 h after round start
+  flush_pending_deletions — on test-mode disable, delete all stored messages
+                            for a server at once
+"""
+
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+import discord
+
+from db.database import get_connection
+
+if TYPE_CHECKING:
+    from discord.ext.commands import Bot
+
+log = logging.getLogger(__name__)
+
+
+# ---------------------------------------------------------------------------
+# T003 — store_forecast_message
+# ---------------------------------------------------------------------------
+
+async def store_forecast_message(
+    round_id: int,
+    division_id: int,
+    phase_number: int,
+    message: "discord.Message",
+    db_path: str,
+) -> None:
+    """Persist the Discord message snowflake for *phase_number* of *round_id*.
+
+    Uses ``INSERT OR REPLACE`` so re-running a phase (e.g. after an amendment)
+    transparently updates the stored ID without leaving stale rows.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+    async with get_connection(db_path) as db:
+        await db.execute(
+            """
+            INSERT OR REPLACE INTO forecast_messages
+                (round_id, division_id, phase_number, message_id, posted_at)
+            VALUES (?, ?, ?, ?, ?)
+            """,
+            (round_id, division_id, phase_number, message.id, now),
+        )
+        await db.commit()
+    log.debug(
+        "Stored forecast message: round=%s div=%s phase=%s msg=%s",
+        round_id, division_id, phase_number, message.id,
+    )
+
+
+# ---------------------------------------------------------------------------
+# T004 + T012 — delete_forecast_message (with test-mode guard)
+# ---------------------------------------------------------------------------
+
+async def delete_forecast_message(
+    round_id: int,
+    division_id: int,
+    phase_number: int,
+    bot: "Bot",
+) -> None:
+    """Delete the stored Discord message for *phase_number* of *round_id*.
+
+    Test-mode guard (FR-012): if test mode is active for the server that owns
+    this round, the deletion is silently skipped.  The row is retained so that
+    ``flush_pending_deletions`` can action it later when test mode is disabled.
+
+    On Discord API failure (NotFound / Forbidden / HTTPException) the DB row is
+    still removed so a stale reference does not block future clean-ups.
+    """
+    db_path: str = bot.db_path  # type: ignore[attr-defined]
+
+    # --- Load stored message row ---
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            """
+            SELECT fm.message_id, d.forecast_channel_id, s.server_id
+            FROM forecast_messages fm
+            JOIN divisions d ON d.id = fm.division_id
+            JOIN seasons s ON s.id = d.season_id
+            WHERE fm.round_id = ? AND fm.division_id = ? AND fm.phase_number = ?
+            """,
+            (round_id, division_id, phase_number),
+        )
+        row = await cursor.fetchone()
+
+    if row is None:
+        log.debug(
+            "delete_forecast_message: no row for round=%s div=%s phase=%s — nothing to delete",
+            round_id, division_id, phase_number,
+        )
+        return
+
+    server_id: int = row["server_id"]
+    message_id: int = row["message_id"]
+    channel_id: int = row["forecast_channel_id"]
+
+    # --- Test-mode guard (T012 / FR-012) ---
+    config = await bot.config_service.get_server_config(server_id)  # type: ignore[attr-defined]
+    if config is not None and config.test_mode_active:
+        log.debug(
+            "delete_forecast_message: test mode active for server=%s — skipping deletion "
+            "(round=%s div=%s phase=%s)",
+            server_id, round_id, division_id, phase_number,
+        )
+        return
+
+    # --- Attempt Discord deletion ---
+    _delete_ok = await _discord_delete(bot, channel_id, message_id)
+
+    # --- Remove DB row (even on Discord error to avoid stale references) ---
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "DELETE FROM forecast_messages "
+            "WHERE round_id = ? AND division_id = ? AND phase_number = ?",
+            (round_id, division_id, phase_number),
+        )
+        await db.commit()
+
+    if _delete_ok:
+        log.info(
+            "Deleted forecast message: round=%s div=%s phase=%s msg=%s",
+            round_id, division_id, phase_number, message_id,
+        )
+    else:
+        log.warning(
+            "forecast message Discord delete failed but DB row removed: "
+            "round=%s div=%s phase=%s msg=%s",
+            round_id, division_id, phase_number, message_id,
+        )
+
+
+# ---------------------------------------------------------------------------
+# T010 — run_post_race_cleanup (Phase 3 message, 24 h after round start)
+# ---------------------------------------------------------------------------
+
+async def run_post_race_cleanup(round_id: int, bot: "Bot") -> None:
+    """Delete the Phase 3 forecast message for all divisions of *round_id*.
+
+    Invoked 24 hours after round start by the APScheduler ``cleanup_r{round_id}``
+    job registered in SchedulerService.
+
+    Each division is processed independently so a single failure does not block
+    the others.
+    """
+    db_path: str = bot.db_path  # type: ignore[attr-defined]
+
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            "SELECT division_id FROM forecast_messages WHERE round_id = ? AND phase_number = 3",
+            (round_id,),
+        )
+        rows = await cursor.fetchall()
+
+    for row in rows:
+        await delete_forecast_message(round_id, row["division_id"], phase_number=3, bot=bot)
+
+
+# ---------------------------------------------------------------------------
+# T013 — flush_pending_deletions (test-mode disable hook)
+# ---------------------------------------------------------------------------
+
+async def flush_pending_deletions(server_id: int, bot: "Bot") -> None:
+    """Delete all pending forecast messages for *server_id*.
+
+    Called when test mode is disabled (FR-015).  By the time this function
+    runs, test mode has already been persisted as ``False`` in the DB, so the
+    test-mode guard inside ``delete_forecast_message`` will not fire.
+
+    All stored messages for the server are iterated and deleted.  Individual
+    Discord API failures are logged but do not halt the batch.
+    """
+    db_path: str = bot.db_path  # type: ignore[attr-defined]
+
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            """
+            SELECT fm.round_id, fm.division_id, fm.phase_number
+            FROM forecast_messages fm
+            JOIN divisions d ON d.id = fm.division_id
+            JOIN seasons s ON s.id = d.season_id
+            WHERE s.server_id = ?
+            ORDER BY fm.round_id, fm.division_id, fm.phase_number
+            """,
+            (server_id,),
+        )
+        rows = await cursor.fetchall()
+
+    if not rows:
+        log.debug("flush_pending_deletions: no pending messages for server=%s", server_id)
+        return
+
+    log.info(
+        "flush_pending_deletions: flushing %d message(s) for server=%s",
+        len(rows), server_id,
+    )
+    for row in rows:
+        await delete_forecast_message(
+            row["round_id"],
+            row["division_id"],
+            row["phase_number"],
+            bot,
+        )
+
+
+# ---------------------------------------------------------------------------
+# Internal helpers
+# ---------------------------------------------------------------------------
+
+async def _discord_delete(bot: "Bot", channel_id: int, message_id: int) -> bool:
+    """Attempt to delete a Discord message.  Returns True on success."""
+    try:
+        channel = bot.get_channel(channel_id)
+        if channel is None:
+            channel = await bot.fetch_channel(channel_id)
+        if not isinstance(channel, discord.TextChannel):
+            log.error(
+                "_discord_delete: channel id=%s is not a TextChannel", channel_id
+            )
+            return False
+        await channel.get_partial_message(message_id).delete()
+        return True
+    except discord.NotFound:
+        log.debug(
+            "_discord_delete: message %s in channel %s already deleted or not found",
+            message_id, channel_id,
+        )
+        return False
+    except discord.Forbidden as exc:
+        log.error(
+            "_discord_delete: missing permissions to delete message %s in channel %s: %s",
+            message_id, channel_id, exc,
+        )
+        return False
+    except discord.HTTPException as exc:
+        log.error(
+            "_discord_delete: HTTP error deleting message %s in channel %s: %s",
+            message_id, channel_id, exc,
+        )
+        return False

--- a/src/services/phase1_service.py
+++ b/src/services/phase1_service.py
@@ -89,10 +89,14 @@ async def run_phase1(round_id: int, bot: "Bot") -> None:
     class _Div:
         forecast_channel_id = row["forecast_channel_id"]
 
-    await bot.output_router.post_forecast(
+    msg = await bot.output_router.post_forecast(
         _Div(),
         phase1_message(row["mention_role_id"], track_name, rpc),
     )
+    if msg is not None:
+        from services.forecast_cleanup_service import store_forecast_message
+        await store_forecast_message(round_id, row["division_id"], 1, msg, bot.db_path)
+
     await bot.output_router.post_log(
         row["server_id"],
         phase_log_message(1, round_id, track_name, payload),

--- a/src/services/phase2_service.py
+++ b/src/services/phase2_service.py
@@ -27,7 +27,7 @@ async def run_phase2(round_id: int, bot: "Bot") -> None:
     # --- Load context ---
     async with get_connection(bot.db_path) as db:
         cursor = await db.execute(
-            "SELECT r.id, r.track_name, r.phase1_done, r.phase2_done, "
+            "SELECT r.id, r.track_name, r.phase1_done, r.phase2_done, r.division_id, "
             "       d.forecast_channel_id, d.mention_role_id, s.server_id "
             "FROM rounds r "
             "JOIN divisions d ON d.id = r.division_id "
@@ -121,10 +121,16 @@ async def run_phase2(round_id: int, bot: "Bot") -> None:
     class _Div:
         forecast_channel_id = row["forecast_channel_id"]
 
-    await bot.output_router.post_forecast(
+    from services.forecast_cleanup_service import delete_forecast_message, store_forecast_message
+    await delete_forecast_message(round_id, row["division_id"], phase_number=1, bot=bot)
+
+    msg = await bot.output_router.post_forecast(
         _Div(),
         phase2_message(row["mention_role_id"], track_name, session_slots),
     )
+    if msg is not None:
+        await store_forecast_message(round_id, row["division_id"], 2, msg, bot.db_path)
+
     await bot.output_router.post_log(
         row["server_id"],
         phase_log_message(2, round_id, track_name, payload),

--- a/src/services/phase3_service.py
+++ b/src/services/phase3_service.py
@@ -29,7 +29,7 @@ async def run_phase3(round_id: int, bot: "Bot") -> None:
     """Execute Phase 3 for *round_id*."""
     async with get_connection(bot.db_path) as db:
         cursor = await db.execute(
-            "SELECT r.id, r.track_name, r.phase2_done, r.phase3_done, "
+            "SELECT r.id, r.track_name, r.phase2_done, r.phase3_done, r.division_id, "
             "       d.forecast_channel_id, d.mention_role_id, s.server_id "
             "FROM rounds r "
             "JOIN divisions d ON d.id = r.division_id "
@@ -137,10 +137,16 @@ async def run_phase3(round_id: int, bot: "Bot") -> None:
     class _Div:
         forecast_channel_id = row["forecast_channel_id"]
 
-    await bot.output_router.post_forecast(
+    from services.forecast_cleanup_service import delete_forecast_message, store_forecast_message
+    await delete_forecast_message(round_id, row["division_id"], phase_number=2, bot=bot)
+
+    msg = await bot.output_router.post_forecast(
         _Div(),
         phase3_message(row["mention_role_id"], track_name, session_weather),
     )
+    if msg is not None:
+        await store_forecast_message(round_id, row["division_id"], 3, msg, bot.db_path)
+
     await bot.output_router.post_log(
         row["server_id"],
         phase_log_message(3, round_id, track_name, payload),

--- a/src/services/scheduler_service.py
+++ b/src/services/scheduler_service.py
@@ -94,6 +94,29 @@ async def _mystery_notice_job(round_id: int) -> None:
     await cb(round_id)
 
 
+async def _forecast_cleanup_job(round_id: int) -> None:
+    """Top-level APScheduler callable for post-race Phase 3 message cleanup.
+
+    Fires 24 hours after round start.  Follows the same module-level pattern as
+    ``_mystery_notice_job`` to avoid closure pickling issues with
+    SQLAlchemyJobStore.
+    """
+    if _GLOBAL_SERVICE is None:
+        log.warning(
+            "_forecast_cleanup_job fired but _GLOBAL_SERVICE is None "
+            "(round=%s) — skipping",
+            round_id,
+        )
+        return
+    cb = _GLOBAL_SERVICE._forecast_cleanup_callback
+    if cb is None:
+        log.warning(
+            "No forecast cleanup callback registered; skipping round %s.", round_id
+        )
+        return
+    await cb(round_id)
+
+
 class SchedulerService:
     def __init__(self, db_path: str) -> None:
         self._db_path = db_path
@@ -109,6 +132,8 @@ class SchedulerService:
         self._season_end_callback: "Callable | None" = None
         # Mystery notice callback injected after bot starts
         self._mystery_notice_callback: "Callable | None" = None
+        # Post-race forecast cleanup callback injected after bot starts
+        self._forecast_cleanup_callback: "Callable | None" = None
 
     def register_callbacks(
         self,
@@ -136,6 +161,14 @@ class SchedulerService:
         Called from bot.py on_ready after the scheduler is started.
         """
         self._mystery_notice_callback = callback
+
+    def register_forecast_cleanup_callback(self, callback: Callable) -> None:
+        """Register the async callable invoked 24 h after a round start.
+
+        The callable must accept ``(round_id: int)``.
+        Called from bot.py on_ready after the scheduler is started.
+        """
+        self._forecast_cleanup_callback = callback
 
     def start(self) -> None:
         global _GLOBAL_SERVICE
@@ -201,13 +234,27 @@ class SchedulerService:
             )
             log.info("Scheduled %s at %s", job_id, fire_at.isoformat())
 
+        # Schedule post-race Phase 3 cleanup: +24 h after round start
+        cleanup_fire_at = scheduled_at + timedelta(hours=24)
+        cleanup_job_id = f"cleanup_r{rnd.id}"
+        self._scheduler.add_job(
+            _forecast_cleanup_job,
+            trigger=DateTrigger(run_date=cleanup_fire_at, timezone="UTC"),
+            id=cleanup_job_id,
+            replace_existing=True,
+            name=f"Forecast cleanup for round {rnd.id}",
+            kwargs={"round_id": rnd.id},
+        )
+        log.info("Scheduled %s at %s", cleanup_job_id, cleanup_fire_at.isoformat())
+
     def cancel_round(self, round_id: int) -> None:
-        """Remove all phase jobs and the mystery-notice job for *round_id*."""
+        """Remove all phase jobs, the mystery-notice job, and the cleanup job for *round_id*."""
         for job_id in (
             f"phase1_r{round_id}",
             f"phase2_r{round_id}",
             f"phase3_r{round_id}",
             f"mystery_r{round_id}",
+            f"cleanup_r{round_id}",
         ):
             try:
                 self._scheduler.remove_job(job_id)

--- a/src/utils/output_router.py
+++ b/src/utils/output_router.py
@@ -10,7 +10,7 @@ No other channel receives bot messages.
 from __future__ import annotations
 
 import logging
-from typing import TYPE_CHECKING
+from typing import TYPE_CHECKING, Optional
 
 import discord
 
@@ -31,13 +31,16 @@ class OutputRouter:
     # Public API
     # ------------------------------------------------------------------
 
-    async def post_forecast(self, division: "Division", content: str) -> None:
+    async def post_forecast(
+        self, division: "Division", content: str
+    ) -> "Optional[discord.Message]":
         """Post *content* to the division's forecast channel.
 
+        Returns the ``discord.Message`` on success, or ``None`` on failure.
         On failure, attempts to surface an alert to the log channel.
         """
         channel_id = division.forecast_channel_id
-        await self._send(channel_id, content, fallback_label="forecast")
+        return await self._send(channel_id, content, fallback_label="forecast")
 
     async def post_log(self, server_id: int, content: str) -> None:
         """Post *content* to the server's calculation log channel.
@@ -50,9 +53,9 @@ class OutputRouter:
             return
 
         channel_id = config.log_channel_id
-        success = await self._send(channel_id, content, fallback_label="log")
+        msg = await self._send(channel_id, content, fallback_label="log")
 
-        if not success:
+        if msg is None:
             # Last resort: try interaction channel
             await self._send(
                 config.interaction_channel_id,
@@ -67,10 +70,11 @@ class OutputRouter:
 
     async def _send(
         self, channel_id: int, content: str, *, fallback_label: str = "unknown"
-    ) -> bool:
+    ) -> "Optional[discord.Message]":
         """Attempt to send *content* to *channel_id*.
 
-        Returns True on success, False on failure. Never raises.
+        Returns the last ``discord.Message`` sent on success, ``None`` on failure.
+        Never raises.
         """
         channel = self._bot.get_channel(channel_id)
         if channel is None:
@@ -81,20 +85,21 @@ class OutputRouter:
                     "_send: cannot fetch %s channel id=%s: %s",
                     fallback_label, channel_id, exc,
                 )
-                return False
+                return None
 
         if not isinstance(channel, discord.TextChannel):
             log.error(
                 "_send: channel id=%s is not a TextChannel (got %s)",
                 channel_id, type(channel).__name__,
             )
-            return False
+            return None
 
         try:
             # Discord messages have a 2000-char limit; chunk if needed
+            last_msg: Optional[discord.Message] = None
             for chunk in _chunk_message(content):
-                await channel.send(chunk)
-            return True
+                last_msg = await channel.send(chunk)
+            return last_msg
         except discord.Forbidden as exc:
             log.error(
                 "_send: missing permissions for %s channel id=%s: %s",
@@ -105,7 +110,7 @@ class OutputRouter:
                 "_send: HTTP error posting to %s channel id=%s: %s",
                 fallback_label, channel_id, exc,
             )
-        return False
+        return None
 
 
 def _chunk_message(content: str, limit: int = 1990) -> list[str]:

--- a/tests/unit/test_forecast_cleanup.py
+++ b/tests/unit/test_forecast_cleanup.py
@@ -1,0 +1,369 @@
+"""Unit tests for forecast_cleanup_service — Feature 007.
+
+Covers all four user stories:
+  US1 — Phase N message deleted before Phase N+1 is posted
+  US2 — Phase 3 message deleted 24 h after round start
+  US3 — Message deletion on amendment (delete_forecast_message called per phase)
+  US4 — Test mode: deletions suppressed while active; flushed on disable
+
+Acceptance scenarios checked:
+  SC-001  store then delete a phase message
+  SC-002  delete_forecast_message on missing row is a no-op
+  SC-003  test mode active → deletion skipped, row kept
+  SC-004  test mode disabled after SC-003 → flush removes row and calls Discord
+  SC-005  run_post_race_cleanup → deletes phase 3 across all divisions
+  SC-006  Discord NotFound is silently absorbed; DB row still removed
+  SC-007  Discord Forbidden is logged; DB row still removed
+"""
+from __future__ import annotations
+
+import os
+import sys
+import tempfile
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import discord
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from db.database import get_connection, run_migrations
+from services.forecast_cleanup_service import (
+    store_forecast_message,
+    delete_forecast_message,
+    run_post_race_cleanup,
+    flush_pending_deletions,
+)
+
+
+# ---------------------------------------------------------------------------
+# Fixtures / helpers
+# ---------------------------------------------------------------------------
+
+async def _make_db(tmp_path: str) -> str:
+    """Run all migrations on a fresh SQLite file and return the path."""
+    db_path = os.path.join(tmp_path, "test.db")
+    await run_migrations(db_path)
+    return db_path
+
+
+async def _seed_base(db_path: str, server_id: int = 1, test_mode: int = 0) -> tuple[int, int]:
+    """Insert server_config, season, division, and round.
+
+    Returns (division_id, round_id).
+    """
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "INSERT INTO server_configs "
+            "(server_id, interaction_role_id, interaction_channel_id, log_channel_id, test_mode_active) "
+            "VALUES (?, 100, 200, 300, ?)",
+            (server_id, test_mode),
+        )
+        await db.execute(
+            "INSERT INTO seasons (id, server_id, start_date, status) "
+            "VALUES (1, ?, '2026-01-01', 'ACTIVE')",
+            (server_id,),
+        )
+        await db.execute(
+            "INSERT INTO divisions (id, season_id, name, forecast_channel_id, mention_role_id) "
+            "VALUES (1, 1, 'Div A', 999, 555)"
+        )
+        await db.execute(
+            "INSERT INTO rounds (id, division_id, round_number, format, track_name, scheduled_at) "
+            "VALUES (1, 1, 1, 'NORMAL', 'Bahrain', '2026-06-01T14:00:00')"
+        )
+        await db.commit()
+    return 1, 1  # division_id=1, round_id=1
+
+
+def _make_mock_message(message_id: int = 12345) -> MagicMock:
+    msg = MagicMock(spec=discord.Message)
+    msg.id = message_id
+    return msg
+
+
+def _make_bot(db_path: str, test_mode_active: bool = False) -> MagicMock:
+    """Build a minimal bot mock with config_service and channel mocking."""
+    bot = MagicMock()
+    bot.db_path = db_path
+
+    # config_service — returns a config with test_mode_active flag
+    config = MagicMock()
+    config.test_mode_active = test_mode_active
+    bot.config_service.get_server_config = AsyncMock(return_value=config)
+
+    # Discord channel mock — get_channel returns a TextChannel whose
+    # get_partial_message().delete() is an AsyncMock
+    partial_msg = MagicMock()
+    partial_msg.delete = AsyncMock()
+    channel = MagicMock(spec=discord.TextChannel)
+    channel.get_partial_message = MagicMock(return_value=partial_msg)
+    bot.get_channel = MagicMock(return_value=channel)
+
+    return bot
+
+
+async def _get_stored_row(db_path: str, round_id: int, division_id: int, phase_number: int):
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            "SELECT * FROM forecast_messages "
+            "WHERE round_id = ? AND division_id = ? AND phase_number = ?",
+            (round_id, division_id, phase_number),
+        )
+        return await cursor.fetchone()
+
+
+# ---------------------------------------------------------------------------
+# store_forecast_message (T003 / SC-001)
+# ---------------------------------------------------------------------------
+
+class TestStoreForecastMessage:
+
+    async def test_inserts_row(self, tmp_path):
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path)
+
+        msg = _make_mock_message(message_id=111)
+        await store_forecast_message(1, 1, 1, msg, db_path)
+
+        row = await _get_stored_row(db_path, round_id=1, division_id=1, phase_number=1)
+        assert row is not None
+        assert row["message_id"] == 111
+        assert row["phase_number"] == 1
+
+    async def test_replace_on_duplicate(self, tmp_path):
+        """INSERT OR REPLACE: re-running a phase updates the stored ID."""
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path)
+
+        await store_forecast_message(1, 1, 1, _make_mock_message(111), db_path)
+        await store_forecast_message(1, 1, 1, _make_mock_message(222), db_path)
+
+        row = await _get_stored_row(db_path, 1, 1, 1)
+        assert row["message_id"] == 222  # updated, not duplicated
+
+    async def test_different_phases_coexist(self, tmp_path):
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path)
+
+        await store_forecast_message(1, 1, 1, _make_mock_message(100), db_path)
+        await store_forecast_message(1, 1, 2, _make_mock_message(200), db_path)
+        await store_forecast_message(1, 1, 3, _make_mock_message(300), db_path)
+
+        for phase, expected_id in ((1, 100), (2, 200), (3, 300)):
+            row = await _get_stored_row(db_path, 1, 1, phase)
+            assert row["message_id"] == expected_id
+
+
+# ---------------------------------------------------------------------------
+# delete_forecast_message — happy path (T004 / SC-001)
+# ---------------------------------------------------------------------------
+
+class TestDeleteForecastMessage:
+
+    async def test_deletes_discord_message_and_row(self, tmp_path):
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path)
+        await store_forecast_message(1, 1, 1, _make_mock_message(111), db_path)
+
+        bot = _make_bot(db_path, test_mode_active=False)
+        await delete_forecast_message(round_id=1, division_id=1, phase_number=1, bot=bot)
+
+        # Discord delete called once
+        channel = bot.get_channel.return_value
+        partial = channel.get_partial_message.return_value
+        partial.delete.assert_awaited_once()
+
+        # DB row removed
+        row = await _get_stored_row(db_path, 1, 1, 1)
+        assert row is None
+
+    async def test_missing_row_is_noop(self, tmp_path):
+        """No row in DB → returns without error, no Discord calls."""
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path)
+
+        bot = _make_bot(db_path, test_mode_active=False)
+        # Should not raise
+        await delete_forecast_message(round_id=1, division_id=1, phase_number=1, bot=bot)
+
+        bot.get_channel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# Test-mode guard (T012 / SC-003 and SC-004)
+# ---------------------------------------------------------------------------
+
+class TestDeleteForecastMessageTestModeGuard:
+
+    async def test_test_mode_suppresses_delete_keeps_row(self, tmp_path):
+        """SC-003: while test mode active, Discord delete is skipped, row retained."""
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path, test_mode=1)
+        await store_forecast_message(1, 1, 1, _make_mock_message(999), db_path)
+
+        bot = _make_bot(db_path, test_mode_active=True)
+        await delete_forecast_message(round_id=1, division_id=1, phase_number=1, bot=bot)
+
+        # Discord delete NOT called
+        bot.get_channel.assert_not_called()
+
+        # Row still present
+        row = await _get_stored_row(db_path, 1, 1, 1)
+        assert row is not None
+        assert row["message_id"] == 999
+
+
+# ---------------------------------------------------------------------------
+# flush_pending_deletions (T013 / SC-004)
+# ---------------------------------------------------------------------------
+
+class TestFlushPendingDeletions:
+
+    async def test_flushes_all_stored_messages_for_server(self, tmp_path):
+        """SC-004: all stored messages deleted once test mode is disabled."""
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path, test_mode=0)  # test mode now OFF
+
+        # Manually insert rows (simulating messages stored while test mode was on)
+        async with get_connection(db_path) as db:
+            for phase in (1, 2, 3):
+                await db.execute(
+                    "INSERT INTO forecast_messages "
+                    "(round_id, division_id, phase_number, message_id, posted_at) "
+                    "VALUES (1, 1, ?, ?, '2026-06-01T12:00:00')",
+                    (phase, 1000 + phase),
+                )
+            await db.commit()
+
+        bot = _make_bot(db_path, test_mode_active=False)
+        await flush_pending_deletions(server_id=1, bot=bot)
+
+        # All rows gone
+        async with get_connection(db_path) as db:
+            cursor = await db.execute("SELECT COUNT(*) FROM forecast_messages WHERE round_id = 1")
+            count = (await cursor.fetchone())[0]
+        assert count == 0
+
+        # Discord delete called three times
+        channel = bot.get_channel.return_value
+        partial = channel.get_partial_message.return_value
+        assert partial.delete.await_count == 3
+
+    async def test_flush_empty_is_noop(self, tmp_path):
+        """No stored messages → completes without error."""
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path)
+
+        bot = _make_bot(db_path, test_mode_active=False)
+        await flush_pending_deletions(server_id=1, bot=bot)  # should not raise
+
+        bot.get_channel.assert_not_called()
+
+
+# ---------------------------------------------------------------------------
+# run_post_race_cleanup (T010 / SC-005)
+# ---------------------------------------------------------------------------
+
+class TestRunPostRaceCleanup:
+
+    async def test_deletes_phase3_for_all_divisions(self, tmp_path):
+        """SC-005: post-race job deletes Phase 3 messages for all divisions."""
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path)
+
+        # Add a second division + round mapping to same round_id = 1 via forecast_messages
+        async with get_connection(db_path) as db:
+            # Second division
+            await db.execute(
+                "INSERT INTO divisions (id, season_id, name, forecast_channel_id, mention_role_id) "
+                "VALUES (2, 1, 'Div B', 888, 666)"
+            )
+            # Phase 3 rows for both divisions
+            for div_id, msg_id in ((1, 301), (2, 302)):
+                await db.execute(
+                    "INSERT INTO forecast_messages "
+                    "(round_id, division_id, phase_number, message_id, posted_at) "
+                    "VALUES (1, ?, 3, ?, '2026-06-01T14:00:00')",
+                    (div_id, msg_id),
+                )
+            await db.commit()
+
+        bot = _make_bot(db_path, test_mode_active=False)
+        await run_post_race_cleanup(round_id=1, bot=bot)
+
+        # Both Phase 3 rows removed
+        async with get_connection(db_path) as db:
+            cursor = await db.execute(
+                "SELECT COUNT(*) FROM forecast_messages WHERE round_id = 1 AND phase_number = 3"
+            )
+            count = (await cursor.fetchone())[0]
+        assert count == 0
+
+    async def test_does_not_delete_earlier_phases(self, tmp_path):
+        """Cleanup job only targets phase 3; phases 1/2 rows are untouched."""
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path)
+
+        async with get_connection(db_path) as db:
+            for phase in (1, 2, 3):
+                await db.execute(
+                    "INSERT INTO forecast_messages "
+                    "(round_id, division_id, phase_number, message_id, posted_at) "
+                    "VALUES (1, 1, ?, ?, '2026-06-01T14:00:00')",
+                    (phase, 100 + phase),
+                )
+            await db.commit()
+
+        bot = _make_bot(db_path, test_mode_active=False)
+        await run_post_race_cleanup(round_id=1, bot=bot)
+
+        async with get_connection(db_path) as db:
+            cursor = await db.execute(
+                "SELECT phase_number FROM forecast_messages WHERE round_id = 1"
+            )
+            remaining = [r["phase_number"] for r in await cursor.fetchall()]
+        assert sorted(remaining) == [1, 2]
+
+
+# ---------------------------------------------------------------------------
+# Discord error handling (SC-006, SC-007)
+# ---------------------------------------------------------------------------
+
+class TestDiscordErrorHandling:
+
+    async def test_not_found_absorbed_row_removed(self, tmp_path):
+        """SC-006: NotFound is silently swallowed; DB row still removed."""
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path)
+        await store_forecast_message(1, 1, 2, _make_mock_message(777), db_path)
+
+        bot = _make_bot(db_path, test_mode_active=False)
+        channel = bot.get_channel.return_value
+        channel.get_partial_message.return_value.delete = AsyncMock(
+            side_effect=discord.NotFound(MagicMock(status=404), "unknown message")
+        )
+
+        # Should not raise
+        await delete_forecast_message(round_id=1, division_id=1, phase_number=2, bot=bot)
+
+        # DB row still removed despite the 404
+        row = await _get_stored_row(db_path, 1, 1, 2)
+        assert row is None
+
+    async def test_forbidden_logged_row_removed(self, tmp_path):
+        """SC-007: Forbidden is logged; DB row removed so future calls are unblocked."""
+        db_path = await _make_db(str(tmp_path))
+        await _seed_base(db_path)
+        await store_forecast_message(1, 1, 3, _make_mock_message(888), db_path)
+
+        bot = _make_bot(db_path, test_mode_active=False)
+        channel = bot.get_channel.return_value
+        channel.get_partial_message.return_value.delete = AsyncMock(
+            side_effect=discord.Forbidden(MagicMock(status=403), "missing access")
+        )
+
+        await delete_forecast_message(round_id=1, division_id=1, phase_number=3, bot=bot)
+
+        row = await _get_stored_row(db_path, 1, 1, 3)
+        assert row is None

--- a/tests/unit/test_mystery_notice.py
+++ b/tests/unit/test_mystery_notice.py
@@ -122,7 +122,8 @@ class TestCancelRoundIncludesMystery:
     def test_removes_four_job_ids_total(self):
         svc = _make_scheduler_no_db()
         svc.cancel_round(7)
-        assert svc._scheduler.remove_job.call_count == 4
+        # phase1, phase2, phase3, mystery, cleanup = 5 job IDs
+        assert svc._scheduler.remove_job.call_count == 5
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Forecast messages are now cleaned up at the following points:
- Before posting the output message of Phase 2 for a given round of a given division, the output message of Phase 1 of the same round and division shall be deleted.
- Likewise, before posting the output message of Phase 3 for a given round of a given division, the output message of Phase 2 of the same round and division shall be deleted.
- 24 hours after a round of a given division is scheduled to start, the output message of Phase 3 for that round and division shall be deleted.
- While test mode is toggled on, the messages are not autodeleted;
- Once test mode is toggled off, the messages that should be autodeleted are thus autodeleted. 