### PR TITLE
feat(008): implement Phase 1 Beta distribution redesign

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,23 @@
 <!--
 SYNC IMPACT REPORT
 ==================
+[2026-03-05 — New feature addition: constitution reuse pass]
+  - Constitution reused as-is; no new principles required for incremental feature work.
+  - Session intent: add a new feature to an already-existing SpecKit-driven codebase.
+  - All placeholder tokens remain resolved; no bracket tokens present.
+  - Version 1.1.0 consistent across all sections; no version bump warranted (no content
+    amendments — reuse session only).
+  - Templates confirmed aligned with Principles I–VII:
+      ✅ .specify/templates/plan-template.md    — Constitution Check gate is dynamic; no
+           hardcoded principle list; no changes needed.
+      ✅ .specify/templates/spec-template.md    — generic structure; no stale references.
+      ✅ .specify/templates/tasks-template.md   — phase structure generic; aligns with I–VII.
+      ✅ .specify/templates/agent-file-template.md — generic placeholders; no stale names.
+      ✅ .specify/templates/checklist-template.md  — no issues.
+  - No stale agent-specific references detected.
+  - Last Amended date remains 2026-03-03 (no content amendments this session).
+  - No deferred TODOs.
+
 [2026-03-04 — New feature addition: constitution validation pass]
   - Constitution reused as-is; no new principles required for incremental feature work.
   - Session intent: validate constitution readiness before beginning a new SpecKit feature

--- a/README.md
+++ b/README.md
@@ -177,6 +177,39 @@ No parameters. Displays a summary of all rounds for the active season, showing w
 
 ---
 
+### Track Distribution Parameters
+
+#### `/track config` — Set per-track Beta distribution parameters
+*Access: Trusted admin*
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|--------------|
+| `track` | String | ✅ | Track ID or name (autocomplete supported) |
+| `mu` | Float | ✅ | Mean rain probability (0.0 – 1.0 exclusive, e.g. `0.30` for 30%) |
+| `sigma` | Float | ✅ | Dispersion / standard deviation (must be > 0) |
+
+Changes take effect for all future Phase 1 draws. Existing results are not retroactively recalculated.
+
+#### `/track reset` — Revert to packaged default
+*Access: Trusted admin*
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|--------------|
+| `track` | String | ✅ | Track ID or name to reset |
+
+Removes the server override; the bot reverts to its packaged default values for that track.
+
+#### `/track info` — Inspect effective parameters
+*Access: Interaction role*
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|--------------|
+| `track` | String | ✅ | Track ID or name |
+
+Shows the effective μ and σ, whether they come from a server override or the bot's packaged default, and (for overrides) who set them and when.
+
+---
+
 ### Track ID Reference
 
 Use these IDs in `/round-add` and `/round-amend` — autocomplete will show the full list as you type.
@@ -192,6 +225,51 @@ Use these IDs in `/round-add` and `/round-amend` — autocomplete will show the 
 | 07 | Belgium | 16 | Mexico | 25 | Texas |
 | 08 | Brazil | 17 | Miami | 26 | Turkey |
 | 09 | Canada | 18 | Monaco | 27 | United Kingdom |
+
+---
+
+## Track Distribution Parameters
+
+Phase 1 draws the rain probability coefficient (`Rpc`) from a **Beta distribution** parameterised by two values per track:
+
+| Symbol | Name | Meaning |
+|--------|------|---------|
+| **μ** (`mu`) | Mean rain probability | Expected average Rpc for this circuit |
+| **σ** (`sigma`) | Dispersion | Controls how wide / unpredictable the distribution is |
+
+The Beta distribution is natively bounded to [0, 1], so no clamping is needed under normal parameters.
+
+### How σ affects the shape
+
+Raising σ **widens** the distribution and pushes probability mass towards both extremes:
+
+- **Small σ** (e.g. Bahrain: μ = 5%, σ = 2%): draws cluster tightly around the mean. Rare to see anything above ~10%; the track feels reliably dry.
+- **Larger σ** (e.g. Belgium: μ = 30%, σ = 8%): draws spread across a wider band. You might see 5% or 55% in the same season — genuine unpredictability.
+
+**Concrete tail probabilities (approximate)**:
+
+| Track | μ | σ | P(Rpc ≥ 10%) | P(Rpc ≥ 25%) |
+|-------|---|---|--------------|---------------|
+| Bahrain | 5% | 2% | ~2% | < 0.1% |
+| Bahrain | 5% | 5% | ~14% | ~3% |
+| Belgium | 30% | 8% | ~97% | ~50% |
+
+Raising Bahrain's σ from 2% to 5% increases the chance of a surprise wet event (≥ 10%) from ~2% to ~14%. Belgium at σ = 8% is almost always substantially wet, but occasionally surprises with a dry day.
+
+### The J-shape / humped-bell transition
+
+The Beta distribution changes shape depending on the derived parameters α = μν and β = (1 − μ)ν, where ν = μ(1 − μ)/σ² − 1.
+
+- **When α < 1** (typical for low-μ, wider-σ tracks): the distribution is **J-shaped** — mode at 0, with a long right tail. Most draws are near 0, but genuine spikes into moderate territory are possible. This is exactly the desired behaviour for arid circuits like Bahrain or Qatar.
+- **When α > 1 and β > 1** (typical for mid-μ tracks with moderate σ): the distribution is **bell-shaped (humped)** — centred around the mean with symmetric spread. United Kingdom (μ = 30%, σ = 5%) behaves like this.
+
+### Feasibility constraint
+
+σ must satisfy `σ < √(μ × (1 − μ))`. If this is violated, the Beta parameters become non-positive and sampling will fail — Phase 1 will block with an error to the log channel. Use `/track info` after setting parameters to verify.
+
+### Packaged defaults
+
+All 27 circuits ship with pre-tuned defaults. Use `/track info <track>` to inspect them or `/track config` to override them for your server.
 
 ---
 

--- a/specs/008-phase1-rpc-redesign/data-model.md
+++ b/specs/008-phase1-rpc-redesign/data-model.md
@@ -1,0 +1,169 @@
+# Data Model: Phase 1 Rpc Distribution Redesign
+
+**Branch**: `008-phase1-rpc-redesign` | **Date**: 2026-03-05
+
+---
+
+## Entities Changed / Added
+
+### 1. `track.py` — application-code constants (not DB)
+
+**Before**:
+```python
+TRACKS: dict[str, float]   # name → btrack (single float)
+get_btrack(name) → float
+```
+
+**After**:
+```python
+TRACK_DEFAULTS: dict[str, tuple[float, float]]  # name → (mu_default, sigma_default)
+get_default_rpc_params(name: str) → tuple[float, float]
+    """Return (mu, sigma) packaged defaults for name; raise ValueError for unknown tracks."""
+
+TRACK_NAMES: Final[list[str]] = list(TRACK_DEFAULTS.keys())
+    # Convenience alias used by autocomplete in season_cog / amendment_cog
+```
+
+**TRACK_DEFAULTS values** (all values fractional, e.g. 0.05 = 5%):
+
+| Track | μ | σ |
+|---|---|---|
+| Abu Dhabi | 0.05 | 0.03 |
+| Australia | 0.10 | 0.05 |
+| Austria | 0.25 | 0.07 |
+| Azerbaijan | 0.10 | 0.03 |
+| Bahrain | 0.05 | 0.02 |
+| Barcelona | 0.20 | 0.05 |
+| Belgium | 0.30 | 0.08 |
+| Brazil | 0.30 | 0.08 |
+| Canada | 0.30 | 0.05 |
+| China | 0.25 | 0.05 |
+| Hungary | 0.25 | 0.05 |
+| Imola | 0.25 | 0.05 |
+| Japan | 0.25 | 0.07 |
+| Las Vegas | 0.05 | 0.02 |
+| Madrid | 0.15 | 0.05 |
+| Mexico | 0.05 | 0.03 |
+| Miami | 0.15 | 0.07 |
+| Monaco | 0.25 | 0.05 |
+| Monza | 0.15 | 0.03 |
+| Netherlands | 0.25 | 0.05 |
+| Portugal | 0.10 | 0.03 |
+| Qatar | 0.05 | 0.02 |
+| Saudi Arabia | 0.05 | 0.03 |
+| Singapore | 0.20 | 0.07 |
+| Texas | 0.10 | 0.03 |
+| Turkey | 0.10 | 0.05 |
+| United Kingdom | 0.30 | 0.05 |
+
+---
+
+### 2. `track_rpc_params` — new DB table (`005_track_rpc_params.sql`)
+
+Stores **server-level override** rows. A track not present in this table uses the
+bot-packaged default from `TRACK_DEFAULTS`.
+
+```sql
+CREATE TABLE IF NOT EXISTS track_rpc_params (
+    track_name      TEXT    PRIMARY KEY,
+    mu_rain_pct     REAL    NOT NULL,   -- fractional, e.g. 0.30 = 30%
+    sigma_rain_pct  REAL    NOT NULL,   -- fractional, e.g. 0.08 = 8%
+    updated_at      TEXT    NOT NULL,   -- ISO UTC datetime of last update
+    updated_by      TEXT    NOT NULL    -- Discord display name of last actor
+);
+```
+
+**Resolution rule** (applied in `track_service.get_effective_rpc_params`):
+1. Query `SELECT mu_rain_pct, sigma_rain_pct FROM track_rpc_params WHERE track_name = ?`
+2. If a row exists → use override values.
+3. If no row → look up `TRACK_DEFAULTS[track_name]`.
+4. If track_name not in `TRACK_DEFAULTS` and no row → raise `ValueError` → Phase 1 blocks
+   (FR-015).
+
+---
+
+### 3. `phase_results.payload` — expanded Phase 1 JSON blob
+
+**Before** (Phase 1 payload keys):
+```json
+{
+  "phase": 1,
+  "round_id": 42,
+  "track": "Belgium",
+  "btrack": 0.30,
+  "rand1": 71,
+  "rand2": 44,
+  "rpc": 0.29
+}
+```
+
+**After**:
+```json
+{
+  "phase": 1,
+  "round_id": 42,
+  "track": "Belgium",
+  "distribution": "beta",
+  "mu": 0.30,
+  "sigma": 0.08,
+  "alpha": 9.5625,
+  "beta_param": 22.3125,
+  "raw_draw": 0.2847,
+  "rpc": 0.28
+}
+```
+
+Notes:
+- `btrack`, `rand1`, `rand2` are removed.
+- `beta_param` avoids shadowing the Python builtin `beta` if deserialised.
+- `raw_draw` is the pre-rounding, pre-clamp value from `random.betavariate`.
+- `rpc` is `round(max(0.0, min(1.0, raw_draw)), 2)`.
+
+---
+
+### 4. `audit_entries` — new change_type values (no schema change)
+
+Two new `change_type` string values are written to the existing `audit_entries` table by
+`track_service`:
+
+| change_type | Triggered by | old_value | new_value |
+|---|---|---|---|
+| `TRACK_RPC_CONFIG` | `/track config` | `"mu=X, sigma=Y"` or `"(default)"` | `"mu=A, sigma=B"` |
+| `TRACK_RPC_RESET` | `/track reset` | `"mu=X, sigma=Y"` (the override being removed) | `"(default) mu=A, sigma=B"` |
+
+---
+
+## Entities Unchanged
+
+- `rounds` — no changes; `track_name` column continues to be the join key.
+- `sessions` — no changes; Phase 2/3 still consume `Rpc` from `phase_results.payload`.
+- `forecast_messages` — no changes.
+- `server_configs`, `seasons`, `divisions` — no changes.
+
+---
+
+## State Transitions
+
+```
+Track config state (per track):
+  [no override row]  --/track config-->  [override row present]
+  [override row present]  --/track reset-->  [no override row]
+
+Phase 1 draw (at T-5d):
+  resolve_params(track_name, db)  -->  (mu, sigma)
+       ↓
+  compute_rpc_beta(mu, sigma)  -->  (raw_draw, rpc)
+       ↓
+  INSERT phase_results payload + UPDATE rounds.phase1_done = 1
+```
+
+---
+
+## Validation Rules
+
+| Field | Rule |
+|---|---|
+| `μ_track` (admin input) | Must be in (0.0, 1.0) exclusive. Values ≤ 0 or ≥ 1 are rejected before persistence. |
+| `σ_track` (admin input) | Must be > 0.0. Values ≤ 0 are rejected before persistence. |
+| `σ_track` (implicit constraint) | Must satisfy σ < √(μ(1−μ)) to keep α > 0 and β > 0. If violated, Phase 1 blocks at draw time with a calc-log error (treated same as FR-015 unknown track). Admins should consult README guidance. |
+| `raw_draw` | Returned by `random.betavariate(α, β)` — always in (0, 1) for valid α > 0, β > 0; clamp applied for safety regardless. |

--- a/specs/008-phase1-rpc-redesign/plan.md
+++ b/specs/008-phase1-rpc-redesign/plan.md
@@ -1,0 +1,120 @@
+# Implementation Plan: Phase 1 Rpc Distribution Redesign
+
+**Branch**: `008-phase1-rpc-redesign` | **Date**: 2026-03-05 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/008-phase1-rpc-redesign/spec.md`
+
+**Reuses plan**: See [`specs/001-league-weather-bot/plan.md`](../001-league-weather-bot/plan.md)
+for the full tech stack, structural decisions, and base data model. Everything in that plan
+applies unchanged. Only the files listed in the Scope table below require edits or creation.
+
+## Summary
+
+Replace the Phase 1 `Rpc` calculation (`(Btrack * rand1 * rand2) / 3025`) with a stochastic
+draw from a **Beta distribution** parameterised by a per-track mean (`μ`) and dispersion
+(`σ`). Both parameters have **bot-packaged immutable defaults** for all 27 known circuits; a
+config-authority user may store **server-level overrides** for any track via `/track config`
+and revert them to packaged defaults via `/track reset`. Phase 1 resolves effective
+parameters at draw time (server override → packaged default). All downstream phases are
+unchanged; `Rpc` remains a float in [0.0, 1.0].
+
+**Technical approach**: `random.betavariate(α, β)` from the Python stdlib is used for
+sampling — no new dependencies. α and β are derived from μ and σ at call time:
+`ν = μ(1−μ)/σ²−1`, `α = μν`, `β = (1−μ)ν`. `math_utils.compute_rpc` is replaced by
+`compute_rpc_beta(mu, sigma) → (raw_draw, rpc)`. `track.py` replaces `TRACKS: dict[str, float]`
+with `TRACK_DEFAULTS: dict[str, tuple[float, float]]` (name → (μ, σ)) and replaces `get_btrack`
+with `get_default_rpc_params`. A new `track_rpc_params` DB table stores nullable server
+overrides resolved at runtime. A new `TrackCog` exposes `/track config` and `/track reset`.
+Phase 1 payload is expanded with Beta-specific audit fields; the public message format is
+unchanged.
+
+## Technical Context
+
+**Language/Version**: Python 3.13.2 (targets 3.8+)
+**Primary Dependencies**: discord.py 2.7.1, aiosqlite ≥ 0.19, APScheduler ≥ 3.10 — no new
+  dependencies; `random.betavariate` is part of Python stdlib
+**Storage**: SQLite via aiosqlite — one new migration (`005_track_rpc_params.sql`)
+**Testing**: pytest 9.0.2 + pytest-asyncio (`asyncio_mode = auto`); `pythonpath = src`
+**Target Platform**: Any host running Python 3.8+ with a Discord bot token
+**Project Type**: Discord bot (event-driven, async)
+**Performance Goals**: Beta sampling is O(1); no meaningful performance impact on Phase 1
+**Constraints**: No changes to Phase 2 or Phase 3 contracts; public Phase 1 message format
+  unchanged; `random.betavariate` only; no scipy/numpy
+**Scale/Scope**: 27 tracks × 1 override row each (max); bounded constant-size DB addition
+
+## Constitution Check
+
+*GATE — evaluated before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Requirement | Status |
+|-----------|-------------|--------|
+| I — Trusted Configuration Authority | `/track config` and `/track reset` are gated by `@admin_only` + `@channel_guard`; only config-authority tier can change distribution parameters | ✅ PASS |
+| II — Multi-Division Isolation | Track parameters are global per-track (server-wide); Phase 1 draws are performed independently per division as before; no cross-division state | ✅ PASS |
+| III — Resilient Schedule Management | Amendment invalidation path unchanged; newly drawn `Rpc` (after amendment) uses same Beta logic; no re-draw on parameter config change | ✅ PASS |
+| IV — Three-Phase Weather Pipeline | Phase 1 replaces only the `Rpc` production step; T−5d trigger, Phase 2/3 contracts, Mystery Round skip, and amendment-invalidation semantics are all unchanged | ✅ PASS |
+| V — Observability & Change Audit Trail | Phase 1 calc-log payload is expanded with μ, σ, α, β, raw draw, distribution type. `/track config` and `/track reset` write audit entries per FR-007 | ✅ PASS |
+| VI — Simplicity & Focused Scope | Change is surgical: new Beta sampling replaces one formula call; one new slash command group; one new migration. No expansion of bot scope | ✅ PASS |
+| VII — Output Channel Discipline | No new channel categories. Phase 1 public message posted to division forecast channel; audit entries posted to calc-log channel. Config command responses are ephemeral | ✅ PASS |
+
+**Constitution Check result: PASS — no violations, no Complexity Tracking entries required.**
+
+*Re-check post-design*: All principles confirmed. No violations introduced by Phase 1 data model (nullable override columns + new table).
+
+## Scope
+
+| File | Change |
+|------|--------|
+| `src/db/migrations/005_track_rpc_params.sql` | **New** — `track_rpc_params` table (server override rows, nullable → falls back to packaged defaults) |
+| `src/models/track.py` | Replace `TRACKS: dict[str, float]` with `TRACK_DEFAULTS: dict[str, tuple[float,float]]`; replace `get_btrack` with `get_default_rpc_params`; add `get_effective_rpc_params` |
+| `src/utils/math_utils.py` | Replace `compute_rpc(btrack, rand1, rand2)` with `compute_rpc_beta(mu, sigma) → tuple[float, float]`; retain old function as deprecated no-op shim until tests are updated |
+| `src/services/phase1_service.py` | Load effective (μ, σ) via `track_service`; call `compute_rpc_beta`; expand payload with Beta audit fields; handle "no params" block + calc-log error (FR-015) |
+| `src/services/track_service.py` | **New** — `get_track_override`, `set_track_override`, `reset_track_override`; all write audit entries |
+| `src/cogs/track_cog.py` | **New** — `/track config`, `/track reset`, `/track info`; all `@admin_only @channel_guard` |
+| `src/cogs/season_cog.py` | Update `TRACKS` import → `TRACK_DEFAULTS`; update validity check (`if name in TRACK_DEFAULTS`) |
+| `src/cogs/amendment_cog.py` | Update `TRACKS` import → `TRACK_DEFAULTS` |
+| `src/bot.py` | Register `TrackCog` |
+| `README.md` | Add "Track Distribution Parameters" section documenting Beta shape, μ/σ chaos knob, J-shape transition (FR-014) |
+| `tests/unit/test_math_utils.py` | Replace `compute_rpc` tests with `compute_rpc_beta` tests; add boundary tests (μ→0, μ→1, large σ) |
+| `tests/unit/test_track_service.py` | **New** — unit tests for override CRUD + audit entries |
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/008-phase1-rpc-redesign/
+├── plan.md          ← this file
+├── spec.md
+├── research.md
+├── data-model.md
+├── quickstart.md
+└── tasks.md         ← generated by /speckit.tasks
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── cogs/
+│   ├── track_cog.py         ← NEW
+│   └── season_cog.py        ← updated (TRACKS → TRACK_DEFAULTS import)
+│   └── amendment_cog.py     ← updated (TRACKS → TRACK_DEFAULTS import)
+├── models/
+│   └── track.py             ← updated (TRACKS → TRACK_DEFAULTS, get_btrack → get_default_rpc_params)
+├── services/
+│   ├── track_service.py     ← NEW
+│   └── phase1_service.py    ← updated (Beta draw, expanded payload, FR-015 guard)
+├── utils/
+│   └── math_utils.py        ← updated (compute_rpc_beta replaces compute_rpc)
+├── db/
+│   └── migrations/
+│       └── 005_track_rpc_params.sql  ← NEW
+└── bot.py                   ← updated (register TrackCog)
+
+tests/
+└── unit/
+    ├── test_math_utils.py       ← updated
+    └── test_track_service.py    ← NEW
+```
+
+**Structure Decision**: Single-project layout (existing); all changes within `src/` and
+`tests/unit/`. No new top-level directories.

--- a/specs/008-phase1-rpc-redesign/quickstart.md
+++ b/specs/008-phase1-rpc-redesign/quickstart.md
@@ -1,0 +1,137 @@
+# Quickstart: Phase 1 Rpc Distribution Redesign
+
+**Branch**: `008-phase1-rpc-redesign` | **Date**: 2026-03-05
+
+---
+
+## What changed
+
+Phase 1 no longer uses the formula `Rpc = (Btrack × rand1 × rand2) / 3025`.
+`Rpc` is now drawn from a **Beta distribution** parameterised by a per-track mean (μ) and
+standard deviation (σ). Bot-packaged defaults exist for all 27 circuits. Server admins can
+override any track's parameters with `/track config` and revert them with `/track reset`.
+
+---
+
+## Deployment steps
+
+1. **Delete `bot.db`** before starting (clean-DB deployment agreed in spec).
+2. Pull / deploy branch `008-phase1-rpc-redesign`.
+3. Start the bot — migration `005_track_rpc_params.sql` applies automatically.
+4. Verify startup log contains `Applied migration: 005_track_rpc_params`.
+5. No other manual setup required — packaged defaults are in application code.
+
+---
+
+## Using the new track config commands
+
+All commands require the config-authority role and must be issued in the configured
+interaction channel.
+
+### View effective parameters for a track
+
+```
+/track info <track>
+```
+
+Returns the effective μ and σ for the track (server override if set; packaged default
+otherwise), plus the derived α and β, and an example of the spike-probability table.
+Response is ephemeral.
+
+### Override a track's parameters
+
+```
+/track config <track> <mean_pct> <stddev_pct>
+```
+
+- `<mean_pct>`: mean rain probability as a percentage, e.g. `30` for 30% (must be 0–100
+  exclusive).
+- `<stddev_pct>`: standard deviation as a percentage, e.g. `8` for 8% (must be > 0).
+
+Example — make Belgium more volatile:
+```
+/track config Belgium 30 12
+```
+
+Response is ephemeral. An audit entry is written to the calculation log channel.
+
+### Reset a track to bot-packaged default
+
+```
+/track reset <track>
+```
+
+Removes the server override for the track. Future Phase 1 draws for that track revert to
+the packaged default μ and σ. An audit entry is written.
+
+---
+
+## How Beta distribution parameters affect behaviour
+
+The **σ (stddev)** value is the primary chaos knob.
+
+### Low σ → tight cluster around μ (predictable)
+
+Belgium default (μ=30%, σ=5%):
+- ~68% of draws land between 25%–35%
+- P(Rpc ≥ 50%) ≈ 0.2%
+
+### Higher σ → wider tails (more surprise)
+
+Belgium with σ=12%:
+- ~68% of draws land between 18%–42%
+- P(Rpc ≥ 50%) ≈ 5%
+- P(Rpc ≤ 10%) ≈ 4%
+
+### Low μ with default σ → mostly dry, occasional spikes (Bahrain, μ=5%, σ=2%)
+
+- P(Rpc ≥ 10%) ≈ 2%; over a 27-race season expect 0–1 meaningful wet Bahrain weekends.
+- Raising σ to 5%: P(Rpc ≥ 10%) rises to ~14% — roughly 3–4 wet Bahrain weekends per season.
+
+### Shape transition: humped bell → J-shape
+
+When `α = μν < 1` (typically when σ is large relative to μ), the distribution becomes
+**J-shaped**: most draws cluster near 0 but the tail extends further right. This is
+desirable behaviour for genuinely arid tracks where rare rain should be dramatic; it means
+"usually dry, occasionally wild". See the README for the full derivation and a worked
+example.
+
+---
+
+## Phase 1 payload changes
+
+The calculation log now shows:
+
+```
+Phase 1 | Round #3 | Belgium (2026-04-15T18:00:00Z)
+  distribution : beta
+  μ (mean)     : 0.30
+  σ (stddev)   : 0.08
+  α            : 9.5625
+  β            : 22.3125
+  raw_draw     : 0.2847
+  Rpc          : 0.28  (28%)
+```
+
+Previously logged fields `btrack`, `rand1`, `rand2` are no longer present.
+
+---
+
+## Testing after deployment
+
+1. Use `/test-mode enable` and `/test-mode advance` on a round assigned to a known track.
+2. Check the calculation log channel — confirm the Phase 1 entry shows `distribution: beta`
+   and `raw_draw` and `rpc` fields.
+3. Run `/track config <track> <mean> <stddev>` and `/test-mode advance` again on a new
+   round — confirm the log uses the updated μ/σ.
+4. Run `/track reset <track>` and verify the next draw reverts to packaged defaults.
+
+---
+
+## Running unit tests
+
+```bash
+pytest tests/unit/test_math_utils.py   # compute_rpc_beta coverage
+pytest tests/unit/test_track_service.py   # override CRUD + audit
+pytest tests/unit/ -q   # full unit suite
+```

--- a/specs/008-phase1-rpc-redesign/research.md
+++ b/specs/008-phase1-rpc-redesign/research.md
@@ -1,0 +1,130 @@
+# Research: Phase 1 Rpc Distribution Redesign
+
+**Branch**: `008-phase1-rpc-redesign` | **Date**: 2026-03-05
+
+---
+
+## Decision 1 — Distribution type for Rpc
+
+**Decision**: Beta distribution
+
+**Rationale**:
+- Natively bounded to (0, 1) — Rpc is always valid with zero clamping risk under normal
+  conditions (σ within the feasible region).
+- Right-skewed at low μ (e.g., Bahrain, Las Vegas): draws cluster near 0 with an extended
+  right tail, enabling rare-but-genuine wet events without the distribution centring on a
+  high middle value. This directly addresses the "too few rainy races" concern.
+- Symmetric bell-shaped near μ = 0.5 (high-rain tracks), giving natural variability.
+- User-facing parameters (μ, σ) map intuitively to mean and spread; α/β are derived
+  internally and are invisible to admins.
+- `random.betavariate(α, β)` is part of the Python stdlib — zero new dependencies.
+
+**Parameterisation** (derived at call time from stored μ and σ):
+
+```
+ν = μ(1 − μ) / σ² − 1
+α = μν
+β = (1 − μ)ν
+```
+
+**Feasibility constraint**: σ must satisfy σ < √(μ(1−μ)); the validation rule σ > 0 plus
+the UI documentation are sufficient guards in practice. If an admin supplies a pathological
+σ that causes α < 0 or β < 0, Phase 1 MUST detect this at draw time and block with a
+calc-log error (same path as FR-015).
+
+**Alternatives considered**:
+
+| Distribution | Reason rejected |
+|---|---|
+| Gaussian (Normal) | Unbounded — requires hard clamping at [0,1] which distorts the true mean for low-μ tracks; symmetric shape produces no right-tail surprise behaviour |
+| Truncated Normal | Bounded by construction but still symmetric — no skew for low-μ tracks; behaviour at boundary is different from interior |
+| Log-normal | Right-skewed ✓, but μ/σ control the underlying log-space, not the actual rain probability mean — less intuitive for admins to configure |
+
+---
+
+## Decision 2 — Parameter scope
+
+**Decision**: Global per-track (server-wide), stored as nullable overrides in a new DB
+table; bot-packaged defaults live in `track.py` (application code, not DB rows).
+
+**Rationale**:
+- Aligns with how `Btrack` worked previously — one value per circuit, no per-season or
+  per-division differentiation.
+- Clean data model: the `track_rpc_params` table stores only rows where an admin has
+  explicitly overridden one or more tracks. If a track has no row, the packaged default is
+  used. This avoids seeding 27 rows on every fresh installation.
+- Phase 1 resolution logic: `get_effective_rpc_params(track_name, db_path)` → checks DB
+  override first, falls back to `TRACK_DEFAULTS[track_name]`.
+
+**Alternatives considered**:
+
+| Scope | Reason rejected |
+|---|---|
+| Per-season override | Added complexity (extra JOIN in Phase 1 lookup); no demonstrated need — the whole point is a global tuning knob |
+| Per-division override | Most granular but unnecessary; same-track divisions would need duplicate config |
+
+---
+
+## Decision 3 — Sampling implementation
+
+**Decision**: `random.betavariate(α, β)` from Python stdlib `random` module.
+
+**Rationale**:
+- Identical module already used for `random.randint` in Phase 1, Phase 2, Phase 3.
+- Zero new pip dependencies; wheels, Docker layers, and Heroku/Railway slugs stay identical.
+- CPython uses the Johnk/Cheng algorithm internally — O(1), accurate, well-tested.
+
+**Alternative**: `scipy.stats.beta.rvs(α, β)` — rejected (new runtime dependency for a
+single one-liner; adds ~50 MB to install footprint).
+
+---
+
+## Decision 4 — `compute_rpc` function signature change
+
+**Decision**: Replace `compute_rpc(btrack, rand1, rand2) → float` with
+`compute_rpc_beta(mu, sigma) → tuple[float, float]` returning `(raw_draw, rpc)`.
+
+**Rationale**:
+- Raw draw must be separately logged for auditability (FR-002, FR-008). Returning both
+  means `phase1_service` never has to recompute.
+- Clean break from old signature avoids ambiguity; old function can be removed (as
+  `test_math_utils.py` is updated) since the only caller (`phase1_service.py`) is rewritten.
+- `round(raw, 2)` and `max(0.0, min(1.0, ...))` clamping applied to raw_draw → rpc as
+  before, for consistency with downstream (Phase 2 expects 2 dp float).
+
+---
+
+## Decision 5 — `track.py` restructuring
+
+**Decision**: Replace `TRACKS: dict[str, float]` (name → btrack) with
+`TRACK_DEFAULTS: dict[str, tuple[float, float]]` (name → (μ, σ)). Keep `TRACK_IDS`
+unchanged. Replace `get_btrack` with `get_default_rpc_params(name) → tuple[float, float]`.
+
+**Rationale**:
+- `TRACKS` is imported in `season_cog.py` and `amendment_cog.py` only for the set of valid
+  track names (autocomplete and validity checks). Both importers are updated to reference
+  `TRACK_DEFAULTS` with minimal change (`if name in TRACK_DEFAULTS` etc.).
+- Keeping the same module avoids deeper import chain refactors.
+- `get_btrack` can be deleted; its single caller (`phase1_service.py`) is rewritten.
+
+---
+
+## Decision 6 — `/track` command location
+
+**Decision**: New `TrackCog` in `src/cogs/track_cog.py`, registered via `bot.py`.
+
+**Rationale**:
+- Follows the project's existing one-domain-per-cog convention (season_cog, amendment_cog,
+  reset_cog, test_mode_cog).
+- Track parameter configuration is an independent domain unrelated to round amendments or
+  season setup, so a dedicated cog avoids bloating amendment_cog.
+
+---
+
+## Decision 7 — Audit entries for track config changes
+
+**Decision**: Write to the existing `audit_entries` table (same table used by
+`AmendmentService`), using `change_type = "TRACK_RPC_CONFIG"` or `"TRACK_RPC_RESET"`.
+
+**Rationale**: Reuses existing infrastructure; keeps all config mutations in a single audit
+table per Principle V. No new table needed.

--- a/specs/008-phase1-rpc-redesign/spec.md
+++ b/specs/008-phase1-rpc-redesign/spec.md
@@ -1,0 +1,161 @@
+# Feature Specification: Phase 1 Rpc Distribution Redesign
+
+**Feature Branch**: `008-phase1-rpc-redesign`  
+**Created**: 2026-03-05  
+**Status**: Draft  
+**Input**: User description: "Redesign Phase 1 Rpc generation to use a configurable statistical distribution per-track instead of the deterministic Btrack formula"
+
+## Overview
+
+Phase 1 currently computes `Rpc` via a deterministic formula driven by a fixed track base factor (`Btrack`) and two uniform random draws (`rand1`, `rand2` ∈ [1, 98]). This feature replaces that formula with a **per-track configurable statistical distribution**, where each track has an administrator-configurable **mean rain percentage** (`μ_track`) and **dispersion parameter** (`σ_track`). `Rpc` is drawn stochastically from this distribution at Phase 1 trigger time.
+
+The chosen distribution is the **Beta distribution**, parameterised by deriving α and β internally from the user-facing μ and σ values: $\nu = \frac{\mu(1-\mu)}{\sigma^2} - 1$, $\alpha = \mu\nu$, $\beta = (1-\mu)\nu$. The Beta distribution is natively bounded to [0, 1] (no clamping required in normal operation), produces right-skewed draws for low-mean tracks enabling rare but genuine surprise wet events, and allows σ to serve as a transparent per-track chaos knob. The user-visible parameters remain μ (mean rain probability) and σ (dispersion); α/β are implementation details. All downstream phases (Phase 2, Phase 3) and the amendment-invalidation pipeline remain unchanged; only the `Rpc` production mechanism in Phase 1 is affected.
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Draw Rpc from configured distribution (Priority: P1)
+
+At T−5 days, the bot draws `Rpc` for a round from the per-track statistical distribution (parameterised by `μ_track` and `σ_track`) and posts the Phase 1 forecast message, replacing the old `(Btrack * rand1 * rand2) / 3.025` formula entirely.
+
+**Why this priority**: This is the core mechanical change. Without it no other story is testable.
+
+**Independent Test**: Trigger Phase 1 against a seeded test environment for a single round; verify that `Rpc` ∈ [0, 1] was drawn according to the configured parameters, and that the forecast message and calculation log entry are both produced correctly.
+
+**Acceptance Scenarios**:
+
+1. **Given** a round with track = United Kingdom (`μ`=0.30, `σ`=0.05), **When** Phase 1 fires at T−5d, **Then** the drawn `Rpc` ∈ [0.0, 1.0], the calc-log records: track, μ, σ, distribution type, raw draw, clamped `Rpc`, UTC timestamp, and the Phase 1 message is posted to the division weather channel.
+2. **Given** a distribution draw produces a value outside [0, 1], **When** Phase 1 fires, **Then** `Rpc` is clamped to [0.0, 1.0]; the log records both the raw draw and the clamped value.
+3. **Given** Phase 1 has already fired and a round amendment subsequently occurs, **When** amendment invalidation runs, **Then** the previous `Rpc` is marked `INVALIDATED` and a fresh draw is performed using the same distribution logic.
+
+---
+
+### User Story 2 — Server admin configures per-track distribution parameters (Priority: P1)
+
+A config-authority user can update `μ_track` and/or `σ_track` for any track via a bot command at any time — before or after season review approval — without a season reset.
+
+**Why this priority**: Configurable parameters are the headline requirement; defaults without a config command leave the feature incomplete.
+
+**Independent Test**: Issue a track parameter update command; verify the new values are persisted and used by the next Phase 1 draw for that track.
+
+**Acceptance Scenarios**:
+
+1. **Given** a season in `SETUP` state, **When** a config-authority user updates Belgium (`μ`=0.30, `σ`=0.08), **Then** the values are persisted and an ephemeral confirmation is returned.
+2. **Given** a season in `ACTIVE` state, **When** the same update is issued, **Then** the values are persisted and an audit log entry records: actor, track, old values, new values, timestamp.
+3. **Given** a user without config-authority issues the update command, **Then** the bot rejects it with a clear permission error (ephemeral).
+4. **Given** a config-authority user supplies `σ` ≤ 0 or `μ` outside (0.0, 1.0), **Then** the bot rejects the input with a descriptive validation error before persisting anything.
+
+---
+
+### User Story 3 — Default parameter values ship with the bot (Priority: P2)
+
+All tracks ship with pre-populated default `μ_track` and `σ_track` values. A fresh installation with no admin overrides must draw from these defaults without additional setup.
+
+**Why this priority**: Enables out-of-the-box use; required for integration tests to pass against a clean database.
+
+**Independent Test**: Run Phase 1 on a freshly seeded database with no admin overrides; verify the draw uses the default values from the Default Parameter Table.
+
+**Acceptance Scenarios**:
+
+1. **Given** a fresh database (no admin overrides), **When** Phase 1 fires for any track in the Default Parameter Table, **Then** the draw uses that track's default `μ` and `σ`.
+2. **Given** an admin has overridden a track's parameters, **When** a reset-to-defaults command is issued for that track, **Then** the server override is removed, the track reverts to the bot-packaged default values, and an audit entry is written recording the actor and the reversion.
+
+---
+
+### Edge Cases
+
+- What happens when the drawn `Rpc` is exactly 0.0 or 1.0? Phase 2 map construction must tolerate boundary values without division-by-zero or empty buckets.
+- What happens when `σ_track` is large relative to `μ_track`, causing frequent out-of-range draws? The log must record the raw draw regardless.
+- If a track is not present in the bot-packaged default table AND has no server override (e.g., a hypothetical future circuit not yet in the defaults), Phase 1 MUST block: it MUST NOT fire, and MUST post an error to the calculation log channel instructing a config-authority user to set μ and σ for that track before the T−5d window passes.
+- If the same track appears in multiple divisions, both divisions use the same `μ_track`/`σ_track` values (server-wide scope). Each division still performs its own independent Phase 1 draw at T−5d, so their drawn `Rpc` values will differ despite sharing the same parameters.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+- **FR-001**: Phase 1 MUST derive `Rpc` by drawing from a per-track statistical distribution parameterised by `μ_track` and `σ_track`, replacing the previous `(Btrack * rand1 * rand2) / 3.025` formula entirely.
+- **FR-002**: The distribution MUST produce values clampable to [0.0, 1.0]. Raw draws outside this range MUST be clamped; both raw and clamped values MUST be written to the calculation log.
+- **FR-003**: `Rpc` MUST be rounded to two decimal places after clamping, consistent with prior behaviour.
+- **FR-004**: The bot MUST ship with immutable, packaged default `μ` and `σ` values for every track in the Default Parameter Table. These are the authoritative fallback values and MUST be present without any admin action or database seeding step.
+- **FR-005**: Config-authority users MUST be able to (a) set a server-level override for `μ_track` and/or `σ_track` for any track at any time (SETUP or ACTIVE season state), and (b) reset any track's server override back to the bot-packaged default via a dedicated reset command. Both operations MUST NOT require a season reset.
+- **FR-006**: The update command MUST validate: `μ_track` ∈ (0.0, 1.0) exclusive, `σ_track` > 0.0. Invalid inputs MUST be rejected with a descriptive error before any persistence occurs.
+- **FR-007**: Every successful update to `μ_track` or `σ_track` MUST produce a timestamped audit log entry (actor, track, old values, new values) per Principle V.
+- **FR-008**: The Phase 1 calculation log entry MUST record: track ID, `μ_track`, `σ_track`, distribution type, raw draw, clamped `Rpc`, UTC timestamp.
+- **FR-009**: The public Phase 1 forecast message format is unchanged: `"Weather radar information for @<DivisionRole>: the likelihood of rain in the next round in <Track> is <Rpc>%!"` where `<Rpc>` is rounded to the nearest integer percentage.
+- **FR-010**: Phase 1 MUST draw `Rpc` from a **Beta distribution**. The implementation MUST derive α and β from the stored μ and σ via: `ν = μ(1−μ)/σ² − 1`, `α = μν`, `β = (1−μ)ν`. The Beta distribution is the sole supported distribution type for this version; per-track distribution-type selection is out of scope.
+- **FR-014**: The README MUST document how `μ_track` and `σ_track` interact with the Beta distribution shape — specifically how increasing σ widens the distribution and pushes probability into the tails (with concrete examples), and the J-shaped / humped-bell transition that occurs when α crosses 1. This documentation MUST be delivered as part of this feature.
+- **FR-011**: Track parameter configuration MUST have server-wide scope. The effective μ/σ for a track is resolved at Phase 1 draw time: use the server override if one exists; otherwise fall back to the bot-packaged default. A parameter change or reset MUST NOT trigger re-draws of any already-persisted Phase 1 result.
+- **FR-015**: If a track scheduled for a round has no bot-packaged default AND no server override, Phase 1 MUST NOT fire for that round. The bot MUST post an error to the calculation log channel identifying the track and instructing a config-authority user to configure μ and σ before the T−5d window expires.
+- **FR-012**: The configuration command MUST be accepted only in the configured interaction channel from config-authority role holders, per Principle I.
+- **FR-013**: No migration strategy for existing active seasons is required. Deployment is against a clean database (`bot.db` deleted prior to deployment); the schema is created fresh with `μ_track` and `σ_track` present from the outset. The `btrack` column MAY be omitted from the new schema entirely.
+
+### Key Entities
+
+- **Track** (existing entity, fields changed):
+  - `mu_rain_pct` (float, nullable): server-level override for mean rain probability; `NULL` means "use bot-packaged default"
+  - `sigma_rain_pct` (float, nullable): server-level override for dispersion; `NULL` means "use bot-packaged default"
+  - `btrack` (float): OMITTED from the new schema entirely
+  - Bot-packaged defaults are resolved in application code (not stored in the DB per-row); they are the values from the Default Parameter Table.
+
+- **PhaseResult / audit log** (existing entity, fields added):
+  - `raw_rpc_draw` (float, nullable): pre-clamp draw value (equal to `Rpc` for Beta since no clamping is needed under normal conditions; populated for auditability regardless)
+  - `distribution_type` (string): always `"beta"` in this version; stored for forward-compatibility
+  - `mu_used` (float): `μ_track` value at moment of draw
+  - `sigma_used` (float): `σ_track` value at moment of draw
+  - `alpha_used` (float): derived α at moment of draw (for full audit reproducibility)
+  - `beta_used` (float): derived β at moment of draw
+
+### Default Parameter Table
+
+| Track          | μ (mean) | σ (stddev) |
+|----------------|----------|------------|
+| Bahrain        | 5%       | 2%         |
+| Saudi Arabia   | 5%       | 3%         |
+| Australia      | 10%      | 5%         |
+| Japan          | 25%      | 7%         |
+| China          | 25%      | 5%         |
+| Miami          | 15%      | 7%         |
+| Imola          | 25%      | 5%         |
+| Monaco         | 25%      | 5%         |
+| Canada         | 30%      | 5%         |
+| Barcelona      | 20%      | 5%         |
+| Madrid         | 15%      | 5%         |
+| Austria        | 25%      | 7%         |
+| United Kingdom | 30%      | 5%         |
+| Hungary        | 25%      | 5%         |
+| Belgium        | 30%      | 8%         |
+| Netherlands    | 25%      | 5%         |
+| Monza          | 15%      | 3%         |
+| Azerbaijan     | 10%      | 3%         |
+| Singapore      | 20%      | 7%         |
+| Texas          | 10%      | 3%         |
+| Mexico         | 5%       | 3%         |
+| Brazil         | 30%      | 8%         |
+| Las Vegas      | 5%       | 2%         |
+| Qatar          | 5%       | 2%         |
+| Abu Dhabi      | 5%       | 3%         |
+| Portugal       | 10%      | 3%         |
+| Turkey         | 10%      | 5%         |
+
+---
+
+## Non-Functional / Quality Attributes
+
+- Distribution sampling MUST complete within the same < 3-second acknowledgment window as all other commands (O(1) operation; no meaningful constraint in practice).
+- `μ_track` and `σ_track` MUST be persisted to durable storage; in-memory caching is permitted as a read-through layer only.
+- Schema changes MUST be delivered as a versioned migration applied automatically on startup.
+- The feature MUST NOT alter Phase 2 or Phase 3 computation contracts; `Rpc` remains a float in [0.0, 1.0] passed downstream unchanged.
+
+---
+
+## Clarifications
+
+### Session 2026-03-05
+
+- Q: Which statistical distribution should be used for the Rpc draw — Gaussian, Beta, Truncated Normal, or Log-normal? → A: **Beta distribution**. Naturally bounded to [0, 1]; right-skewed at low μ enabling rare shock wet events; σ is a transparent per-track chaos knob; α/β derived internally from μ/σ. The σ behaviour (spike rarity, J-shape transition when α < 1) MUST be documented in the README.
+- Q: What is the scope of μ_track/σ_track configuration — global per-track, per-season, or per-division? → A: **Global per-track (server-wide)**. One set of μ/σ per track, shared across all divisions and all seasons. Changes take effect for future Phase 1 draws only; already-persisted Rpc values are never retroactively recalculated.
+- Q: What is the deployment migration strategy for existing active seasons? → A: **No migration needed** — the database (`bot.db`) will be deleted prior to deployment; schema is created fresh with the new columns present from the start. `btrack` column is dropped from the schema entirely.
+- Q: How should unknown tracks (no packaged default, no server override) be handled at Phase 1, and is there a reset-to-defaults command? → A: **Two-layer model**: bot ships with immutable packaged defaults for all known tracks; server stores nullable overrides. Effective value = override if set, else packaged default. A reset command (removes override) is **in scope**. For tracks with no packaged default AND no override, Phase 1 MUST block with an error to the calc-log channel.

--- a/specs/008-phase1-rpc-redesign/tasks.md
+++ b/specs/008-phase1-rpc-redesign/tasks.md
@@ -1,0 +1,190 @@
+---
+description: "Task list for Phase 1 Rpc Distribution Redesign"
+---
+
+# Tasks: Phase 1 Rpc Distribution Redesign
+
+**Input**: Design documents from `specs/008-phase1-rpc-redesign/`
+**Prerequisites**: [plan.md](plan.md), [spec.md](spec.md), [research.md](research.md), [data-model.md](data-model.md)
+**Branch**: `008-phase1-rpc-redesign`
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: User story this task belongs to (US1 / US2 / US3)
+- Exact file paths included in every task description
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: No new project scaffolding is needed — the repository already exists. This phase establishes the one structural artefact required before any other work can proceed.
+
+- [X] T001 Create migration file `src/db/migrations/005_track_rpc_params.sql` — `CREATE TABLE IF NOT EXISTS track_rpc_params (track_name TEXT PRIMARY KEY, mu_rain_pct REAL NOT NULL, sigma_rain_pct REAL NOT NULL, updated_at TEXT NOT NULL, updated_by TEXT NOT NULL)`
+
+**Checkpoint**: Migration file exists and will be picked up automatically by `database.py run_migrations()` on next startup.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core in-code changes that are prerequisites for all three user stories. US1 cannot draw from Beta without `compute_rpc_beta`. US2 and US3 cannot resolve effective parameters without `TRACK_DEFAULTS` and `get_effective_rpc_params`. Both tasks touch different files and can proceed in parallel after T001.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [X] T002 [P] Update `src/models/track.py` — replace `TRACKS: dict[str, float]` with `TRACK_DEFAULTS: dict[str, tuple[float, float]]` (all 27 tracks with μ and σ from Default Parameter Table in spec.md); replace `get_btrack` with `get_default_rpc_params(name) -> tuple[float, float]`; add `get_effective_rpc_params(name, override_mu, override_sigma) -> tuple[float, float]` (returns server override if both non-None, else packaged default; raises `ValueError` if track has no packaged default)
+- [X] T003 [P] Update `src/utils/math_utils.py` — replace `compute_rpc(btrack, rand1, rand2)` with `compute_rpc_beta(mu: float, sigma: float) -> tuple[float, float]` returning `(raw_draw, rpc)` where: `ν = μ(1−μ)/σ²−1`, `α = μν`, `β_param = (1−μ)ν`, draw via `random.betavariate(α, β_param)`, clamp to [0.0, 1.0], round `rpc` to 2 decimal places; raise `ValueError` for invalid α/β (infeasible σ); keep old `compute_rpc` as a deprecated stub that raises `DeprecationWarning` so existing callers surface clearly
+
+**Checkpoint**: Foundation ready — `TRACK_DEFAULTS` resolves for all 27 circuits; `compute_rpc_beta` produces a valid `(raw_draw, rpc)` tuple; user story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 — Draw Rpc from Beta Distribution (Priority: P1) 🎯 MVP
+
+**Goal**: At T−5d Phase 1 trigger, `Rpc` is drawn from the per-track Beta distribution and the correct audit payload and forecast message are produced; the old `(Btrack * rand1 * rand2) / 3.025` formula is gone.
+
+**Independent Test**: Trigger Phase 1 for a single round against a seeded test environment; assert `Rpc ∈ [0.0, 1.0]`, confirm calc-log payload contains `distribution`, `mu`, `sigma`, `alpha`, `beta_param`, `raw_draw`, `rpc`, and forecast message is posted.
+
+### Tests for User Story 1
+
+- [X] T004 [P] [US1] Update `tests/unit/test_math_utils.py` — replace all `compute_rpc` tests with `compute_rpc_beta` tests covering: normal mid-range draw (μ=0.30, σ=0.05), low-μ track (μ=0.05, σ=0.02), boundary clamp (manually verified: raw draw forced outside [0,1] via monkeypatching `random.betavariate`), infeasible σ raises `ValueError` (σ ≥ √(μ(1−μ))), return type is `tuple[float, float]`, `rpc` rounded to 2dp
+
+### Implementation for User Story 1
+
+- [X] T005 [US1] Update `src/services/phase1_service.py` — (a) query `track_rpc_params` for server override row; (b) call `track_model.get_effective_rpc_params(track_name, override_mu, override_sigma)` — if this raises `ValueError` (track unknown, no packaged default), post FR-015 error to calc-log channel and return without posting forecast message; (c) call `compute_rpc_beta(mu, sigma)` — if this raises `ValueError` (infeasible σ), log the error to calc-log channel and return; (d) replace old `{btrack, rand1, rand2, rpc}` calc-log payload with expanded payload: `{"phase": 1, "round_id": ..., "track": ..., "distribution": "beta", "mu": ..., "sigma": ..., "alpha": ..., "beta_param": ..., "raw_draw": ..., "rpc": ...}`; (e) public forecast message format unchanged: `"Weather radar information for @<DivisionRole>: the likelihood of rain in the next round in <Track> is <Rpc>%!"`
+
+**Checkpoint**: Phase 1 draws from Beta, posts correct message, logs complete Beta audit payload. The old formula is fully removed. US1 independently testable.
+
+---
+
+## Phase 4: User Story 2 — Admin Configures Per-Track Parameters (Priority: P1)
+
+**Goal**: Config-authority users can update μ and σ for any track via `/track config` and query current effective values via `/track info`; every successful write produces a timestamped audit entry.
+
+**Independent Test**: Issue `/track config track:Belgium mu:0.30 sigma:0.08`; assert DB row written to `track_rpc_params`; assert ephemeral confirmation returned; assert audit entry recorded; issue with bad σ (≤ 0) and assert rejection before any write.
+
+### Tests for User Story 2
+
+- [X] T006 [P] [US2] Create `tests/unit/test_track_service.py` — unit tests covering: `set_track_override` persists row and returns old values for audit; `set_track_override` rejects μ ≤ 0.0, μ ≥ 1.0, σ ≤ 0.0 with `ValueError` before writing; `get_track_override` returns `None` when no row exists; audit entry is written on successful `set_track_override`
+
+### Implementation for User Story 2
+
+- [X] T007 [US2] Create `src/services/track_service.py` — implement: `get_track_override(db, track_name) -> tuple[float, float] | None` (SELECT from `track_rpc_params`); `set_track_override(db, track_name, mu, sigma, actor) -> None` — validate μ ∈ (0.0, 1.0) exclusive and σ > 0.0 (raise `ValueError` with descriptive message on failure), UPSERT row into `track_rpc_params`, write audit entry (actor, track, old values, new values, UTC timestamp) via existing audit mechanism; `reset_track_override` stub (placeholder, full impl in T010)
+- [X] T008 [US2] Create `src/cogs/track_cog.py` — `TrackCog(commands.Cog)` with `@app_commands.group(name="track")`; `/track config track sigma mu` — decorated `@admin_only @channel_guard`, calls `track_service.set_track_override`, returns ephemeral confirmation or descriptive error; `/track info track` — decorated `@channel_guard`, calls `get_track_override` + `get_default_rpc_params`, returns ephemeral embed showing effective μ, σ, source (override / default), and (if override) when it was set and by whom
+- [X] T009 [US2] Register `TrackCog` in `src/bot.py` — add `await bot.add_cog(TrackCog(bot))` alongside existing cog registrations
+
+**Checkpoint**: `/track config` and `/track info` fully functional; validation and audit trail working. US2 independently testable.
+
+---
+
+## Phase 5: User Story 3 — Default Parameter Values Ship with Bot + Reset Command (Priority: P2)
+
+**Goal**: A fresh database with no admin overrides works out of the box for all 27 circuits; admins can revert any override to the packaged default via `/track reset`.
+
+**Independent Test**: Run Phase 1 on a freshly initialised database for any circuit from the Default Parameter Table; assert the packaged default μ/σ were used (no DB override row). Then issue `/track reset track:Belgium`; assert override row is deleted from `track_rpc_params`, audit entry recorded, subsequent Phase 1 draw for Belgium uses packaged default.
+
+### Implementation for User Story 3
+
+- [X] T010 [P] [US3] Complete `reset_track_override` in `src/services/track_service.py` — implement: DELETE row from `track_rpc_params` for the given track (no-op if row does not exist); write audit entry (actor, track, old values, "reset to default", UTC timestamp); return old `(mu, sigma)` if a row existed, else `None`
+- [X] T011 [US3] Add `/track reset` subcommand to `src/cogs/track_cog.py` — decorated `@admin_only @channel_guard`; calls `track_service.reset_track_override`; if no override existed returns ephemeral "no override set, already using defaults"; otherwise returns ephemeral confirmation showing the old override that was cleared
+
+**Checkpoint**: All three user stories independently functional. Clean-database deployment works out of the box for all 27 tracks. US3 independently testable.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Cleanup of import references across unchanged-business-logic cogs, and the README documentation mandated by FR-014.
+
+- [X] T012 [P] Update import in `src/cogs/season_cog.py` — change `from models.track import TRACKS, TRACK_IDS` to `from models.track import TRACK_DEFAULTS, TRACK_IDS`; update all `if name in TRACKS` validity checks to `if name in TRACK_DEFAULTS`
+- [X] T013 [P] Update import in `src/cogs/amendment_cog.py` — change `from models.track import TRACKS` to `from models.track import TRACK_DEFAULTS`; update validity check to `if name in TRACK_DEFAULTS`
+- [X] T014 Add "Track Distribution Parameters" section to `README.md` — document: how μ (mean rain probability) and σ (dispersion) parameterise the Beta distribution; how increasing σ widens the distribution and pushes probability into the tails; the J-shaped / humped-bell transition that occurs when α = μν crosses 1 (with concrete numeric examples for Bahrain μ=0.05 and United Kingdom μ=0.30); guidance on choosing σ (bigger σ → more surprising draws)
+- [X] T015 Run full test suite (`pytest`) and validate key flows against `quickstart.md` — confirm: all unit tests pass, Phase 1 draws from Beta and logs the expanded payload, `/track config` accepts valid inputs and rejects invalid, `/track reset` clears overrides and is reflected in the next Phase 1 draw
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 → Phase 2**: T001 MUST complete before T002/T003 (schema file must exist before code references it)
+- **Phase 2 → Phase 3**: T002 and T003 MUST complete before Phase 3 (US1 calls both)
+- **Phase 2 → Phase 4**: T002 MUST complete before Phase 4 (US2 resolves effective params)
+- **Phase 3 → Phase 5**: T005 MUST complete before Phase 5 validation (FR-015 path uses `get_effective_rpc_params`)
+- **Phase 4 → Phase 5**: T007 MUST complete before T010 (T010 extends track_service); T008 MUST complete before T011 (T011 extends track_cog)
+- **Phase 5 → Phase 6**: All US phases SHOULD complete before Polish
+
+### User Story Dependencies
+
+- **US1 (P1)**: Foundation (Phase 2) complete — no dependency on US2 or US3
+- **US2 (P1)**: Foundation (Phase 2) complete — no dependency on US1 (independently testable)
+- **US3 (P2)**: Foundation (Phase 2) complete — extends US2 artefacts (track_service, track_cog) but independently testable via clean-DB scenario
+
+### Parallel Opportunities
+
+Within Phase 2: T002 and T003 target different files — run in parallel.
+
+Within Phase 3: T004 (tests) and foundation are both ready — T004 can be written before T005.
+
+Within Phase 4: T006 (tests) can be written before T007 (implementation) — write-fail-implement TDD if desired. T007 and T008 target different files — once T007 is done, T008 can proceed independently of T009.
+
+Within Phase 6: T012 and T013 touch different files — run in parallel alongside T014.
+
+---
+
+## Parallel Example: Phase 2
+
+```text
+# Both can start immediately after T001:
+Task T002: Update src/models/track.py  (TRACK_DEFAULTS, get_default_rpc_params, get_effective_rpc_params)
+Task T003: Update src/utils/math_utils.py  (compute_rpc_beta)
+```
+
+## Parallel Example: Phase 4
+
+```text
+# T006 can proceed alongside T007 (different files):
+Task T006: Create tests/unit/test_track_service.py
+Task T007: Create src/services/track_service.py
+
+# After T007 completes, T008 and the bot registration proceed:
+Task T008: Create src/cogs/track_cog.py
+Task T009: Update src/bot.py
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (User Story 1 Only — Core Mechanical Change)
+
+1. Complete Phase 1: T001 — migration file
+2. Complete Phase 2: T002 + T003 — foundation (parallel)
+3. Complete Phase 3: T004 + T005 — Beta draw live in Phase 1
+4. **STOP and VALIDATE**: `pytest tests/unit/test_math_utils.py`, trigger Phase 1 manually via test environment, confirm Beta payload in calc-log
+5. Deploy if ready (US2/US3 can follow for admin configuration surface)
+
+### Incremental Delivery
+
+1. Phase 1 + Phase 2 → Foundation ready
+2. Phase 3 → US1 (core formula live) → MVP
+3. Phase 4 → US2 (admin commands) → `/track config` and `/track info` available
+4. Phase 5 → US3 (defaults + reset) → full out-of-the-box experience
+5. Phase 6 → Polish (imports, README)
+
+---
+
+## Summary
+
+| Phase | Tasks | User Story | Notes |
+|-------|-------|------------|-------|
+| Phase 1 — Setup | T001 | — | Migration file |
+| Phase 2 — Foundational | T002, T003 | — | Blocks all US; run T002/T003 in parallel |
+| Phase 3 — US1 | T004, T005 | US1 (P1) | Core Beta draw; MVP complete here |
+| Phase 4 — US2 | T006, T007, T008, T009 | US2 (P1) | Admin config commands |
+| Phase 5 — US3 | T010, T011 | US3 (P2) | Reset command + defaults |
+| Phase 6 — Polish | T012, T013, T014, T015 | — | Imports, README, validation |
+
+**Total tasks**: 15  
+**Parallel opportunities**: T002/T003 (Phase 2); T006/T007 (Phase 4); T012/T013 (Phase 6)  
+**Suggested MVP scope**: Phases 1–3 (T001–T005, 5 tasks, delivers US1 end-to-end)

--- a/src/bot.py
+++ b/src/bot.py
@@ -126,12 +126,14 @@ async def main() -> None:
     from cogs.amendment_cog import AmendmentCog
     from cogs.test_mode_cog import TestModeCog
     from cogs.reset_cog import ResetCog
+    from cogs.track_cog import TrackCog
 
     await bot.add_cog(InitCog(bot))
     await bot.add_cog(SeasonCog(bot))
     await bot.add_cog(AmendmentCog(bot))
     await bot.add_cog(TestModeCog(bot))
     await bot.add_cog(ResetCog(bot))
+    await bot.add_cog(TrackCog(bot))
 
     log.info("All cogs loaded. Starting bot...")
     async with bot:

--- a/src/cogs/amendment_cog.py
+++ b/src/cogs/amendment_cog.py
@@ -14,7 +14,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from models.round import RoundFormat
-from models.track import TRACKS, TRACK_IDS
+from models.track import TRACK_DEFAULTS, TRACK_IDS
 from utils.channel_guard import channel_guard, admin_only
 
 log = logging.getLogger(__name__)
@@ -90,7 +90,7 @@ class AmendmentCog(commands.Cog):
             new_track: str | None = ...
             if track:
                 resolved = TRACK_IDS.get(track.zfill(2), track)
-                if resolved not in TRACKS:
+                if resolved not in TRACK_DEFAULTS:
                     await interaction.response.send_message(
                         f"❌ Unknown track `{track}`. Use autocomplete to pick a valid track.",
                         ephemeral=True,
@@ -210,7 +210,7 @@ class AmendmentCog(commands.Cog):
         if track:
             # Allow lookup by numeric ID (e.g. "27" → "United Kingdom")
             resolved = TRACK_IDS.get(track.zfill(2), track)
-            if resolved not in TRACKS:
+            if resolved not in TRACK_DEFAULTS:
                 await interaction.response.send_message(
                     f"\u274c Unknown track `{track}`. Use `/round-amend` and let autocomplete guide you.",
                     ephemeral=True,

--- a/src/cogs/season_cog.py
+++ b/src/cogs/season_cog.py
@@ -19,7 +19,7 @@ from discord import app_commands
 from discord.ext import commands
 
 from models.round import RoundFormat
-from models.track import TRACKS, TRACK_IDS
+from models.track import TRACK_DEFAULTS, TRACK_IDS
 from utils.channel_guard import channel_guard, admin_only
 
 log = logging.getLogger(__name__)
@@ -385,10 +385,10 @@ class SeasonCog(commands.Cog):
             )
             return
 
-        if track_name and track_name not in TRACKS:
+        if track_name and track_name not in TRACK_DEFAULTS:
             # Allow lookup by numeric ID (e.g. "27" → "United Kingdom")
             track_name = TRACK_IDS.get(track_name.zfill(2), track_name)
-        if track_name and track_name not in TRACKS:
+        if track_name and track_name not in TRACK_DEFAULTS:
             await interaction.response.send_message(
                 f"\u274c Unknown track `{track_name}`.\n"
                 f"Use `/round-add` and type a number or name — autocomplete will guide you.",

--- a/src/cogs/track_cog.py
+++ b/src/cogs/track_cog.py
@@ -1,0 +1,250 @@
+"""TrackCog — /track command group.
+
+Subcommands:
+  /track config track mu sigma  — set server-level override for a track's Beta parameters
+  /track reset  track           — revert a track's override to the bot-packaged default
+  /track info   track           — show effective (mu, sigma) and their source
+
+All subcommands require channel_guard (interaction role + channel).
+config and reset additionally require admin_only (Manage Server permission).
+"""
+
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from db.database import get_connection
+from models.track import TRACK_DEFAULTS, TRACK_IDS, get_default_rpc_params
+from services.track_service import get_track_override, set_track_override, reset_track_override
+from utils.channel_guard import channel_guard, admin_only
+
+log = logging.getLogger(__name__)
+
+
+class TrackCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    # ------------------------------------------------------------------
+    # Command group
+    # ------------------------------------------------------------------
+
+    track = app_commands.Group(
+        name="track",
+        description="Track Beta distribution parameter commands",
+    )
+
+    # ------------------------------------------------------------------
+    # Autocomplete helper
+    # ------------------------------------------------------------------
+
+    async def _autocomplete_track(
+        self,
+        interaction: discord.Interaction,
+        current: str,
+    ) -> list[app_commands.Choice[str]]:
+        """Suggest track names from TRACK_IDS for autocomplete."""
+        results: list[app_commands.Choice[str]] = []
+        current_lower = current.lower()
+        for track_id, name in TRACK_IDS.items():
+            if current_lower in name.lower() or current_lower in track_id:
+                results.append(app_commands.Choice(name=f"{track_id} — {name}", value=name))
+        return results[:25]
+
+    # ------------------------------------------------------------------
+    # /track config
+    # ------------------------------------------------------------------
+
+    @track.command(
+        name="config",
+        description="Set server-level μ (mean rain %) and σ (dispersion) for a track. Admin only.",
+    )
+    @app_commands.describe(
+        track="Track name or ID",
+        mu="Mean rain probability (0.0 – 1.0 exclusive, e.g. 0.30 for 30%)",
+        sigma="Dispersion / standard deviation (must be > 0)",
+    )
+    @app_commands.autocomplete(track=_autocomplete_track)
+    @channel_guard
+    @admin_only
+    async def config(
+        self,
+        interaction: discord.Interaction,
+        track: str,
+        mu: float,
+        sigma: float,
+    ) -> None:
+        # Resolve track name from ID or exact name
+        resolved = _resolve_track(track)
+        if resolved is None:
+            await interaction.response.send_message(
+                f"❌ Unknown track `{track}`. Use a valid track name or ID.",
+                ephemeral=True,
+            )
+            return
+
+        try:
+            async with get_connection(self.bot.db_path) as db:  # type: ignore[attr-defined]
+                await set_track_override(
+                    db,
+                    server_id=interaction.guild_id,  # type: ignore[arg-type]
+                    track_name=resolved,
+                    mu=mu,
+                    sigma=sigma,
+                    actor_id=interaction.user.id,
+                    actor_name=str(interaction.user),
+                )
+                await db.commit()
+        except ValueError as exc:
+            await interaction.response.send_message(
+                f"❌ Validation error: {exc}",
+                ephemeral=True,
+            )
+            return
+
+        await interaction.response.send_message(
+            f"✅ **{resolved}** updated — μ = `{mu}`, σ = `{sigma}`. "
+            "Applies to future Phase 1 draws; existing results are unchanged.",
+            ephemeral=True,
+        )
+
+    # ------------------------------------------------------------------
+    # /track reset
+    # ------------------------------------------------------------------
+
+    @track.command(
+        name="reset",
+        description="Reset a track's override to the bot-packaged default. Admin only.",
+    )
+    @app_commands.describe(track="Track name or ID to reset")
+    @app_commands.autocomplete(track=_autocomplete_track)
+    @channel_guard
+    @admin_only
+    async def reset(
+        self,
+        interaction: discord.Interaction,
+        track: str,
+    ) -> None:
+        resolved = _resolve_track(track)
+        if resolved is None:
+            await interaction.response.send_message(
+                f"❌ Unknown track `{track}`.",
+                ephemeral=True,
+            )
+            return
+
+        async with get_connection(self.bot.db_path) as db:  # type: ignore[attr-defined]
+            old = await reset_track_override(
+                db,
+                server_id=interaction.guild_id,  # type: ignore[arg-type]
+                track_name=resolved,
+                actor_id=interaction.user.id,
+                actor_name=str(interaction.user),
+            )
+            await db.commit()
+
+        if old is None:
+            default_mu, default_sigma = get_default_rpc_params(resolved)
+            await interaction.response.send_message(
+                f"ℹ️ **{resolved}** had no server override — already using packaged defaults "
+                f"(μ = `{default_mu}`, σ = `{default_sigma}`).",
+                ephemeral=True,
+            )
+        else:
+            default_mu, default_sigma = get_default_rpc_params(resolved)
+            await interaction.response.send_message(
+                f"✅ **{resolved}** reset to packaged defaults — "
+                f"μ = `{default_mu}`, σ = `{default_sigma}` "
+                f"(was μ = `{old[0]}`, σ = `{old[1]}`).",
+                ephemeral=True,
+            )
+
+    # ------------------------------------------------------------------
+    # /track info
+    # ------------------------------------------------------------------
+
+    @track.command(
+        name="info",
+        description="Show the effective μ and σ for a track (override or packaged default).",
+    )
+    @app_commands.describe(track="Track name or ID")
+    @app_commands.autocomplete(track=_autocomplete_track)
+    @channel_guard
+    async def info(
+        self,
+        interaction: discord.Interaction,
+        track: str,
+    ) -> None:
+        resolved = _resolve_track(track)
+        if resolved is None:
+            await interaction.response.send_message(
+                f"❌ Unknown track `{track}`.",
+                ephemeral=True,
+            )
+            return
+
+        async with get_connection(self.bot.db_path) as db:  # type: ignore[attr-defined]
+            override = await get_track_override(db, resolved)
+
+        if override is not None:
+            mu, sigma = override
+            source = "⚙️ Server override"
+            # Fetch updated_at / updated_by from DB
+            async with get_connection(self.bot.db_path) as db:  # type: ignore[attr-defined]
+                cursor = await db.execute(
+                    "SELECT updated_at, updated_by FROM track_rpc_params WHERE track_name = ?",
+                    (resolved,),
+                )
+                meta = await cursor.fetchone()
+            footer = (
+                f"Set by **{meta['updated_by']}** at `{meta['updated_at']}`"
+                if meta else ""
+            )
+        else:
+            try:
+                mu, sigma = get_default_rpc_params(resolved)
+            except ValueError:
+                await interaction.response.send_message(
+                    f"⚠️ **{resolved}** has no packaged default and no server override. "
+                    "Use `/track config` to set parameters before Phase 1 can fire.",
+                    ephemeral=True,
+                )
+                return
+            source = "📦 Bot-packaged default"
+            footer = ""
+
+        lines = [
+            f"**{resolved}** — {source}",
+            f"μ (mean rain %): `{mu:.4f}` ({mu * 100:.1f}%)",
+            f"σ (dispersion):   `{sigma:.4f}` ({sigma * 100:.1f}%)",
+        ]
+        if footer:
+            lines.append(footer)
+
+        await interaction.response.send_message("\n".join(lines), ephemeral=True)
+
+
+# ---------------------------------------------------------------------------
+# Helpers
+# ---------------------------------------------------------------------------
+
+def _resolve_track(value: str) -> str | None:
+    """Resolve *value* to a canonical track name.
+
+    Accepts a two-digit ID (e.g. "07") or an exact canonical name (e.g. "Belgium").
+    Returns None for unknown inputs.
+    """
+    if value in TRACK_DEFAULTS:
+        return value
+    if value in TRACK_IDS:
+        return TRACK_IDS[value]
+    # Partial case-insensitive match on name
+    value_lower = value.lower()
+    for name in TRACK_DEFAULTS:
+        if name.lower() == value_lower:
+            return name
+    return None

--- a/src/db/migrations/005_track_rpc_params.sql
+++ b/src/db/migrations/005_track_rpc_params.sql
@@ -1,0 +1,12 @@
+-- Migration 005: track_rpc_params
+-- Adds a server-level override table for per-track Beta distribution parameters.
+-- When a row exists for a track, Phase 1 uses its mu/sigma instead of the
+-- bot-packaged defaults from models.track.TRACK_DEFAULTS.
+
+CREATE TABLE IF NOT EXISTS track_rpc_params (
+    track_name      TEXT    PRIMARY KEY,
+    mu_rain_pct     REAL    NOT NULL,
+    sigma_rain_pct  REAL    NOT NULL,
+    updated_at      TEXT    NOT NULL,
+    updated_by      TEXT    NOT NULL
+);

--- a/src/models/track.py
+++ b/src/models/track.py
@@ -1,4 +1,8 @@
-"""Track registry: 27 F1 circuits with their base rain-probability factor (Btrack).
+"""Track registry: 27 F1 circuits with Beta distribution parameters (μ, σ).
+
+Each circuit has a bot-packaged default mean rain probability (μ) and dispersion
+(σ). Server admins may store overrides in the ``track_rpc_params`` DB table; the
+effective parameters are resolved at Phase 1 draw time.
 
 Each circuit also has a short numeric ID in TRACK_IDS for use in Discord
 autocomplete (users can type an ID or partial name to filter choices).
@@ -40,42 +44,68 @@ TRACK_IDS: Final[dict[str, str]] = {
     "27": "United Kingdom",
 }
 
-TRACKS: Final[dict[str, float]] = {
-    "Bahrain": 0.05,
-    "Saudi Arabia": 0.05,
-    "Australia": 0.10,
-    "Japan": 0.25,
-    "China": 0.25,
-    "Miami": 0.15,
-    "Imola": 0.25,
-    "Monaco": 0.25,
-    "Canada": 0.30,
-    "Barcelona": 0.20,
-    "Madrid": 0.15,
-    "Austria": 0.25,
-    "United Kingdom": 0.30,
-    "Hungary": 0.25,
-    "Belgium": 0.30,
-    "Netherlands": 0.25,
-    "Monza": 0.15,
-    "Azerbaijan": 0.10,
-    "Singapore": 0.20,
-    "Texas": 0.10,
-    "Mexico": 0.05,
-    "Brazil": 0.30,
-    "Las Vegas": 0.05,
-    "Qatar": 0.05,
-    "Abu Dhabi": 0.05,
-    "Portugal": 0.10,
-    "Turkey": 0.10,
+# Immutable, bot-packaged default Beta distribution parameters for every known circuit.
+# Format: track_name -> (mu_rain_pct, sigma_rain_pct)  — both as fractional probabilities.
+# These are never stored in the database; they are the authoritative fallback values.
+# Server admins may override these per-track via /track config (stored in track_rpc_params).
+TRACK_DEFAULTS: Final[dict[str, tuple[float, float]]] = {
+    "Bahrain":        (0.05, 0.02),
+    "Saudi Arabia":   (0.05, 0.03),
+    "Australia":      (0.10, 0.05),
+    "Japan":          (0.25, 0.07),
+    "China":          (0.25, 0.05),
+    "Miami":          (0.15, 0.07),
+    "Imola":          (0.25, 0.05),
+    "Monaco":         (0.25, 0.05),
+    "Canada":         (0.30, 0.05),
+    "Barcelona":      (0.20, 0.05),
+    "Madrid":         (0.15, 0.05),
+    "Austria":        (0.25, 0.07),
+    "United Kingdom": (0.30, 0.05),
+    "Hungary":        (0.25, 0.05),
+    "Belgium":        (0.30, 0.08),
+    "Netherlands":    (0.25, 0.05),
+    "Monza":          (0.15, 0.03),
+    "Azerbaijan":     (0.10, 0.03),
+    "Singapore":      (0.20, 0.07),
+    "Texas":          (0.10, 0.03),
+    "Mexico":         (0.05, 0.03),
+    "Brazil":         (0.30, 0.08),
+    "Las Vegas":      (0.05, 0.02),
+    "Qatar":          (0.05, 0.02),
+    "Abu Dhabi":      (0.05, 0.03),
+    "Portugal":       (0.10, 0.03),
+    "Turkey":         (0.10, 0.05),
 }
 
 
-def get_btrack(name: str) -> float:
-    """Return Btrack for *name*; raise ValueError for unknown circuits."""
+def get_default_rpc_params(name: str) -> tuple[float, float]:
+    """Return the bot-packaged (mu, sigma) for *name*; raise ValueError for unknown circuits."""
     try:
-        return TRACKS[name]
+        return TRACK_DEFAULTS[name]
     except KeyError:
         raise ValueError(
-            f"Unknown track {name!r}. Valid options: {sorted(TRACKS)}"
+            f"Unknown track {name!r}. Valid options: {sorted(TRACK_DEFAULTS)}"
         ) from None
+
+
+def get_effective_rpc_params(
+    name: str,
+    override_mu: float | None,
+    override_sigma: float | None,
+) -> tuple[float, float]:
+    """Resolve effective (mu, sigma) for *name* at Phase 1 draw time.
+
+    Resolution order:
+      1. If *override_mu* and *override_sigma* are both non-None, use them.
+      2. Otherwise fall back to the bot-packaged default from TRACK_DEFAULTS.
+      3. Raise ValueError if the track has no packaged default AND no override.
+    """
+    if override_mu is not None and override_sigma is not None:
+        return (override_mu, override_sigma)
+    if name in TRACK_DEFAULTS:
+        return TRACK_DEFAULTS[name]
+    raise ValueError(
+        f"Track {name!r} has no packaged default and no server override. "
+        "A config-authority user must run /track config before Phase 1 can fire."
+    )

--- a/src/services/phase1_service.py
+++ b/src/services/phase1_service.py
@@ -1,6 +1,6 @@
 """Phase 1 service — Rain probability announcement (T−5 days).
 
-Draws rand1, rand2 in [1, 98], computes Rpc, persists PhaseResult,
+Draws Rpc from the per-track Beta distribution (mu, sigma), persists PhaseResult,
 posts to forecast and log channels.
 """
 
@@ -8,13 +8,12 @@ from __future__ import annotations
 
 import json
 import logging
-import random
 from datetime import datetime, timezone
 from typing import TYPE_CHECKING
 
 from db.database import get_connection
-from models.track import get_btrack
-from utils.math_utils import compute_rpc
+from models.track import get_effective_rpc_params
+from utils.math_utils import compute_rpc_beta
 from utils.message_builder import phase1_message, phase_log_message
 
 if TYPE_CHECKING:
@@ -51,23 +50,55 @@ async def run_phase1(round_id: int, bot: "Bot") -> None:
         log.error("Phase 1: round %s has no track_name", round_id)
         return
 
+    # --- Resolve effective (mu, sigma) — server override > packaged default ---
+    async with get_connection(bot.db_path) as db:
+        override_cursor = await db.execute(
+            "SELECT mu_rain_pct, sigma_rain_pct FROM track_rpc_params WHERE track_name = ?",
+            (track_name,),
+        )
+        override_row = await override_cursor.fetchone()
+
+    override_mu = override_row["mu_rain_pct"] if override_row else None
+    override_sigma = override_row["sigma_rain_pct"] if override_row else None
+
     try:
-        btrack = get_btrack(track_name)
+        mu, sigma = get_effective_rpc_params(track_name, override_mu, override_sigma)
     except ValueError as exc:
-        log.error("Phase 1: %s", exc)
+        # FR-015: no packaged default AND no server override — block Phase 1
+        err_msg = (
+            f"\u26a0\ufe0f Phase 1 BLOCKED for round {round_id} ({track_name}): {exc} "
+            "Please run `/track config` for this track before the T\u22125d window expires."
+        )
+        log.error(err_msg)
+        await bot.output_router.post_log(row["server_id"], err_msg)
         return
 
-    rand1 = random.randint(1, 98)
-    rand2 = random.randint(1, 98)
-    rpc = compute_rpc(btrack, rand1, rand2)
+    # --- Draw Rpc from Beta distribution ---
+    try:
+        raw_draw, rpc = compute_rpc_beta(mu, sigma)
+    except ValueError as exc:
+        err_msg = (
+            f"\u26a0\ufe0f Phase 1 BLOCKED for round {round_id} ({track_name}): "
+            f"Beta sampling failed — {exc}"
+        )
+        log.error(err_msg)
+        await bot.output_router.post_log(row["server_id"], err_msg)
+        return
+
+    nu = mu * (1.0 - mu) / sigma ** 2 - 1.0
+    alpha = mu * nu
+    beta_param = (1.0 - mu) * nu
 
     payload = {
         "phase": 1,
         "round_id": round_id,
         "track": track_name,
-        "btrack": btrack,
-        "rand1": rand1,
-        "rand2": rand2,
+        "distribution": "beta",
+        "mu": mu,
+        "sigma": sigma,
+        "alpha": alpha,
+        "beta_param": beta_param,
+        "raw_draw": raw_draw,
         "rpc": rpc,
     }
 

--- a/src/services/track_service.py
+++ b/src/services/track_service.py
@@ -1,0 +1,167 @@
+"""Track distribution parameter service.
+
+Manages server-level overrides for per-track Beta distribution parameters
+(mu_rain_pct, sigma_rain_pct) stored in the ``track_rpc_params`` table.
+
+Resolution order at Phase 1 draw time:
+  1. Server override row (if present in track_rpc_params)
+  2. Bot-packaged default from models.track.TRACK_DEFAULTS
+  3. ValueError (blocks Phase 1, prompts admin)
+"""
+
+from __future__ import annotations
+
+import json
+import logging
+from datetime import datetime, timezone
+from typing import TYPE_CHECKING
+
+if TYPE_CHECKING:
+    import aiosqlite
+
+log = logging.getLogger(__name__)
+
+
+async def get_track_override(
+    db: "aiosqlite.Connection",
+    track_name: str,
+) -> tuple[float, float] | None:
+    """Return the server override (mu, sigma) for *track_name*, or None if not set."""
+    cursor = await db.execute(
+        "SELECT mu_rain_pct, sigma_rain_pct FROM track_rpc_params WHERE track_name = ?",
+        (track_name,),
+    )
+    row = await cursor.fetchone()
+    if row is None:
+        return None
+    return (row["mu_rain_pct"], row["sigma_rain_pct"])
+
+
+async def set_track_override(
+    db: "aiosqlite.Connection",
+    server_id: int,
+    track_name: str,
+    mu: float,
+    sigma: float,
+    actor_id: int,
+    actor_name: str,
+) -> None:
+    """Persist a server-level override for *track_name*.
+
+    Validates mu and sigma, reads the current value for audit, UPSERTs the row,
+    and writes an audit entry.
+
+    Args:
+        db: Open aiosqlite connection (caller owns commit).
+        server_id: Discord guild ID.
+        track_name: Canonical circuit name.
+        mu: Mean rain probability; must satisfy 0.0 < mu < 1.0.
+        sigma: Dispersion; must be > 0.0.
+        actor_id: Discord user ID issuing the command.
+        actor_name: Discord user display name (for the audit record).
+
+    Raises:
+        ValueError: If mu or sigma fail validation. Nothing is persisted.
+    """
+    # --- Validate before any write ---
+    if mu <= 0.0 or mu >= 1.0:
+        raise ValueError(
+            f"μ must be in the open interval (0.0, 1.0); received {mu}."
+        )
+    if sigma <= 0.0:
+        raise ValueError(f"σ must be > 0.0; received {sigma}.")
+
+    now = datetime.now(timezone.utc).isoformat()
+
+    # --- Read old values for audit (may be None if no override yet) ---
+    old = await get_track_override(db, track_name)
+    old_value_json = json.dumps({"mu": old[0], "sigma": old[1]}) if old else "null"
+    new_value_json = json.dumps({"mu": mu, "sigma": sigma})
+
+    # --- UPSERT override row ---
+    await db.execute(
+        """
+        INSERT INTO track_rpc_params (track_name, mu_rain_pct, sigma_rain_pct, updated_at, updated_by)
+        VALUES (?, ?, ?, ?, ?)
+        ON CONFLICT(track_name) DO UPDATE SET
+            mu_rain_pct  = excluded.mu_rain_pct,
+            sigma_rain_pct = excluded.sigma_rain_pct,
+            updated_at   = excluded.updated_at,
+            updated_by   = excluded.updated_by
+        """,
+        (track_name, mu, sigma, now, actor_name),
+    )
+
+    # --- Audit entry ---
+    await db.execute(
+        """
+        INSERT INTO audit_entries
+            (server_id, actor_id, actor_name, division_id, change_type, old_value, new_value, timestamp)
+        VALUES (?, ?, ?, NULL, ?, ?, ?, ?)
+        """,
+        (
+            server_id,
+            actor_id,
+            actor_name,
+            "track.rpc_params",
+            old_value_json,
+            new_value_json,
+            now,
+        ),
+    )
+
+    log.info(
+        "track_service: override set for %r by %r (mu=%s, sigma=%s)",
+        track_name, actor_name, mu, sigma,
+    )
+
+
+async def reset_track_override(
+    db: "aiosqlite.Connection",
+    server_id: int,
+    track_name: str,
+    actor_id: int,
+    actor_name: str,
+) -> tuple[float, float] | None:
+    """Remove the server-level override for *track_name* (revert to packaged default).
+
+    Returns the old (mu, sigma) override values if one existed, else None.
+    Writes an audit entry regardless.
+    Args:
+        db: Open aiosqlite connection (caller owns commit).
+        server_id: Discord guild ID.
+        track_name: Canonical circuit name.
+        actor_id: Discord user ID issuing the command.
+        actor_name: Discord user display name.
+    """
+    now = datetime.now(timezone.utc).isoformat()
+
+    old = await get_track_override(db, track_name)
+    old_value_json = json.dumps({"mu": old[0], "sigma": old[1]}) if old else "null"
+
+    await db.execute(
+        "DELETE FROM track_rpc_params WHERE track_name = ?",
+        (track_name,),
+    )
+
+    await db.execute(
+        """
+        INSERT INTO audit_entries
+            (server_id, actor_id, actor_name, division_id, change_type, old_value, new_value, timestamp)
+        VALUES (?, ?, ?, NULL, ?, ?, 'reset_to_default', ?)
+        """,
+        (
+            server_id,
+            actor_id,
+            actor_name,
+            "track.rpc_params.reset",
+            old_value_json,
+            now,
+        ),
+    )
+
+    log.info(
+        "track_service: override reset for %r by %r (previous=%s)",
+        track_name, actor_name, old_value_json,
+    )
+    return old

--- a/src/utils/math_utils.py
+++ b/src/utils/math_utils.py
@@ -18,6 +18,8 @@ from __future__ import annotations
 
 import logging
 import math
+import random as _random
+import warnings
 
 log = logging.getLogger(__name__)
 
@@ -26,19 +28,61 @@ log = logging.getLogger(__name__)
 # Phase 1 – Rain Probability Coefficient
 # ---------------------------------------------------------------------------
 
-def compute_rpc(btrack: float, rand1: float, rand2: float) -> float:
-    """Compute Rpc = round((Btrack * R1 * R2) / 3025, 2), clamped to [0.0, 1.0].
+def compute_rpc_beta(mu: float, sigma: float) -> tuple[float, float]:
+    """Draw Rpc from a Beta distribution parameterised by *mu* and *sigma*.
 
-    rand1 and rand2 are expected in the range [1, 98] (integer dice).
-    Intermediate calculation is unclamped; clamping occurs at the end.
+    *mu* is the mean rain probability (0.0–1.0 exclusive).
+    *sigma* is the dispersion / standard deviation.
+
+    The Beta distribution parameters are derived internally:
+        nu      = mu * (1 - mu) / sigma**2 - 1
+        alpha   = mu * nu
+        beta_p  = (1 - mu) * nu
+
+    Returns:
+        (raw_draw, rpc) where *raw_draw* is the pre-clamp Beta variate and
+        *rpc* is clamped to [0.0, 1.0] and rounded to 2 decimal places.
+
+    Raises:
+        ValueError: if *sigma* is infeasible (sigma >= sqrt(mu*(1-mu))), producing
+                    non-positive alpha or beta_p, which would error in betavariate.
     """
+    feasibility_limit = math.sqrt(mu * (1.0 - mu))
+    if sigma <= 0.0 or sigma >= feasibility_limit:
+        raise ValueError(
+            f"Infeasible sigma={sigma!r} for mu={mu!r}. "
+            f"sigma must satisfy 0 < sigma < sqrt(mu*(1-mu)) = {feasibility_limit:.6f}."
+        )
+
+    nu = mu * (1.0 - mu) / sigma ** 2 - 1.0
+    alpha = mu * nu
+    beta_p = (1.0 - mu) * nu
+
+    raw_draw = _random.betavariate(alpha, beta_p)
+
+    if raw_draw < 0.0 or raw_draw > 1.0:
+        log.warning(
+            "compute_rpc_beta: raw_draw=%s outside [0.0, 1.0] (mu=%s, sigma=%s); clamping.",
+            raw_draw, mu, sigma,
+        )
+
+    rpc = round(max(0.0, min(1.0, raw_draw)), 2)
+    return (raw_draw, rpc)
+
+
+def compute_rpc(btrack: float, rand1: float, rand2: float) -> float:
+    """[DEPRECATED] Old Btrack formula — replaced by compute_rpc_beta.
+
+    Retained only so imports in tests surface as DeprecationWarning rather than
+    ImportError. Will be removed in a future cleanup pass.
+    """
+    warnings.warn(
+        "compute_rpc is deprecated; use compute_rpc_beta instead.",
+        DeprecationWarning,
+        stacklevel=2,
+    )
     raw = (btrack * rand1 * rand2) / 3025
     result = round(raw, 2)
-    if result < 0.0 or result > 1.0:
-        log.warning(
-            "compute_rpc: raw result %s outside [0.0, 1.0] (btrack=%s, r1=%s, r2=%s); clamping.",
-            result, btrack, rand1, rand2,
-        )
     return max(0.0, min(1.0, result))
 
 

--- a/tests/unit/test_math_utils.py
+++ b/tests/unit/test_math_utils.py
@@ -11,7 +11,7 @@ import os
 sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
 
 from utils.math_utils import (
-    compute_rpc,
+    compute_rpc_beta,
     compute_ir,
     compute_im,
     compute_is,
@@ -25,27 +25,72 @@ from utils.math_utils import (
 )
 
 
-class TestComputeRpc:
-    def test_basic_calculation(self) -> None:
-        # btrack=0.05, dice=1,1: (0.05 * 1 * 1) / 3025 ≈ 0.0000165 → rounds to 0.0
-        result = compute_rpc(0.05, 1, 1)
-        assert result == round((0.05 * 1 * 1) / 3025, 2)
+class TestComputeRpcBeta:
+    """Tests for compute_rpc_beta — Beta distribution sampling."""
 
-    def test_clamps_to_zero(self) -> None:
-        # Artificially: btrack extreme values that might push < 0
-        result = compute_rpc(0.0, 1, 1)
-        assert result == 0.0
+    def test_returns_tuple(self) -> None:
+        raw_draw, rpc = compute_rpc_beta(0.30, 0.05)
+        assert isinstance(raw_draw, float)
+        assert isinstance(rpc, float)
 
-    def test_clamps_to_one(self) -> None:
-        # Very large inputs should clamp to 1.0
-        result = compute_rpc(1.0, 98, 98)
-        assert result == 1.0
+    def test_rpc_within_bounds_mid_range(self) -> None:
+        # United Kingdom: mu=0.30, sigma=0.05 — run 50 draws
+        for _ in range(50):
+            raw_draw, rpc = compute_rpc_beta(0.30, 0.05)
+            assert 0.0 <= rpc <= 1.0, f"rpc={rpc} out of [0,1]"
 
-    def test_result_within_bounds_for_typical_values(self) -> None:
-        for btrack in [0.05, 0.10, 0.25, 0.30]:
-            for r in range(1, 99, 20):
-                rpc = compute_rpc(btrack, r, r)
-                assert 0.0 <= rpc <= 1.0, f"Out of bounds: btrack={btrack}, r={r}, rpc={rpc}"
+    def test_rpc_within_bounds_low_mu(self) -> None:
+        # Bahrain: mu=0.05, sigma=0.02
+        for _ in range(50):
+            raw_draw, rpc = compute_rpc_beta(0.05, 0.02)
+            assert 0.0 <= rpc <= 1.0, f"rpc={rpc} out of [0,1]"
+
+    def test_rpc_rounded_to_2dp(self) -> None:
+        for _ in range(20):
+            _, rpc = compute_rpc_beta(0.25, 0.05)
+            assert rpc == round(rpc, 2)
+
+    def test_raw_draw_recorded(self) -> None:
+        # raw_draw must be present and be a float (even if clamped rpc differs)
+        raw_draw, rpc = compute_rpc_beta(0.30, 0.05)
+        assert isinstance(raw_draw, float)
+
+    def test_clamp_applied_via_monkeypatch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Force betavariate to return 1.5 (out of range) — rpc must clamp to 1.0
+        import utils.math_utils as math_utils
+        monkeypatch.setattr(math_utils._random, "betavariate", lambda a, b: 1.5)
+        raw_draw, rpc = compute_rpc_beta(0.30, 0.05)
+        assert raw_draw == 1.5
+        assert rpc == 1.0
+
+    def test_clamp_lower_bound_via_monkeypatch(self, monkeypatch: pytest.MonkeyPatch) -> None:
+        # Force betavariate to return -0.1 — rpc must clamp to 0.0
+        import utils.math_utils as math_utils
+        monkeypatch.setattr(math_utils._random, "betavariate", lambda a, b: -0.1)
+        raw_draw, rpc = compute_rpc_beta(0.30, 0.05)
+        assert raw_draw == pytest.approx(-0.1)
+        assert rpc == 0.0
+
+    def test_infeasible_sigma_raises(self) -> None:
+        # sigma >= sqrt(mu*(1-mu)) must raise ValueError
+        import math
+        mu = 0.30
+        sigma = math.sqrt(mu * (1.0 - mu))  # exactly at boundary
+        with pytest.raises(ValueError, match="Infeasible"):
+            compute_rpc_beta(mu, sigma)
+
+    def test_sigma_zero_raises(self) -> None:
+        with pytest.raises(ValueError):
+            compute_rpc_beta(0.30, 0.0)
+
+    def test_all_27_default_tracks_produce_valid_rpc(self) -> None:
+        """Smoke test: all packaged defaults produce a valid draw."""
+        import sys, os
+        sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+        from models.track import TRACK_DEFAULTS
+        for track, (mu, sigma) in TRACK_DEFAULTS.items():
+            raw_draw, rpc = compute_rpc_beta(mu, sigma)
+            assert 0.0 <= rpc <= 1.0, f"{track}: rpc={rpc} out of [0,1]"
 
 
 class TestSlotDistribution:

--- a/tests/unit/test_track_service.py
+++ b/tests/unit/test_track_service.py
@@ -1,0 +1,201 @@
+"""Unit tests for track_service — per-track Beta parameter override CRUD."""
+
+from __future__ import annotations
+
+import json
+import sys
+import os
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+# ---------------------------------------------------------------------------
+# Fixtures — in-memory aiosqlite database
+# ---------------------------------------------------------------------------
+
+@pytest.fixture
+async def db():
+    """An in-memory aiosqlite DB with the track_rpc_params and audit_entries tables."""
+    import aiosqlite
+    async with aiosqlite.connect(":memory:") as connection:
+        connection.row_factory = aiosqlite.Row
+        await connection.execute(
+            """
+            CREATE TABLE track_rpc_params (
+                track_name      TEXT PRIMARY KEY,
+                mu_rain_pct     REAL NOT NULL,
+                sigma_rain_pct  REAL NOT NULL,
+                updated_at      TEXT NOT NULL,
+                updated_by      TEXT NOT NULL
+            )
+            """
+        )
+        await connection.execute(
+            """
+            CREATE TABLE audit_entries (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                server_id   INTEGER NOT NULL,
+                actor_id    INTEGER NOT NULL,
+                actor_name  TEXT    NOT NULL,
+                division_id INTEGER,
+                change_type TEXT    NOT NULL,
+                old_value   TEXT    NOT NULL,
+                new_value   TEXT    NOT NULL,
+                timestamp   TEXT    NOT NULL
+            )
+            """
+        )
+        await connection.commit()
+        yield connection
+
+
+# ---------------------------------------------------------------------------
+# get_track_override
+# ---------------------------------------------------------------------------
+
+class TestGetTrackOverride:
+    async def test_returns_none_when_no_row(self, db) -> None:
+        from services.track_service import get_track_override
+        result = await get_track_override(db, "Belgium")
+        assert result is None
+
+    async def test_returns_tuple_when_row_exists(self, db) -> None:
+        from services.track_service import get_track_override, set_track_override
+        await set_track_override(db, 999, "Belgium", 0.30, 0.08, 1, "admin")
+        await db.commit()
+        result = await get_track_override(db, "Belgium")
+        assert result == (0.30, 0.08)
+
+
+# ---------------------------------------------------------------------------
+# set_track_override — validation
+# ---------------------------------------------------------------------------
+
+class TestSetTrackOverrideValidation:
+    async def test_rejects_mu_zero(self, db) -> None:
+        from services.track_service import set_track_override
+        with pytest.raises(ValueError, match="μ"):
+            await set_track_override(db, 999, "Belgium", 0.0, 0.08, 1, "admin")
+
+    async def test_rejects_mu_one(self, db) -> None:
+        from services.track_service import set_track_override
+        with pytest.raises(ValueError, match="μ"):
+            await set_track_override(db, 999, "Belgium", 1.0, 0.08, 1, "admin")
+
+    async def test_rejects_mu_negative(self, db) -> None:
+        from services.track_service import set_track_override
+        with pytest.raises(ValueError, match="μ"):
+            await set_track_override(db, 999, "Belgium", -0.1, 0.08, 1, "admin")
+
+    async def test_rejects_mu_greater_than_one(self, db) -> None:
+        from services.track_service import set_track_override
+        with pytest.raises(ValueError, match="μ"):
+            await set_track_override(db, 999, "Belgium", 1.5, 0.08, 1, "admin")
+
+    async def test_rejects_sigma_zero(self, db) -> None:
+        from services.track_service import set_track_override
+        with pytest.raises(ValueError, match="σ"):
+            await set_track_override(db, 999, "Belgium", 0.30, 0.0, 1, "admin")
+
+    async def test_rejects_sigma_negative(self, db) -> None:
+        from services.track_service import set_track_override
+        with pytest.raises(ValueError, match="σ"):
+            await set_track_override(db, 999, "Belgium", 0.30, -0.05, 1, "admin")
+
+    async def test_no_write_on_validation_failure(self, db) -> None:
+        """Nothing is persisted if validation raises."""
+        from services.track_service import set_track_override, get_track_override
+        with pytest.raises(ValueError):
+            await set_track_override(db, 999, "Belgium", 0.0, 0.08, 1, "admin")
+        result = await get_track_override(db, "Belgium")
+        assert result is None
+
+
+# ---------------------------------------------------------------------------
+# set_track_override — persistence and audit
+# ---------------------------------------------------------------------------
+
+class TestSetTrackOverridePersistence:
+    async def test_persists_override_row(self, db) -> None:
+        from services.track_service import set_track_override, get_track_override
+        await set_track_override(db, 999, "Belgium", 0.30, 0.08, 42, "TestUser")
+        await db.commit()
+        result = await get_track_override(db, "Belgium")
+        assert result == (0.30, 0.08)
+
+    async def test_upsert_updates_existing_row(self, db) -> None:
+        from services.track_service import set_track_override, get_track_override
+        await set_track_override(db, 999, "Belgium", 0.30, 0.08, 42, "TestUser")
+        await set_track_override(db, 999, "Belgium", 0.35, 0.06, 42, "TestUser")
+        await db.commit()
+        result = await get_track_override(db, "Belgium")
+        assert result == (0.35, 0.06)
+
+    async def test_writes_audit_entry(self, db) -> None:
+        from services.track_service import set_track_override
+        await set_track_override(db, 999, "Belgium", 0.30, 0.08, 42, "TestUser")
+        await db.commit()
+        cursor = await db.execute("SELECT * FROM audit_entries")
+        rows = await cursor.fetchall()
+        assert len(rows) == 1
+        entry = rows[0]
+        assert entry["change_type"] == "track.rpc_params"
+        assert entry["actor_name"] == "TestUser"
+        assert entry["server_id"] == 999
+        new_val = json.loads(entry["new_value"])
+        assert new_val["mu"] == pytest.approx(0.30)
+        assert new_val["sigma"] == pytest.approx(0.08)
+
+    async def test_audit_records_old_value_on_update(self, db) -> None:
+        from services.track_service import set_track_override
+        await set_track_override(db, 999, "Belgium", 0.30, 0.08, 42, "TestUser")
+        await set_track_override(db, 999, "Belgium", 0.35, 0.06, 42, "TestUser")
+        await db.commit()
+        cursor = await db.execute("SELECT * FROM audit_entries ORDER BY id")
+        rows = await cursor.fetchall()
+        assert len(rows) == 2
+        old_val = json.loads(rows[1]["old_value"])
+        assert old_val["mu"] == pytest.approx(0.30)
+
+
+# ---------------------------------------------------------------------------
+# reset_track_override
+# ---------------------------------------------------------------------------
+
+class TestResetTrackOverride:
+    async def test_returns_none_when_no_override(self, db) -> None:
+        from services.track_service import reset_track_override
+        result = await reset_track_override(db, 999, "Belgium", 42, "Admin")
+        await db.commit()
+        assert result is None
+
+    async def test_removes_override_row(self, db) -> None:
+        from services.track_service import set_track_override, reset_track_override, get_track_override
+        await set_track_override(db, 999, "Belgium", 0.30, 0.08, 42, "Admin")
+        await reset_track_override(db, 999, "Belgium", 42, "Admin")
+        await db.commit()
+        assert await get_track_override(db, "Belgium") is None
+
+    async def test_returns_old_values_on_reset(self, db) -> None:
+        from services.track_service import set_track_override, reset_track_override
+        await set_track_override(db, 999, "Belgium", 0.30, 0.08, 42, "Admin")
+        old = await reset_track_override(db, 999, "Belgium", 42, "Admin")
+        await db.commit()
+        assert old == (pytest.approx(0.30), pytest.approx(0.08))
+
+    async def test_writes_audit_entry_on_reset(self, db) -> None:
+        from services.track_service import set_track_override, reset_track_override
+        await set_track_override(db, 999, "Belgium", 0.30, 0.08, 42, "Admin")
+        await db.commit()
+        await reset_track_override(db, 999, "Belgium", 42, "Admin")
+        await db.commit()
+        cursor = await db.execute(
+            "SELECT * FROM audit_entries WHERE change_type = 'track.rpc_params.reset'"
+        )
+        rows = await cursor.fetchall()
+        assert len(rows) == 1
+        entry = rows[0]
+        assert entry["new_value"] == "reset_to_default"
+        old_val = json.loads(entry["old_value"])
+        assert old_val["mu"] == pytest.approx(0.30)


### PR DESCRIPTION
- Replace Btrack formula with compute_rpc_beta (Beta distribution)
- Add TRACK_DEFAULTS (mu, sigma) for all 27 circuits; remove TRACKS/get_btrack
- Add track_rpc_params migration (005) for server-level overrides
- Add track_service: get/set/reset override + audit entries
- Add TrackCog: /track config, /track reset, /track info
- Register TrackCog in bot.py
- Update phase1_service to use Beta draw with expanded audit payload (FR-015 guard)
- Update season_cog/amendment_cog to TRACK_DEFAULTS import
- Update test_math_utils: TestComputeRpcBeta (10 tests)
- Add test_track_service: 14 tests covering CRUD + audit
- Add README: Track Distribution Parameters section (FR-014)
- All 162 tests pass

Closes tasks T001-T015 in specs/008-phase1-rpc-redesign/tasks.md