### PR TITLE
fix: results/standings spec corrections (C1, C2, I1, I2, module perms)

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,35 @@
 <!--
 SYNC IMPACT REPORT
 ==================
+[2026-03-19 — Session reuse: Results & Standings continuation — feature branch created]
+  - Constitution reused as-is; no principle amendments required.
+  - Session intent: begin a new session for results & standings specification and
+    incremental implementation verification. Feature branch `020-results-standings-session`
+    created from main.
+  - Existing implementation status at session start:
+      ✅ specs/018-results-standings/  — fully merged to main; all tasks [X] complete.
+         Covers: R&S module enable/disable lifecycle; weather-channel decoupling;
+         /division weather-channel, /division results-channel, /division standings-channel
+         commands; season-approval prerequisite gates (weather + R&S + points-config).
+      ✅ specs/019-results-submission-standings/  — fully merged to main; all tasks [X]
+         complete (T016 results_formatter.py confirmed present despite unchecked box).
+         Covers: points-config store CRUD; season config attachment + snapshot; submission
+         wizard with transient channel; results and standings posting; config view; penalty
+         wizard; full session amendment; mid-season amendment mode; reserves visibility
+         toggle; full unit + integration test suite (T028–T035).
+  - No placeholder tokens present; constitution is fully resolved at v2.4.1.
+  - No version bump required (no content amendments this session).
+  - All templates confirmed aligned with Principles I–XII:
+      ✅ .specify/templates/plan-template.md      — dynamic Constitution Check; no changes.
+      ✅ .specify/templates/spec-template.md      — generic structure; no stale references.
+      ✅ .specify/templates/tasks-template.md     — generic; aligns with I–XII.
+      ✅ .specify/templates/agent-file-template.md — generic placeholders; no stale names.
+      ✅ .specify/templates/checklist-template.md  — no impact.
+  - No stale agent-specific references detected.
+  - Deferred TODOs: none.
+  - Pending: user to provide new specification for this session; constitution will be
+    re-evaluated and amended once the scope of new work is defined.
+
 [2026-03-18 — v2.4.0 → v2.4.1: PATCH clarifications for Results & Standings module]
   Version change    : 2.4.0 → 2.4.1
   Bump rationale    : PATCH — Non-semantic clarifications to Principle XII covering three

--- a/src/cogs/module_cog.py
+++ b/src/cogs/module_cog.py
@@ -14,7 +14,7 @@ from discord.ext import commands
 
 from db.database import get_connection
 from models.driver_profile import DriverState
-from utils.channel_guard import admin_only, channel_guard
+from utils.channel_guard import admin_only, channel_guard, server_admin_only
 
 log = logging.getLogger(__name__)
 
@@ -145,7 +145,7 @@ class ModuleCog(commands.Cog):
     )
     @app_commands.choices(module_name=_MODULE_CHOICES)
     @channel_guard
-    @admin_only
+    @server_admin_only
     async def enable(
         self,
         interaction: discord.Interaction,
@@ -172,7 +172,7 @@ class ModuleCog(commands.Cog):
     @app_commands.describe(module_name="Module to disable")
     @app_commands.choices(module_name=_MODULE_CHOICES)
     @channel_guard
-    @admin_only
+    @server_admin_only
     async def disable(
         self,
         interaction: discord.Interaction,

--- a/src/cogs/results_cog.py
+++ b/src/cogs/results_cog.py
@@ -15,10 +15,10 @@ from services.points_config_service import (
     InvalidSessionTypeError,
 )
 from services.season_points_service import (
-    ConfigAlreadyAttachedError,
     ConfigNotAttachedError,
     SeasonNotInSetupError,
 )
+from utils.channel_guard import admin_only, channel_guard
 
 log = logging.getLogger(__name__)
 
@@ -52,15 +52,6 @@ class ResultsCog(commands.Cog):
             return False
         return True
 
-    async def _server_admin_gate(self, interaction: discord.Interaction) -> bool:
-        if not interaction.user.guild_permissions.administrator:
-            await interaction.response.send_message(
-                "\u274c This command requires server admin permissions.",
-                ephemeral=True,
-            )
-            return False
-        return True
-
     # ------------------------------------------------------------------
     # /results config group
     # ------------------------------------------------------------------
@@ -72,6 +63,8 @@ class ResultsCog(commands.Cog):
 
     @config_group.command(name="add", description="Add a named points configuration to this server.")
     @app_commands.describe(name="Unique config name, e.g. '100%'")
+    @channel_guard
+    @admin_only
     async def config_add(self, interaction: discord.Interaction, name: str) -> None:
         if not await self._module_gate(interaction):
             return
@@ -89,6 +82,8 @@ class ResultsCog(commands.Cog):
 
     @config_group.command(name="remove", description="Remove a named points configuration.")
     @app_commands.describe(name="Config name to remove")
+    @channel_guard
+    @admin_only
     async def config_remove(self, interaction: discord.Interaction, name: str) -> None:
         if not await self._module_gate(interaction):
             return
@@ -110,6 +105,8 @@ class ResultsCog(commands.Cog):
         points="Points awarded",
     )
     @app_commands.choices(session=_SESSION_CHOICES)
+    @channel_guard
+    @admin_only
     async def config_session(
         self,
         interaction: discord.Interaction,
@@ -145,6 +142,8 @@ class ResultsCog(commands.Cog):
         points="Bonus points for fastest lap",
     )
     @app_commands.choices(session=_RACE_SESSION_CHOICES)
+    @channel_guard
+    @admin_only
     async def config_fl(
         self,
         interaction: discord.Interaction,
@@ -179,6 +178,8 @@ class ResultsCog(commands.Cog):
         limit="Highest eligible position (e.g. 10 → positions 1–10 eligible)",
     )
     @app_commands.choices(session=_RACE_SESSION_CHOICES)
+    @channel_guard
+    @admin_only
     async def config_fl_plimit(
         self,
         interaction: discord.Interaction,
@@ -208,6 +209,8 @@ class ResultsCog(commands.Cog):
 
     @config_group.command(name="append", description="Attach a server config to the current season in SETUP.")
     @app_commands.describe(name="Config name to attach")
+    @channel_guard
+    @admin_only
     async def config_append(self, interaction: discord.Interaction, name: str) -> None:
         if not await self._module_gate(interaction):
             return
@@ -225,17 +228,14 @@ class ResultsCog(commands.Cog):
                 "\u274c Config attachment is only allowed for seasons in SETUP.", ephemeral=True
             )
             return
-        except ConfigAlreadyAttachedError:
-            await interaction.followup.send(
-                f"\u2139\ufe0f Config **{name}** is already attached to this season.", ephemeral=True
-            )
-            return
         await interaction.followup.send(
             f"\u2705 Config **{name}** attached to the current season.", ephemeral=True
         )
 
     @config_group.command(name="detach", description="Detach a config from the current season in SETUP.")
     @app_commands.describe(name="Config name to detach")
+    @channel_guard
+    @admin_only
     async def config_detach(self, interaction: discord.Interaction, name: str) -> None:
         if not await self._module_gate(interaction):
             return
@@ -272,6 +272,8 @@ class ResultsCog(commands.Cog):
         session="Optional: filter to a specific session type",
     )
     @app_commands.choices(session=_SESSION_CHOICES)
+    @channel_guard
+    @admin_only
     async def config_view(
         self,
         interaction: discord.Interaction,
@@ -365,10 +367,10 @@ class ResultsCog(commands.Cog):
     )
 
     @amend_group.command(name="toggle", description="Enable or disable amendment mode for the current season.")
+    @channel_guard
+    @admin_only
     async def amend_toggle(self, interaction: discord.Interaction) -> None:
         if not await self._module_gate(interaction):
-            return
-        if not await self._server_admin_gate(interaction):
             return
         await interaction.response.defer(ephemeral=True)
 
@@ -404,6 +406,8 @@ class ResultsCog(commands.Cog):
                 )
 
     @amend_group.command(name="revert", description="Revert all modification store changes to the season points.")
+    @channel_guard
+    @admin_only
     async def amend_revert(self, interaction: discord.Interaction) -> None:
         if not await self._module_gate(interaction):
             return
@@ -438,6 +442,8 @@ class ResultsCog(commands.Cog):
         points="Points to award",
     )
     @app_commands.choices(session=_SESSION_CHOICES)
+    @channel_guard
+    @admin_only
     async def amend_session(
         self,
         interaction: discord.Interaction,
@@ -476,6 +482,8 @@ class ResultsCog(commands.Cog):
         points="FL bonus points",
     )
     @app_commands.choices(session=_RACE_SESSION_CHOICES)
+    @channel_guard
+    @admin_only
     async def amend_fl(
         self,
         interaction: discord.Interaction,
@@ -511,6 +519,8 @@ class ResultsCog(commands.Cog):
         limit="Highest eligible position",
     )
     @app_commands.choices(session=_RACE_SESSION_CHOICES)
+    @channel_guard
+    @admin_only
     async def amend_fl_plimit(
         self,
         interaction: discord.Interaction,
@@ -540,10 +550,10 @@ class ResultsCog(commands.Cog):
         )
 
     @amend_group.command(name="review", description="Review modification store changes and approve or reject.")
+    @channel_guard
+    @admin_only
     async def amend_review(self, interaction: discord.Interaction) -> None:
         if not await self._module_gate(interaction):
-            return
-        if not await self._server_admin_gate(interaction):
             return
         await interaction.response.defer(ephemeral=True)
 
@@ -618,6 +628,8 @@ class ResultsCog(commands.Cog):
 
     @reserves_group.command(name="toggle", description="Toggle reserve driver visibility in division standings.")
     @app_commands.describe(division="Division name")
+    @channel_guard
+    @admin_only
     async def reserves_toggle(self, interaction: discord.Interaction, division: str) -> None:
         if not await self._module_gate(interaction):
             return

--- a/src/services/season_points_service.py
+++ b/src/services/season_points_service.py
@@ -36,14 +36,11 @@ async def attach_config(
             f"Config attachment is only allowed for seasons in SETUP (status: {season_status})"
         )
     async with get_connection(db_path) as db:
-        try:
-            await db.execute(
-                "INSERT INTO season_points_links (season_id, config_name) VALUES (?, ?)",
-                (season_id, config_name),
-            )
-            await db.commit()
-        except aiosqlite.IntegrityError:
-            raise ConfigAlreadyAttachedError(config_name)
+        await db.execute(
+            "INSERT OR REPLACE INTO season_points_links (season_id, config_name) VALUES (?, ?)",
+            (season_id, config_name),
+        )
+        await db.commit()
 
 
 async def detach_config(
@@ -131,7 +128,7 @@ async def validate_monotonic_ordering(db_path: str, season_id: int) -> list[str]
         for i in range(len(entries) - 1):
             curr = entries[i]
             nxt = entries[i + 1]
-            if curr["points"] < nxt["points"]:
+            if nxt["points"] > 0 and nxt["points"] >= curr["points"]:
                 errors.append(
                     f"Config '{config_name}', {session_type}: "
                     f"position {curr['position']} ({curr['points']} pts) < "

--- a/src/utils/channel_guard.py
+++ b/src/utils/channel_guard.py
@@ -107,3 +107,38 @@ def admin_only(func: Callable) -> Callable:
         await func(self, interaction, *args, **kwargs)
 
     return wrapper
+
+
+def server_admin_only(func: Callable) -> Callable:
+    """Additional decorator for commands that require the Discord ``Administrator`` permission.
+
+    Apply *after* channel_guard when both are needed::
+
+        @channel_guard
+        @server_admin_only
+        async def my_command(...)
+
+    Used for module enable/disable so only Discord server administrators
+    can arm or disarm optional capabilities server-wide.
+    """
+
+    @functools.wraps(func)
+    async def wrapper(self: Any, interaction: Interaction, *args: Any, **kwargs: Any) -> None:
+        member = interaction.user
+        if not isinstance(member, discord.Member):
+            await interaction.response.send_message(
+                "⛔ This command can only be used inside a server.",
+                ephemeral=True,
+            )
+            return
+
+        if not member.guild_permissions.administrator:
+            await interaction.response.send_message(
+                "⛔ You need the **Administrator** permission to use this command.",
+                ephemeral=True,
+            )
+            return
+
+        await func(self, interaction, *args, **kwargs)
+
+    return wrapper

--- a/tests/unit/test_mystery_notice.py
+++ b/tests/unit/test_mystery_notice.py
@@ -122,8 +122,8 @@ class TestCancelRoundIncludesMystery:
     def test_removes_four_job_ids_total(self):
         svc = _make_scheduler_no_db()
         svc.cancel_round(7)
-        # phase1, phase2, phase3, mystery, cleanup = 5 job IDs
-        assert svc._scheduler.remove_job.call_count == 5
+        # phase1, phase2, phase3, mystery, cleanup, results = 6 job IDs
+        assert svc._scheduler.remove_job.call_count == 6
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_season_points_service.py
+++ b/tests/unit/test_season_points_service.py
@@ -119,6 +119,39 @@ async def test_validate_monotonic_invalid(db_path):
     assert "BAD" in errors[0]
 
 
+@pytest.mark.asyncio
+async def test_validate_monotonic_equal_nonzero(db_path):
+    season_id = await _make_season(db_path)
+    # P1=25, P2=25 — equal non-zero counts as a violation
+    async with get_connection(db_path) as db:
+        for pos, pts in [(1, 25), (2, 25)]:
+            await db.execute(
+                "INSERT INTO season_points_entries (season_id, config_name, session_type, position, points) "
+                "VALUES (?, 'EQ', 'FEATURE_RACE', ?, ?)",
+                (season_id, pos, pts),
+            )
+        await db.commit()
+    errors = await validate_monotonic_ordering(db_path, season_id)
+    assert len(errors) >= 1
+    assert "EQ" in errors[0]
+
+
+@pytest.mark.asyncio
+async def test_validate_monotonic_trailing_zeros_ok(db_path):
+    season_id = await _make_season(db_path)
+    # P1=0, P2=0 — equal zeros are NOT a violation
+    async with get_connection(db_path) as db:
+        for pos, pts in [(1, 0), (2, 0)]:
+            await db.execute(
+                "INSERT INTO season_points_entries (season_id, config_name, session_type, position, points) "
+                "VALUES (?, 'ZEROS', 'FEATURE_RACE', ?, ?)",
+                (season_id, pos, pts),
+            )
+        await db.commit()
+    errors = await validate_monotonic_ordering(db_path, season_id)
+    assert errors == []
+
+
 # ---------------------------------------------------------------------------
 # get_season_points_view — trailing-zero collapse
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
C1: config_append now upserts (INSERT OR REPLACE) instead of raising on re-attach; always returns success response.

C2: monotonic ordering validation now catches equal non-zero adjacent positions (e.g. P1=25, P2=25 is a violation). Added two regression tests.

I1: Added @channel_guard + @admin_only to all 15 results_cog commands. Previously no access control was applied at the decorator level.

I2: amend_toggle and amend_review now use standard Tier-2 decorator access instead of a bespoke inline administrator check.

Module correction: /module enable and /module disable now require Discord Administrator permission (new @server_admin_only decorator) instead of Manage Server.

Fix stale cancel_round job-count assertion in test_mystery_notice.py (019 added results_r{id} job, making total 6 not 5).