### PR TITLE
026 penalty posting appeals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,7 +4,7 @@ results_module_specification.md
 signup_module_specification.md
 weather_module_specification.md
 stats_module_specification.md
-rsvp_module_specification.md
+attendance_module_specification.md
 steward_module_specification.md
 other_changes.md
 

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,47 @@
 <!--
 SYNC IMPACT REPORT
 ==================
+[2026-03-29 — v2.6.0 → v2.7.0: Penalty posting channel + appeals workflow formalized]
+  Version change    : 2.6.0 → 2.7.0
+  Bump rationale    : MINOR — "Penalty and protest adjudication" promoted from planned
+                      future scope to formally in-scope (Principle VI item 10). Principle
+                      XII extended with two new subsections:
+                        1. Penalty Announcements: penalties applied via the wizard MUST
+                           be posted to a configured per-division penalty announcement
+                           channel (module-introduced channel, fallback to results channel).
+                        2. Penalty Appeals: a second review tier allowing interaction-role
+                           members to appeal their own penalty; resolved by a tier-2 admin
+                           via Uphold / Overturn; outcome posted to the same channel.
+                      New data entities: PenaltyRecord, AppealRecord. DivisionResultsConfig
+                      amended to add penalty_channel_id.
+  Feature branch    : 026-penalty-posting-appeals (created 2026-03-29 from main)
+  Modified principles:
+    - Principle VI (Incremental Scope Expansion) — item 10 (penalty adjudication) added
+      to in-scope; corresponding entry removed from planned future scope.
+    - Principle XII (Race Results & Championship Integrity) — Amendment & Penalty section
+      extended: Penalty Announcements and Penalty Appeals subsections added.
+  Added sections    :
+    - Data & State Management: New Entities (v2.7.0) — PenaltyRecord, AppealRecord;
+      DivisionResultsConfig amendment note (penalty_channel_id).
+  Removed sections  : None
+  Templates confirmed aligned:
+    ✅ .specify/templates/plan-template.md       — dynamic Constitution Check; no changes.
+    ✅ .specify/templates/spec-template.md       — generic structure; no stale references.
+    ✅ .specify/templates/tasks-template.md      — generic; aligns with I–XII.
+    ✅ .specify/templates/agent-file-template.md — generic placeholders; no stale names.
+    ✅ .specify/templates/checklist-template.md  — no impact.
+  Deferred TODOs    :
+    - Exact command naming for appeal submission and review commands to be defined in
+      the feature specification.
+    - Whether appeals are driver-initiated only or also administratively triggered to be
+      confirmed in the feature specification.
+    - Whether a penalty announcement channel is required before the module may be enabled
+      (or only before a penalty can be posted) to be defined in the feature specification.
+  Follow-up TODOs   :
+    - The existing penalty wizard in DriverSessionResult uses loose text fields
+      (post_race_time_penalties, post_stewarding_total_time); these MUST be superseded
+      by PenaltyRecord rows in the feature increment. Migration required.
+
 [2026-03-27 — v2.5.0 → v2.6.0: Signup close timer, lineup announcements, module-config decoupling]
   Version change    : 2.5.0 → 2.6.0
   Bump rationale    : MINOR — Three governance additions:
@@ -775,11 +816,14 @@ domains are formally in-scope as of this version:
    (DNF, DNS, DSQ), and result amendments with full audit trail.
 9. **Championship standings computation and display**: points accumulation per driver per
    division, tiebreaking, and derivation of current and final standings.
+10. **Penalty adjudication and appeals**: application of post-race penalties (time
+    penalties, disqualifications) via a stewards workflow, posting of penalty decisions
+    to a dedicated channel, and a second-level appeals process allowing interaction-role
+    members to contest a penalty, resolved by a tier-2 admin.
 
 The following domains are **planned future scope** — each will be formally ratified as an
 independent feature increment before any implementation begins:
 
-- **Penalty and protest adjudication**.
 - **Season history and statistics**: aggregated career records and cross-season metrics
   derived from the Season Archive (see Data & State Management).
 - Financial or licensing workflows.
@@ -1140,6 +1184,39 @@ governs the **Results & Standings optional module** (Principle X).
   (default false) tracks uncommitted changes; it is set on any modification and cleared
   on approval or revert.
 
+#### Penalty Announcements
+
+- When a penalty (time penalty or DSQ) is applied via the penalty wizard, the bot MUST
+  post a penalty announcement notice to the division's configured **penalty announcement
+  channel** (`penalty_channel_id` on `DivisionResultsConfig`).
+- The announcement MUST include: the affected driver's display name, the round name, the
+  session type, the penalty type and magnitude (e.g., "+5 seconds" or "DSQ"), a reason if
+  provided by the tier-2 admin, and the Discord display name of the admin who applied it.
+- If no penalty announcement channel is configured for a division, announcements fall back
+  to that division's results channel.
+- The penalty announcement channel is a module-introduced channel category governed by
+  Principle VII. Configuring it is not required for module activation; if absent the
+  fallback ensures the notice is always posted.
+
+#### Penalty Appeals
+
+- Any driver holding the interaction role MAY submit an appeal against a penalty applied
+  to their own result record. Each penalty MAY have at most one active appeal at any time.
+- Appeals follow a two-outcome lifecycle: **Pending** (submitted, awaiting review) →
+  **Upheld** (penalty stands) or **Overturned** (penalty reversed).
+- A tier-2 admin MUST resolve every appeal by selecting Uphold or Overturn via a guided
+  interaction. The review decision MUST produce an audit log entry (Principle V).
+- On **Overturn**: the associated `PenaltyRecord` is voided; the affected
+  `DriverSessionResult` is reverted to its pre-penalty state; standings for the affected
+  round and all subsequent rounds in that division MUST be recomputed and reposted
+  atomically, consistent with the amendment recomputation rule above.
+- On **Uphold**: the penalty record and session result remain unchanged.
+- The appeal outcome — including the reviewer's display name and decision reason — MUST
+  be posted as a follow-up notice to the same channel where the original penalty
+  announcement was posted.
+- A driver MAY NOT submit a second appeal on a penalty that has already been upheld or
+  overturned (each penalty is a one-appeal-lifetime limit).
+
 #### Standings Computation
 
 - **Driver standings**: all drivers who have participated in a division, ranked by (1)
@@ -1493,6 +1570,41 @@ for team-level aggregates):
 - `position_finish_counts` (TEXT — JSON map)
 - `position_first_round` (TEXT — JSON map)
 
+### New Entities (v2.7.0)
+
+**PenaltyRecord** (per `DriverSessionResult` — one row per applied penalty):
+- `penalty_id` (INTEGER PK, server-scoped auto-increment)
+- `driver_session_result_id` (INTEGER, FK → DriverSessionResult)
+- `penalty_type` (ENUM: TIME_PENALTY / DSQ)
+- `time_seconds` (INTEGER, nullable — magnitude in seconds; null for DSQ)
+- `reason` (TEXT, nullable — free-text reason supplied by the tier-2 admin)
+- `applied_by` (TEXT — Discord User ID of the tier-2 admin who applied the penalty)
+- `applied_at` (TEXT — UTC ISO 8601 timestamp)
+- `voided` (BOOLEAN, default false — set to true when an AppealRecord with status
+  OVERTURNED is resolved against this penalty)
+- `announcement_channel_id` (TEXT, nullable — the channel ID where the penalty notice
+  was posted; retained to enable the appeal outcome follow-up post to the same channel)
+- Replaces the loose `post_race_time_penalties` and `post_stewarding_total_time` fields
+  on DriverSessionResult; those fields are retained for backwards compatibility during
+  migration but are superseded by PenaltyRecord rows.
+
+**AppealRecord** (per `PenaltyRecord` — at most one per penalty lifetime):
+- `appeal_id` (INTEGER PK, server-scoped auto-increment)
+- `penalty_id` (INTEGER, FK → PenaltyRecord)
+- `status` (ENUM: PENDING / UPHELD / OVERTURNED, default PENDING)
+- `submitted_by` (TEXT — Discord User ID of the driver submitting the appeal)
+- `submitted_at` (TEXT — UTC ISO 8601 timestamp)
+- `reviewed_by` (TEXT, nullable — Discord User ID of the reviewing tier-2 admin)
+- `reviewed_at` (TEXT, nullable — UTC ISO 8601 timestamp)
+- `review_reason` (TEXT, nullable — free-text outcome reason supplied by the reviewer)
+- Uniquely keyed on `penalty_id`; a second appeal row for the same penalty MUST be
+  rejected at the data layer.
+
+*Amendment to DivisionResultsConfig (v2.4.0 entity, updated v2.7.0)*:
+- `penalty_channel_id` (TEXT, nullable) added — when set, penalty announcements and
+  appeal outcomes for this division are posted to this channel; if null, the bot falls
+  back to `results_channel_id`.
+
 ### New Entities (v2.6.0)
 
 **SignupDivisionConfig** (per server, per division — owned by the signup module):
@@ -1535,4 +1647,4 @@ before merge. Any deliberate violation of a principle MUST be documented in the 
 Complexity Tracking table with a justification for why the simpler compliant path is
 insufficient.
 
-**Version**: 2.6.0 | **Ratified**: 2026-03-03 | **Last Amended**: 2026-03-27
+**Version**: 2.7.0 | **Ratified**: 2026-03-03 | **Last Amended**: 2026-03-29

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1200,22 +1200,24 @@ governs the **Results & Standings optional module** (Principle X).
 
 #### Penalty Appeals
 
-- Any driver holding the interaction role MAY submit an appeal against a penalty applied
-  to their own result record. Each penalty MAY have at most one active appeal at any time.
-- Appeals follow a two-outcome lifecycle: **Pending** (submitted, awaiting review) →
-  **Upheld** (penalty stands) or **Overturned** (penalty reversed).
-- A tier-2 admin MUST resolve every appeal by selecting Uphold or Overturn via a guided
-  interaction. The review decision MUST produce an audit log entry (Principle V).
-- On **Overturn**: the associated `PenaltyRecord` is voided; the affected
-  `DriverSessionResult` is reverted to its pre-penalty state; standings for the affected
-  round and all subsequent rounds in that division MUST be recomputed and reposted
-  atomically, consistent with the amendment recomputation rule above.
-- On **Uphold**: the penalty record and session result remain unchanged.
-- The appeal outcome — including the reviewer's display name and decision reason — MUST
-  be posted as a follow-up notice to the same channel where the original penalty
-  announcement was posted.
-- A driver MAY NOT submit a second appeal on a penalty that has already been upheld or
-  overturned (each penalty is a one-appeal-lifetime limit).
+- The appeals stage is fully admin-driven. After the penalty review is approved, a tier-2
+  admin runs an appeals review wizard (mirroring the penalty review wizard) in the same
+  transient submission channel. The admin stages corrections and approves them; no driver
+  submission step exists in this increment.
+- Appeals follow a two-outcome lifecycle: **Upheld** (correction applied to the result) or
+  **Overturned** (no change; reserved for future use). Every correction staged and approved
+  in this increment is stored as `UPHELD`. A `PENDING` state and driver-initiated appeal
+  submission are explicitly deferred to a future stewarding module.
+- The appeals review MUST produce an audit log entry per correction, including description
+  and justification (Principle V).
+- On approving corrections: the affected `DriverSessionResult` rows are updated; standings
+  for the affected round and all subsequent rounds in that division MUST be recomputed and
+  reposted atomically, consistent with the amendment recomputation rule above.
+- On approving with no staged corrections: the round advances to `FINAL` with results
+  identical to the `Post-Race Penalty Results` post. No result changes occur.
+- Each applied correction MUST produce one announcement post to the division's configured
+  verdicts channel (if accessible). Announcement skipped silently if channel is
+  inaccessible; finalization is never blocked by an announcement failure.
 
 #### Standings Computation
 

--- a/specs/026-penalty-posting-appeals/checklists/requirements.md
+++ b/specs/026-penalty-posting-appeals/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Penalty Posting, Appeals, and Result Lifecycle
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-03-30
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- All items pass. Spec revised 2026-03-30 after researching the existing spec 023 flow and `penalty_wizard.py` implementation. All three previously deferred decisions resolved:
+  1. Penalty stage close = the existing `ApprovalView.approve_btn`; behaviour changed to transition to appeals state instead of closing the channel.
+  2. Appeals stage appears automatically in the same transient submission channel after penalty approval; no separate command.
+  3. `AddPenaltyModal` class extended with two new required `TextInput` fields (description, justification); same modal reused for appeals wizard.
+- Spec is ready for `/speckit.plan`.

--- a/specs/026-penalty-posting-appeals/contracts/announcement-message-format.md
+++ b/specs/026-penalty-posting-appeals/contracts/announcement-message-format.md
@@ -1,0 +1,78 @@
+# Contract: Verdict Announcement Message Format
+
+**Feature**: 026-penalty-posting-appeals  
+**Service**: `verdict_announcement_service.py`  
+**Applies to**: Penalty announcements (posted after penalty review approval) and appeal announcements (posted after appeals review approval)
+
+---
+
+## Announcement Structure
+
+Each announcement is a single Discord message. One message is posted **per applied penalty or appeal correction**. If no penalties or corrections were staged, no announcement is posted.
+
+```
+**Season {N} {Division Name} Round {X} — {Session Name}**
+━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
+**Driver**: <@{driver_discord_id}>
+**Penalty**: {penalty_description}
+**Description**: {description_text}
+**Justification**: {justification_text}
+```
+
+---
+
+## Field Definitions
+
+| Field | Source | Example |
+|-------|--------|---------|
+| `N` | `seasons.season_number` | `3` |
+| `Division Name` | `divisions.name` | `Pro Division` |
+| `X` | `rounds.round_number` | `7` |
+| `Session Name` | `sessions.session_type` formatted | `Feature Race` |
+| `driver_discord_id` | `driver_profiles.discord_user_id` | `123456789012345678` |
+| `penalty_description` | Translated from penalty magnitude (see below) | `5 seconds removed` |
+| `description_text` | Verbatim from `AddPenaltyModal.description` field | `Track limits — Turn 8` |
+| `justification_text` | Verbatim from `AddPenaltyModal.justification` field | `Video evidence confirmed 3 instances` |
+
+---
+
+## Penalty Magnitude Translation
+
+| Raw penalty value | Translated text |
+|-------------------|-----------------|
+| `+Ns` (positive time, e.g. `+5s`) | `{N} seconds removed` |
+| `-Ns` (negative time, e.g. `-3s`) | `{N} seconds added` |
+| `DSQ` | `Disqualified` |
+
+Translation is performed by `verdict_announcement_service.translate_penalty(penalty_str: str) -> str`.
+
+---
+
+## Channel Resolution
+
+```
+if division_results_config.penalty_channel_id is not None:
+    target = bot.get_channel(int(penalty_channel_id))
+    if target is None:
+        # channel deleted or inaccessible — fall back
+        target = bot.get_channel(int(results_channel_id))
+else:
+    target = bot.get_channel(int(results_channel_id))
+
+if target is None:
+    log_error("announcement skipped — both channels inaccessible")
+    return   # does NOT block finalization
+```
+
+---
+
+## Session Name for Multi-Session Rounds
+
+When a round has multiple sessions (e.g. Sprint format: Qualifying + Sprint Race + Feature Race), one announcement per penalty is posted. The **Session Name** in the header is the session to which the penalty belongs — derived from the `driver_session_result_id`'s linked `session.session_type`.
+
+---
+
+## Error Handling
+
+- Channel send failure (permission denied, channel deleted): error is logged via `bot.output_router`; announcement skipped; **finalization is not blocked**.
+- Missing driver profile (Discord ID not found): announcement posts `*(unknown driver)*` in place of mention; does not block.

--- a/specs/026-penalty-posting-appeals/contracts/announcement-message-format.md
+++ b/specs/026-penalty-posting-appeals/contracts/announcement-message-format.md
@@ -51,16 +51,12 @@ Translation is performed by `verdict_announcement_service.translate_penalty(pena
 ## Channel Resolution
 
 ```
-if division_results_config.penalty_channel_id is not None:
-    target = bot.get_channel(int(penalty_channel_id))
-    if target is None:
-        # channel deleted or inaccessible — fall back
-        target = bot.get_channel(int(results_channel_id))
-else:
-    target = bot.get_channel(int(results_channel_id))
+if division_results_config.penalty_channel_id is None:
+    return   # no verdicts channel configured — skip silently
 
+target = bot.get_channel(int(penalty_channel_id))
 if target is None:
-    log_error("announcement skipped — both channels inaccessible")
+    log_error("announcement skipped — verdicts channel inaccessible")
     return   # does NOT block finalization
 ```
 

--- a/specs/026-penalty-posting-appeals/contracts/division-verdicts-channel-command.md
+++ b/specs/026-penalty-posting-appeals/contracts/division-verdicts-channel-command.md
@@ -1,0 +1,79 @@
+# Contract: /division verdicts-channel Command
+
+**Feature**: 026-penalty-posting-appeals  
+**Command**: `/division verdicts-channel`  
+**Cog**: `SeasonCog` (`src/cogs/season_cog.py`)  
+**Group**: `division` (existing `app_commands.Group`)
+
+---
+
+## Command Schema
+
+```
+/division verdicts-channel <division> <channel>
+```
+
+| Parameter | Type | Required | Description |
+|-----------|------|----------|-------------|
+| `division` | `str` | Yes | Division name; autocomplete from active divisions on this server |
+| `channel` | `discord.TextChannel` | Yes | Discord text channel to use for verdict announcements |
+
+---
+
+## Access Control
+
+- **Gate**: `@channel_guard` + `@admin_only` (tier-2 authority required — same as all other `division` subcommands)
+- **Module gate**: Checks Results & Standings module enabled for the server before proceeding
+- **Scope**: Guild-only; no DM support
+
+---
+
+## Behaviour
+
+| Condition | Response |
+|-----------|----------|
+| Division not found for this server | Ephemeral error: `❌ Division "{name}" not found.` |
+| Channel not accessible by the bot | Ephemeral error: `❌ Cannot access that channel. Ensure the bot has permission to post there.` |
+| Success (first set) | Ephemeral confirmation: `✅ Verdicts channel for {division} set to #{channel.name}.` |
+| Success (overwrite) | Ephemeral confirmation: `✅ Verdicts channel for {division} updated to #{channel.name}.` |
+
+---
+
+## Side Effects
+
+1. `division_results_configs.penalty_channel_id` set to `str(channel.id)` for the matching `(guild_id, division_id)` row.
+2. Audit log entry written: actor, division, change type `VERDICTS_CHANNEL_SET`, previous value (old channel ID or `None`), new value.
+
+---
+
+## Season Review Display
+
+When the Results module is enabled, `/season review` displays the verdicts channel for each division in the per-division block, between the standings channel line and the teams block:
+
+```
+  Verdicts channel: #channel-name   ← if configured
+  Verdicts channel: *(not configured)*  ← if missing
+```
+
+This is driven by `season_service.get_divisions_with_results_config()` including `penalty_channel_id` in its SELECT and LEFT JOIN result.
+
+---
+
+## Season Approval Gate
+
+When the Results module is enabled, `/season approve` Gate 2 includes a check for `penalty_channel_id`. If any division is missing it, the approval is blocked:
+
+```
+❌ Season cannot be approved — R&S prerequisites not met:
+• **{DivisionName}** is missing a verdicts channel — run /division verdicts-channel {DivisionName} <channel>
+```
+
+This check is added to the existing `errors` list alongside the results channel and standings channel checks.
+
+---
+
+## Validation
+
+- `channel` must be resolvable via `interaction.guild.get_channel(channel.id)` (not None)
+- Bot must have `send_messages` permission in `channel` — validated via `channel.permissions_for(guild.me).send_messages`
+- `division` must match an existing `divisions` row for `guild_id`

--- a/specs/026-penalty-posting-appeals/contracts/result-post-heading-format.md
+++ b/specs/026-penalty-posting-appeals/contracts/result-post-heading-format.md
@@ -1,0 +1,76 @@
+# Contract: Result Post Heading and Lifecycle Label Format
+
+**Feature**: 026-penalty-posting-appeals  
+**Service**: `results_post_service.py`  
+**Applies to**: All results posts and standings posts produced by the bot
+
+---
+
+## Format
+
+Every results post and every standings post MUST begin with:
+
+```
+**Season {N} {Division Name} Round {X} — {Session Name}**
+{Label}
+```
+
+Where:
+
+| Token | Source | Example |
+|-------|--------|---------|
+| `N` | `seasons.season_number` | `3` |
+| `Division Name` | `divisions.name` | `Pro Division` |
+| `X` | `rounds.round_number` | `7` |
+| `Session Name` | `sessions.session_type` formatted (see below) | `Feature Race` |
+| `Label` | Derived from `rounds.result_status` (see below) | `Provisional Results` |
+
+---
+
+## Lifecycle Labels
+
+| `result_status` | Label |
+|-----------------|-------|
+| `PROVISIONAL` | `Provisional Results` |
+| `POST_RACE_PENALTY` | `Post-Race Penalty Results` |
+| `FINAL` | `Final Results` |
+
+---
+
+## Session Type Formatting
+
+| Raw session_type value | Display name |
+|------------------------|-------------|
+| `QUALIFYING` | `Qualifying` |
+| `SPRINT_RACE` | `Sprint Race` |
+| `FEATURE_RACE` | `Feature Race` |
+| `SPRINT_QUALIFYING` | `Sprint Qualifying` |
+| `ENDURANCE_QUALIFYING` | `Feature Qualifying` |
+| `ENDURANCE_RACE` | `Feature Race` |
+| Any other | Title-cased raw value |
+
+---
+
+## Standings Post Heading
+
+Standings posts use the same heading format. The `{Session Name}` for a standings post is the session type of the most recently posted session for that round, or the round's primary session type if displaying an aggregate standings block.
+
+> **Implementation note**: if the standings post aggregates multiple sessions (e.g., championship standings after a Sprint weekend), the heading uses the round's last posted session type. The label reflects the round's current `result_status` at the time of posting.
+
+---
+
+## Amendment Results
+
+Results produced by `round results amend` MUST always use the label `Final Results` (the command is only permitted when `result_status = FINAL`; the amended post replaces the previous `Final Results` post with a new `Final Results` post).
+
+---
+
+## Invariant
+
+**Zero unlabelled posts permitted.** Every call path in `results_post_service.py` that produces a results or standings message MUST pass the heading and label. This includes:
+- Initial submission results post (label: `Provisional Results`)
+- Post-penalty-approval repost (label: `Post-Race Penalty Results`)
+- Post-appeals-approval repost (label: `Final Results`)
+- `round results amend` repost (label: `Final Results`)
+- `standings sync` forced repost (label: matches current `result_status`)
+- `rounds sync` forced repost (label: matches current `result_status`)

--- a/specs/026-penalty-posting-appeals/data-model.md
+++ b/specs/026-penalty-posting-appeals/data-model.md
@@ -70,7 +70,6 @@ All other rows default to `PROVISIONAL` via the column default.
 |--------|------|-------------|-------------|
 | `id` | INTEGER | PRIMARY KEY AUTOINCREMENT | |
 | `driver_session_result_id` | INTEGER | NOT NULL, FK → `driver_session_results(id)` | The result row this appeal correction modifies |
-| `penalty_record_id` | INTEGER | NULL, FK → `penalty_records(id)` | Associated penalty, if correction targets a specific one |
 | `status` | TEXT | NOT NULL DEFAULT 'UPHELD' | `UPHELD` (correction applied) or `OVERTURNED` (no change; reserved for future use) |
 | `penalty_type` | TEXT | NOT NULL | `TIME_PENALTY` or `DSQ` — the corrected value |
 | `time_seconds` | INTEGER | NULL | Corrected signed seconds; NULL for DSQ; same sign convention as PenaltyRecord |
@@ -95,7 +94,7 @@ All other rows default to `PROVISIONAL` via the column default.
 | `penalty_channel_id` | *(absent)* | `TEXT NULL` — Discord channel ID for verdict announcements |
 
 **Population**: Set via `/division verdicts-channel <division> <channel>`.  
-**Fallback**: If `NULL`, the bot uses `results_channel_id` for all verdict announcements.
+**Behaviour if inaccessible**: If the channel is deleted or the bot cannot post to it, the announcement is skipped (logged) without blocking finalization. No fallback channel is used.
 
 **Season review / approval impact**: `season_service.get_divisions_with_results_config()` must extend its SELECT and LEFT JOIN to include `drc.penalty_channel_id` so that `season_cog` can display it in `/season review` and enforce it as a blocker in `/season approve` Gate 2.
 
@@ -147,7 +146,6 @@ CREATE TABLE IF NOT EXISTS penalty_records (
 CREATE TABLE IF NOT EXISTS appeal_records (
     id                       INTEGER PRIMARY KEY AUTOINCREMENT,
     driver_session_result_id INTEGER NOT NULL REFERENCES driver_session_results(id),
-    penalty_record_id        INTEGER REFERENCES penalty_records(id),
     status                   TEXT    NOT NULL DEFAULT 'UPHELD',
     penalty_type             TEXT    NOT NULL,
     time_seconds             INTEGER,

--- a/specs/026-penalty-posting-appeals/data-model.md
+++ b/specs/026-penalty-posting-appeals/data-model.md
@@ -1,0 +1,174 @@
+# Data Model: Penalty Posting, Appeals, and Result Lifecycle
+
+**Feature**: 026-penalty-posting-appeals  
+**Date**: 2026-03-30  
+**Migration file**: `src/db/migrations/026_result_status_penalty_records.sql`
+
+---
+
+## Entity Changes
+
+### Round (amended)
+
+**Table**: `rounds`
+
+| Change | Before | After |
+|--------|--------|-------|
+| `finalized` | `INTEGER NOT NULL DEFAULT 0` | Retained (inert after migration) |
+| `result_status` | *(absent)* | `TEXT NOT NULL DEFAULT 'PROVISIONAL'` |
+
+**Valid values for `result_status`**: `PROVISIONAL`, `POST_RACE_PENALTY`, `FINAL`
+
+**State transitions**:
+
+```
+PROVISIONAL
+    │
+    ▼  (penalty review Approve clicked)
+POST_RACE_PENALTY
+    │
+    ▼  (appeals review Approve clicked  OR  round results amend applied)
+FINAL
+```
+
+**Migration data rule**: `UPDATE rounds SET result_status = 'FINAL' WHERE finalized = 1`  
+All other rows default to `PROVISIONAL` via the column default.
+
+**Model change** (`src/models/round.py`):  
+`finalized: bool = False` → `result_status: str = "PROVISIONAL"`
+
+---
+
+### PenaltyRecord (new)
+
+**Table**: `penalty_records`
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INTEGER | PRIMARY KEY AUTOINCREMENT | |
+| `driver_session_result_id` | INTEGER | NOT NULL, FK → `driver_session_results(id)` | The result row this penalty modifies |
+| `penalty_type` | TEXT | NOT NULL | `TIME_PENALTY` or `DSQ` |
+| `time_seconds` | INTEGER | NULL | Signed integer; positive = time removed, negative = time added; NULL for DSQ |
+| `description` | TEXT | NOT NULL | Admin-entered description of the ruling |
+| `justification` | TEXT | NOT NULL | Admin-entered justification |
+| `applied_by` | TEXT | NOT NULL | Discord user ID of approving admin |
+| `applied_at` | TEXT | NOT NULL | UTC ISO-8601 timestamp |
+| `announcement_channel_id` | TEXT | NULL | Channel where announcement was posted (NULL if skipped) |
+
+**Notes**:
+- `penalty_type = 'TIME_PENALTY'` and `time_seconds` encodes sign: `+5` seconds = 5 (removes 5s from driver time), `-3` seconds = -3 (adds 3s back).
+- `penalty_type = 'DSQ'` sets `time_seconds = NULL`.
+- Replaces the loose `post_race_time_penalties` / `post_stewarding_total_time` text fields on `driver_session_results` for all new records. Existing rows retain their legacy columns (no migration required on existing data).
+
+---
+
+### AppealRecord (new)
+
+**Table**: `appeal_records`
+
+| Column | Type | Constraints | Description |
+|--------|------|-------------|-------------|
+| `id` | INTEGER | PRIMARY KEY AUTOINCREMENT | |
+| `driver_session_result_id` | INTEGER | NOT NULL, FK → `driver_session_results(id)` | The result row this appeal correction modifies |
+| `penalty_record_id` | INTEGER | NULL, FK → `penalty_records(id)` | Associated penalty, if correction targets a specific one |
+| `status` | TEXT | NOT NULL DEFAULT 'UPHELD' | `UPHELD` (correction applied) or `OVERTURNED` (no change; reserved for future use) |
+| `penalty_type` | TEXT | NOT NULL | `TIME_PENALTY` or `DSQ` — the corrected value |
+| `time_seconds` | INTEGER | NULL | Corrected signed seconds; NULL for DSQ; same sign convention as PenaltyRecord |
+| `description` | TEXT | NOT NULL | Admin-entered description of the appeal ruling |
+| `justification` | TEXT | NOT NULL | Admin-entered justification |
+| `submitted_by` | TEXT | NOT NULL | Discord user ID of approving admin |
+| `submitted_at` | TEXT | NOT NULL | UTC ISO-8601 timestamp |
+| `announcement_channel_id` | TEXT | NULL | Channel where announcement was posted |
+
+**Notes**:
+- For spec 026, the appeals wizard is admin-driven (not driver-initiated). The `status` column defaults to `UPHELD` for every staged correction applied. `OVERTURNED` is reserved for a future driver-initiated appeals flow where a driver appeals and the admin upholds the original decision (no result change).
+- In this increment, only applied corrections are stored (one row per applied appeal correction). The admin stages corrections → approves → all are stored as `UPHELD`.
+
+---
+
+### DivisionResultsConfig (amended)
+
+**Table**: `division_results_configs`
+
+| Change | Before | After |
+|--------|--------|-------|
+| `penalty_channel_id` | *(absent)* | `TEXT NULL` — Discord channel ID for verdict announcements |
+
+**Population**: Set via `/division verdicts-channel <division> <channel>`.  
+**Fallback**: If `NULL`, the bot uses `results_channel_id` for all verdict announcements.
+
+**Season review / approval impact**: `season_service.get_divisions_with_results_config()` must extend its SELECT and LEFT JOIN to include `drc.penalty_channel_id` so that `season_cog` can display it in `/season review` and enforce it as a blocker in `/season approve` Gate 2.
+
+## StagedPenalty dataclass changes (in-memory only)
+
+`StagedPenalty` in `penalty_service.py` gains two new fields:
+
+```python
+@dataclass
+class StagedPenalty:
+    driver_id: int
+    penalty_str: str      # existing: raw modal input e.g. "+5s", "-3s", "DSQ"
+    description: str      # NEW: verbatim from modal
+    justification: str    # NEW: verbatim from modal
+```
+
+This is a transient in-memory object; no migration needed.
+
+---
+
+## Migration SQL
+
+**File**: `src/db/migrations/026_result_status_penalty_records.sql`
+
+```sql
+-- Add result_status to rounds
+ALTER TABLE rounds ADD COLUMN result_status TEXT NOT NULL DEFAULT 'PROVISIONAL';
+
+-- Populate result_status from existing finalized flag
+UPDATE rounds SET result_status = 'FINAL' WHERE finalized = 1;
+
+-- Add penalty_channel_id to division_results_configs
+ALTER TABLE division_results_configs ADD COLUMN penalty_channel_id TEXT;
+
+-- penalty_records: stores each applied penalty from the wizard
+CREATE TABLE IF NOT EXISTS penalty_records (
+    id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+    driver_session_result_id INTEGER NOT NULL REFERENCES driver_session_results(id),
+    penalty_type             TEXT    NOT NULL,
+    time_seconds             INTEGER,
+    description              TEXT    NOT NULL,
+    justification            TEXT    NOT NULL,
+    applied_by               TEXT    NOT NULL,
+    applied_at               TEXT    NOT NULL,
+    announcement_channel_id  TEXT
+);
+
+-- appeal_records: stores each applied appeal correction from the appeals wizard
+CREATE TABLE IF NOT EXISTS appeal_records (
+    id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+    driver_session_result_id INTEGER NOT NULL REFERENCES driver_session_results(id),
+    penalty_record_id        INTEGER REFERENCES penalty_records(id),
+    status                   TEXT    NOT NULL DEFAULT 'UPHELD',
+    penalty_type             TEXT    NOT NULL,
+    time_seconds             INTEGER,
+    description              TEXT    NOT NULL,
+    justification            TEXT    NOT NULL,
+    submitted_by             TEXT    NOT NULL,
+    submitted_at             TEXT    NOT NULL,
+    announcement_channel_id  TEXT
+);
+```
+
+---
+
+## Validation Rules
+
+| Field | Rule |
+|-------|------|
+| `result_status` | Must be one of exactly: `PROVISIONAL`, `POST_RACE_PENALTY`, `FINAL` (enforced in application layer, not DB constraint) |
+| `penalty_type` | Must be one of exactly: `TIME_PENALTY`, `DSQ` |
+| `time_seconds` for TIME_PENALTY | Non-zero signed integer (enforced by existing `validate_penalty_input`) |
+| `time_seconds` for DSQ | Must be NULL |
+| `description` | Non-empty string, max 200 characters (enforced by Discord modal's `max_length=200, required=True`) |
+| `justification` | Non-empty string, max 200 characters (enforced by Discord modal's `max_length=200, required=True`) |
+| `penalty_channel_id` | Valid Discord channel ID accessible by the bot (validated at command time via `bot.get_channel()`) |

--- a/specs/026-penalty-posting-appeals/plan.md
+++ b/specs/026-penalty-posting-appeals/plan.md
@@ -1,0 +1,101 @@
+# Implementation Plan: Penalty Posting, Appeals, and Result Lifecycle
+
+**Branch**: `026-penalty-posting-appeals` | **Date**: 2026-03-30 | **Spec**: [specs/026-penalty-posting-appeals/spec.md](spec.md)  
+**Input**: Feature specification from `specs/026-penalty-posting-appeals/spec.md`
+
+## Summary
+
+Extends the post-submission penalty review wizard (spec 023) with a three-state round result lifecycle (`PROVISIONAL` → `POST_RACE_PENALTY` → `FINAL`). When the tier-2 admin approves the penalty review, the transient submission channel now transitions to an **Appeals Review** state rather than closing — closing only once the appeals review is approved too. Every results and standings post gains a standard heading and lifecycle label. A new `verdict_announcement_service` posts one announcement per applied penalty or appeal correction to a per-division configured verdicts channel (fallback: results channel). The existing `AddPenaltyModal` is expanded with mandatory description and justification fields (same modal reused for appeals). `round results amend` is gated to rounds in `FINAL` state only.
+
+## Technical Context
+
+**Language/Version**: Python 3.13.2  
+**Primary Dependencies**: discord.py 2.7.1 (`app_commands`, `discord.ui.Modal`, `discord.ui.View`), aiosqlite ≥ 0.19, APScheduler ≥ 3.10  
+**Storage**: SQLite via aiosqlite; schema migrations in `src/db/migrations/` as numbered SQL files applied on bot startup  
+**Testing**: pytest (`python -m pytest tests/ -v` from repo root); unit tests in `tests/unit/`, integration in `tests/integration/`  
+**Target Platform**: Linux (Raspberry Pi); developed on Windows  
+**Project Type**: Discord bot service  
+**Performance Goals**: All interaction callbacks must call `interaction.response.defer()` before any DB or network I/O to stay within Discord's 3-second response window  
+**Constraints**: SQLite single-writer; all persistent `discord.ui.View` instances must use `timeout=None` and be re-registered on bot restart so the appeals prompt survives a restart  
+**Scale/Scope**: Single Discord server per bot instance; small-to-medium league servers
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-checked after Phase 1 design.*
+
+| Principle | Verdict | Notes |
+|-----------|---------|-------|
+| I. Trusted Configuration Authority | ✅ PASS | New wizard interactions reuse `_require_lm` (tier-2 gate). `/division verdicts-channel` uses `@admin_only`. No implicit super-user paths introduced. |
+| II. Multi-Division Isolation | ✅ PASS | `penalty_channel_id` stored per `DivisionResultsConfig`; all announcement state and wizard state is division-scoped; no cross-division reads. |
+| III. Resilient Schedule Management | ✅ PASS | No interaction with scheduling, postponements, or track changes. |
+| IV. Three-Phase Weather Pipeline | ✅ PASS | Entirely separate module; zero overlap with weather pipeline. |
+| V. Observability & Change Audit Trail | ✅ PASS | Audit log entries written for each penalty and appeal approval, including description and justification (FR-020). No silent mutations. |
+| VI. Incremental Scope Expansion | ✅ PASS | Penalty adjudication and appeals formally ratified as in-scope item 10 (constitution v2.7.0). |
+| VII. Output Channel Discipline | ✅ PASS | Verdicts channel is a module-introduced channel documented in spec (FR-011). Fallback to results channel specified. Bot does not post to unregistered channels. |
+| VIII. Driver Profile Integrity | ✅ PASS | Driver state machine unaffected; existing driver lookup in wizard reused without modification. |
+| IX. Team & Division Structural Integrity | ✅ PASS | No team-level changes; division structure unaffected. |
+| X. Modular Feature Architecture | ✅ PASS | Feature lives in the Results & Standings module; `/division verdicts-channel` checks module-enabled gate. |
+| XI. Signup Wizard Integrity | ✅ PASS | Completely unaffected. |
+| XII. Race Results & Championship Integrity | ✅ PASS | Lifecycle labels, FINAL gate on amend, and standings recomputation all align with constitution v2.7.0 Penalty Announcements + Penalty Appeals subsections. |
+
+**Gate result**: All 12 principles pass. No violations.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/026-penalty-posting-appeals/
+├── plan.md              # This file (/speckit.plan command output)
+├── research.md          # Phase 0 output (/speckit.plan command)
+├── data-model.md        # Phase 1 output (/speckit.plan command)
+├── quickstart.md        # Phase 1 output (/speckit.plan command)
+├── contracts/           # Phase 1 output (/speckit.plan command)
+│   ├── division-verdicts-channel-command.md
+│   ├── announcement-message-format.md
+│   └── result-post-heading-format.md
+└── tasks.md             # Phase 2 output (/speckit.tasks command — NOT created by /speckit.plan)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── db/
+│   └── migrations/
+│       └── 026_result_status_penalty_records.sql   # NEW — result_status column, penalty_records,
+│                                                   #        appeal_records tables, penalty_channel_id
+├── models/
+│   └── round.py                                    # MODIFY — result_status: str replaces finalized: bool
+├── services/
+│   ├── penalty_wizard.py                           # MODIFY — +2 modal fields; AppealsReviewView new class;
+│   │                                               #           penalty-approve splits from appeals-approve
+│   ├── result_submission_service.py                # MODIFY — finalize_round split into two paths:
+│   │                                               #           penalty-approval and appeals-approval
+│   ├── results_post_service.py                     # MODIFY — add heading + lifecycle label to all
+│   │                                               #           results and standings post functions
+│   ├── penalty_service.py                          # MODIFY — apply_penalties stores PenaltyRecord rows;
+│   │                                               #           StagedPenalty carries description + justification
+│   ├── season_service.py                           # MODIFY — get_divisions_with_results_config query
+│   │                                               #           extended to include penalty_channel_id
+│   └── verdict_announcement_service.py             # NEW — post one announcement per penalty/correction
+│                                                   #        to verdicts channel or results channel fallback
+└── cogs/
+    ├── results_cog.py                              # MODIFY — gate `round results amend` to FINAL state only
+    └── season_cog.py                               # MODIFY — /division verdicts-channel command;
+                                                    #           /season review shows verdicts channel;
+                                                    #           /season approve blocks if verdicts channel
+                                                    #           missing on any division (Gate 2 extension)
+
+tests/
+├── unit/
+│   ├── test_penalty_wizard.py                      # MODIFY — expanded modal fields, appeals view behaviour
+│   ├── test_results_post_service.py                # MODIFY — assert heading and label on all post types
+│   └── test_verdict_announcement_service.py        # NEW — announcement formatting, channel fallback,
+│                                                   #        empty-staged list produces no post
+└── integration/
+    └── test_round_lifecycle.py                     # NEW/MODIFY — full three-state lifecycle:
+                                                    #   PROVISIONAL → POST_RACE_PENALTY → FINAL
+```
+
+**Structure Decision**: Single project (existing layout). All changes land within the existing `src/` and `tests/` trees. One new service file (`verdict_announcement_service.py`); all other changes modify existing files. One new migration file (`026_result_status_penalty_records.sql`).

--- a/specs/026-penalty-posting-appeals/plan.md
+++ b/specs/026-penalty-posting-appeals/plan.md
@@ -5,7 +5,7 @@
 
 ## Summary
 
-Extends the post-submission penalty review wizard (spec 023) with a three-state round result lifecycle (`PROVISIONAL` → `POST_RACE_PENALTY` → `FINAL`). When the tier-2 admin approves the penalty review, the transient submission channel now transitions to an **Appeals Review** state rather than closing — closing only once the appeals review is approved too. Every results and standings post gains a standard heading and lifecycle label. A new `verdict_announcement_service` posts one announcement per applied penalty or appeal correction to a per-division configured verdicts channel (fallback: results channel). The existing `AddPenaltyModal` is expanded with mandatory description and justification fields (same modal reused for appeals). `round results amend` is gated to rounds in `FINAL` state only.
+Extends the post-submission penalty review wizard (spec 023) with a three-state round result lifecycle (`PROVISIONAL` → `POST_RACE_PENALTY` → `FINAL`). When the tier-2 admin approves the penalty review, the transient submission channel now transitions to an **Appeals Review** state rather than closing — closing only once the appeals review is approved too. Every results and standings post gains a standard heading and lifecycle label. A new `verdict_announcement_service` posts one announcement per applied penalty or appeal correction to the per-division configured verdicts channel. The existing `AddPenaltyModal` is expanded with mandatory description and justification fields (same modal reused for appeals). `round results amend` is gated to rounds in `FINAL` state only.
 
 ## Technical Context
 
@@ -31,7 +31,7 @@ Extends the post-submission penalty review wizard (spec 023) with a three-state 
 | IV. Three-Phase Weather Pipeline | ✅ PASS | Entirely separate module; zero overlap with weather pipeline. |
 | V. Observability & Change Audit Trail | ✅ PASS | Audit log entries written for each penalty and appeal approval, including description and justification (FR-020). No silent mutations. |
 | VI. Incremental Scope Expansion | ✅ PASS | Penalty adjudication and appeals formally ratified as in-scope item 10 (constitution v2.7.0). |
-| VII. Output Channel Discipline | ✅ PASS | Verdicts channel is a module-introduced channel documented in spec (FR-011). Fallback to results channel specified. Bot does not post to unregistered channels. |
+| VII. Output Channel Discipline | ✅ PASS | Verdicts channel is a module-introduced channel documented in spec (FR-011). Required for season approval (FR-026). Bot skips announcement if channel is inaccessible; does not post to unregistered channels. |
 | VIII. Driver Profile Integrity | ✅ PASS | Driver state machine unaffected; existing driver lookup in wizard reused without modification. |
 | IX. Team & Division Structural Integrity | ✅ PASS | No team-level changes; division structure unaffected. |
 | X. Modular Feature Architecture | ✅ PASS | Feature lives in the Results & Standings module; `/division verdicts-channel` checks module-enabled gate. |
@@ -79,20 +79,23 @@ src/
 │   ├── season_service.py                           # MODIFY — get_divisions_with_results_config query
 │   │                                               #           extended to include penalty_channel_id
 │   └── verdict_announcement_service.py             # NEW — post one announcement per penalty/correction
-│                                                   #        to verdicts channel or results channel fallback
+│                                                   #        to verdicts channel; skip if inaccessible
 └── cogs/
     ├── results_cog.py                              # MODIFY — gate `round results amend` to FINAL state only
     └── season_cog.py                               # MODIFY — /division verdicts-channel command;
                                                     #           /season review shows verdicts channel;
                                                     #           /season approve blocks if verdicts channel
                                                     #           missing on any division (Gate 2 extension)
+bot.py                                              # MODIFY — register AppealsReviewView for restart
+                                                    #           recovery: re-post appeals prompt for
+                                                    #           rounds in POST_RACE_PENALTY state
 
 tests/
 ├── unit/
 │   ├── test_penalty_wizard.py                      # MODIFY — expanded modal fields, appeals view behaviour
 │   ├── test_results_post_service.py                # MODIFY — assert heading and label on all post types
-│   └── test_verdict_announcement_service.py        # NEW — announcement formatting, channel fallback,
-│                                                   #        empty-staged list produces no post
+│   └── test_verdict_announcement_service.py        # NEW — announcement formatting, inaccessible channel
+│                                                   #        skips cleanly, empty-staged list produces no post
 └── integration/
     └── test_round_lifecycle.py                     # NEW/MODIFY — full three-state lifecycle:
                                                     #   PROVISIONAL → POST_RACE_PENALTY → FINAL

--- a/specs/026-penalty-posting-appeals/quickstart.md
+++ b/specs/026-penalty-posting-appeals/quickstart.md
@@ -1,0 +1,107 @@
+# Quickstart: Penalty Posting, Appeals, and Result Lifecycle
+
+**Feature**: 026-penalty-posting-appeals  
+**Branch**: `026-penalty-posting-appeals`
+
+---
+
+## Prerequisites
+
+- Python 3.13.2 installed
+- Bot token and Discord server configured
+- All dependencies installed: `pip install -r requirements.txt`
+- Bot has already been run once (or migrations applied) from the `main` branch
+
+---
+
+## Running the Migration
+
+The migration file `src/db/migrations/026_result_status_penalty_records.sql` is applied automatically on bot startup. To verify it runs cleanly without starting the full bot:
+
+```powershell
+# Windows (PowerShell) — run from repo root
+python -c "
+import asyncio, aiosqlite
+
+async def check():
+    async with aiosqlite.connect('your_bot.db') as db:
+        async with db.execute(\"PRAGMA table_info(rounds)\") as cur:
+            cols = [row[1] async for row in cur]
+        print('rounds columns:', cols)
+        async with db.execute(\"PRAGMA table_info(penalty_records)\") as cur:
+            cols = [row[1] async for row in cur]
+        print('penalty_records columns:', cols)
+        async with db.execute(\"PRAGMA table_info(appeal_records)\") as cur:
+            cols = [row[1] async for row in cur]
+        print('appeal_records columns:', cols)
+
+asyncio.run(check())
+"
+```
+
+Expected output includes `result_status` in rounds, and both new tables present.
+
+---
+
+## Running Tests
+
+```powershell
+# From repo root (Windows)
+python -m pytest tests/ -v
+
+# Run only tests related to this feature
+python -m pytest tests/unit/test_penalty_wizard.py tests/unit/test_results_post_service.py tests/unit/test_verdict_announcement_service.py tests/integration/test_round_lifecycle.py -v
+```
+
+---
+
+## Key Flow to Verify Manually
+
+1. **Submit a round** with at least one session → initial results post should read  
+   `Season N {DivisionName} Round X — {SessionName}` followed by `Provisional Results`
+
+2. **In the submission channel**, click `Add Penalty` → modal now has 4 fields: driver, penalty value, description, justification. Fill all four.
+
+3. **Click Approve** on `PenaltyReviewView` → `_show_approval_step()` posts `ApprovalView`
+
+4. **Click Approve** on `ApprovalView`:
+   - Results and standings reposted with label `Post-Race Penalty Results`
+   - Channel stays open; `AppealsReviewView` appears
+   - Penalty announcement posted to verdicts channel (or results channel if no verdicts channel configured)
+   - Round `result_status` = `POST_RACE_PENALTY`
+
+5. **In the appeals prompt**, optionally add a correction; then click Approve:
+   - Results and standings reposted with label `Final Results`
+   - Channel closes
+   - Round `result_status` = `FINAL`
+   - `round results amend` now available for this round
+
+6. **Verify amend gate**: attempt `round results amend` on a round still in `PROVISIONAL` or `POST_RACE_PENALTY` → bot should reject with a clear error.
+
+---
+
+## Configuring a Verdicts Channel
+
+```
+/division verdicts-channel <division_name> <#channel>
+```
+
+- Requires tier-2 admin role
+- Bot validates channel accessibility before storing
+- If not configured, announcements fall back to the division's results channel
+
+---
+
+## File Locations Quick Reference
+
+| File | Purpose |
+|------|---------|
+| `src/db/migrations/026_result_status_penalty_records.sql` | DB schema changes |
+| `src/models/round.py` | Round dataclass — `result_status` field |
+| `src/services/penalty_wizard.py` | Main wizard — modal, views, transitions |
+| `src/services/result_submission_service.py` | `finalize_penalty_review()`, `finalize_appeals_review()` |
+| `src/services/results_post_service.py` | Heading + label on all result/standings posts |
+| `src/services/penalty_service.py` | `StagedPenalty` dataclass + `apply_penalties()` |
+| `src/services/verdict_announcement_service.py` | Announcement posting logic |
+| `src/cogs/season_cog.py` | `/division verdicts-channel` command |
+| `src/cogs/results_cog.py` | `round results amend` FINAL state gate |

--- a/specs/026-penalty-posting-appeals/quickstart.md
+++ b/specs/026-penalty-posting-appeals/quickstart.md
@@ -88,7 +88,7 @@ python -m pytest tests/unit/test_penalty_wizard.py tests/unit/test_results_post_
 
 - Requires tier-2 admin role
 - Bot validates channel accessibility before storing
-- If not configured, announcements fall back to the division's results channel
+- If the channel is inaccessible, announcements are skipped without blocking finalization (no fallback)
 
 ---
 

--- a/specs/026-penalty-posting-appeals/research.md
+++ b/specs/026-penalty-posting-appeals/research.md
@@ -1,0 +1,110 @@
+# Research: Penalty Posting, Appeals, and Result Lifecycle
+
+**Feature**: 026-penalty-posting-appeals  
+**Date**: 2026-03-30  
+**Status**: Complete — no NEEDS CLARIFICATION items remain
+
+> All technical unknowns were resolved during the specification phase through direct
+> codebase research (spec 023, `penalty_wizard.py`, `result_submission_service.py`).
+> The user confirmed "keep the technologies" — no new dependencies introduced.
+
+---
+
+## Decision Log
+
+### D-001: How the penalty stage closes
+
+**Question**: Does closing the penalty stage require a new slash command, or does the existing wizard do it?
+
+**Decision**: The existing `ApprovalView.approve_btn` IS the penalty-stage close action. No new command needed.
+
+**Rationale**: The penalty wizard is entirely channel-based. All interactions happen via Discord UI components (buttons, modals) posted to the transient submission channel. The `ApprovalView` is posted by `_show_approval_step()` after the admin clicks "Approve" in `PenaltyReviewView`. Currently `ApprovalView.approve_btn` calls `finalize_round()`, which closes the channel. This feature repurposes that call: instead of closing, it transitions the round to `POST_RACE_PENALTY` and posts the `AppealsReviewView`.
+
+**Alternatives considered**: Separate `/round penalty-close` slash command. Rejected — inconsistent with the established wizard-channel pattern; would require admins to leave the wizard channel and issue a command.
+
+---
+
+### D-002: Where appeals starts
+
+**Question**: Does the appeals stage start in the same channel as the penalty review, or does it open a new channel?
+
+**Decision**: Appeals starts automatically in the same transient submission channel. No new channel is created.
+
+**Rationale**: The transient submission channel is already open and scoped to the round. Keeping appeals in the same channel requires no new channel lifecycle management and mirrors the penalty review flow exactly. The `_show_approval_step()` pattern (post a new View to the channel) already demonstrates how to chain review stages in a single channel.
+
+**Alternatives considered**: Separate dedicated appeals channel. Rejected — adds channel management complexity and creates a second transient channel that also needs lifetime management and recovery.
+
+---
+
+### D-003: How the AddPenaltyModal is extended
+
+**Question**: Is a new modal class created for appeals, or is the existing `AddPenaltyModal` extended?
+
+**Decision**: The existing `AddPenaltyModal` is extended with two new `TextInput` fields (`description`, `justification`). The same class is reused for both penalty review and appeals review.
+
+**Rationale**: The spec's assumption that description and justification are needed regardless of penalty vs. appeal is correct. Discord supports up to 5 fields per modal; `AddPenaltyModal` currently has 2 fields, so 2 more fit within limit. Reusing the class avoids duplicated validation logic.
+
+**Alternatives considered**: Separate `AddAppealModal` class. Rejected — identical fields and validation; would create a maintenance surface with no benefit.
+
+---
+
+### D-004: Where result_status is tracked
+
+**Question**: Is result lifecycle state tracked at the round level or per-session level?
+
+**Decision**: `result_status` is tracked at the **round level** (`rounds` table). All sessions within a round advance simultaneously via the wizard.
+
+**Rationale**: The penalty and appeals wizards operate across all sessions of a round at once. There is no per-session independent lifecycle. The existing `rounds.finalized` boolean confirms this — it was always a round-level field. The `result_status` ENUM replaces it with three states.
+
+**Alternatives considered**: Per-session status. Rejected — the wizard has no per-session approval granularity; advancing one session independently of others in the same round is not a supported operation.
+
+---
+
+### D-005: finalize_round split
+
+**Question**: How does `finalize_round()` need to change?
+
+**Decision**: `finalize_round()` in `result_submission_service.py` is split into two paths:
+1. **`finalize_penalty_review(interaction, state)`** — applies staged penalties, reposts as `Post-Race Penalty Results`, sets `result_status = POST_RACE_PENALTY`, posts penalty announcements, keeps channel open, posts `AppealsReviewView`.
+2. **`finalize_appeals_review(interaction, state)`** — applies staged appeal corrections, reposts as `Final Results`, sets `result_status = FINAL`, posts appeal announcements, closes channel.
+
+**Rationale**: The two approval events have different terminal behaviours (keep open vs. close channel) and produce different result labels. Separating them cleanly avoids a flag-based branching mess inside a single function.
+
+**Alternatives considered**: Single `finalize_round(stage=...)` with a parameter. Rejected — parameter-based branching on a domain concept is harder to read and test independently.
+
+---
+
+### D-006: Migration strategy for rounds.finalized
+
+**Question**: How does the `finalized` boolean column migrate to `result_status`?
+
+**Decision**: Add a new `result_status TEXT NOT NULL DEFAULT 'PROVISIONAL'` column to `rounds`. Populate it from existing `finalized` values: `UPDATE rounds SET result_status = 'FINAL' WHERE finalized = 1`. The `finalized` column is retained (not dropped) in this migration to allow rollback safety; it can be dropped in a future cleanup migration.
+
+**Rationale**: SQLite does not support `DROP COLUMN` before version 3.35.0 (2021). To maintain compatibility across deployment targets, the safer approach is to add the new column and leave the old one in place. The application code switches to reading/writing `result_status` exclusively; `finalized` becomes inert.
+
+**Alternatives considered**: `ALTER TABLE rounds DROP COLUMN finalized`. Rejected — SQLite version constraint on Raspberry Pi deployment could be older; adding and ignoring is safer.
+
+---
+
+### D-007: Where /division verdicts-channel lives
+
+**Question**: Which cog hosts the new `/division verdicts-channel` command?
+
+**Decision**: `season_cog.py` — the `division` `app_commands.Group` is already defined there. `season_service.py` also needs modification: `get_divisions_with_results_config()` must extend its SELECT to include `penalty_channel_id` so the review display and approval gate can read it.
+
+**Rationale**: Grep of all cogs confirmed the `division` group (`name="division"`, guild_only, default_permissions=None) lives in `SeasonCog`. All existing `/division` subcommands (`division add`, etc.) are in that file. Adding `verdicts-channel` to the same group is the natural location.
+
+**Alternatives considered**: `results_cog.py`. Rejected — that cog uses a `results_group` hierarchy (`/results config`, `/results round`, etc.); the `/division` namespace belongs to `season_cog.py`.
+
+---
+
+### D-008: Technology choices (confirmed — no changes)
+
+**Decision**: All existing technologies retained unchanged.
+
+- Python 3.13.2 / discord.py 2.7.1: sufficient for 4-field modals and chained Views.
+- aiosqlite / SQLite: sufficient; new tables are simple foreign-key joins.
+- APScheduler: no new scheduled jobs introduced by this feature.
+- pytest: existing test structure extended; no new test frameworks.
+
+**Rationale**: User explicitly instructed "keep the technologies, as this is a small feature increase." All requirements are satisfied by the existing stack.

--- a/specs/026-penalty-posting-appeals/spec.md
+++ b/specs/026-penalty-posting-appeals/spec.md
@@ -64,6 +64,8 @@ A tier-2 admin runs `/division verdicts-channel` with a division name and a Disc
 3. **Given** no verdicts channel is configured, **When** a penalty or appeal announcement would be posted, **Then** the message falls back to the division's results channel.
 4. **Given** a verdicts channel is configured, **When** a penalty or appeal announcement is posted, **Then** it goes to the verdicts channel, not the results channel.
 5. **Given** an invalid or non-existent channel is supplied, **When** the command is run, **Then** the bot rejects it with a clear error.
+6. **Given** the Results module is enabled and a verdicts channel is configured for a division, **When** a tier-2 admin runs `/season review`, **Then** the review output lists the verdicts channel for that division alongside the results and standings channels.
+7. **Given** the Results module is enabled and a division has no verdicts channel configured, **When** a tier-2 admin runs `/season approve`, **Then** the approval is rejected with an error identifying the division and instructing the admin to run `/division verdicts-channel`.
 
 ---
 
@@ -158,6 +160,8 @@ The existing `AddPenaltyModal` (currently: driver field + penalty value field) i
 - **FR-011**: A new `/division verdicts-channel <division> <channel>` command MUST be implemented for tier-2 admins. It sets `penalty_channel_id` on the division's `DivisionResultsConfig` record.
 - **FR-012**: The command MUST validate that the supplied channel exists and is accessible by the bot before storing it.
 - **FR-013**: If no `penalty_channel_id` is configured for a division, the bot MUST fall back to `results_channel_id` for all verdict announcements.
+- **FR-025**: When the Results module is enabled, `/season review` MUST display the configured verdicts channel (or `*(not configured)*`) for each division, in the same per-division block as the results and standings channels.
+- **FR-026**: When the Results module is enabled, `/season approve` MUST be rejected if any division does not have a `penalty_channel_id` configured. The error message MUST identify each unconfigured division and instruct the admin to run `/division verdicts-channel <division> <channel>`.
 
 **Penalty & Appeal Announcement Format**
 
@@ -221,3 +225,4 @@ The existing `AddPenaltyModal` (currently: driver field + penalty value field) i
 - **SC-004**: `round results amend` is rejected for every round not in `FINAL` state and accepted for every round in `FINAL` state — no false positives or false negatives in any test scenario.
 - **SC-005**: The division verdicts channel can be configured and updated by a tier-2 admin in a single command interaction.
 - **SC-006**: The full round lifecycle (initial submission → penalty review approved → appeals review approved) produces exactly three results and standings reposts per session, each with the correct label, using only the existing wizard channel without any additional commands.
+- **SC-007**: `/season approve` is blocked for any server where the Results module is enabled and at least one division has no verdicts channel configured — and it succeeds once all divisions have a verdicts channel configured.

--- a/specs/026-penalty-posting-appeals/spec.md
+++ b/specs/026-penalty-posting-appeals/spec.md
@@ -13,7 +13,7 @@ This specification extends the inline post-submission penalty review flow define
 2. When the tier-2 admin approves the penalty review (existing `Approve` button in `ApprovalView`), the transient submission channel no longer closes immediately. Instead it transitions to an **Appeals Review** state, and the round is marked `POST_RACE_PENALTY`. The channel closes only when the appeals review is approved, at which point the round becomes `FINAL`.
 3. Every results and standings post gains a standard heading (`Season {N} {Division Name} Round {X} — {Session Name}`) and a lifecycle label (`Provisional Results`, `Post-Race Penalty Results`, or `Final Results`).
 4. The existing `AddPenaltyModal` (which already has two fields: driver and penalty value) is expanded with two new mandatory fields: **description** and **justification**. This same modal is reused for the appeals wizard.
-5. When a penalty is staged and approved, an announcement is posted to the division's configured **verdicts channel** (fallback: results channel) using the populated description and justification fields.
+5. When a penalty is staged and approved, an announcement is posted to the division's configured **verdicts channel** using the populated description and justification fields. If the verdicts channel is inaccessible, the announcement is skipped without blocking finalization.
 6. `round results amend` (full re-entry amendment) is restricted to rounds in `FINAL` state.
 
 **Terminology mapping to spec 023**:
@@ -53,7 +53,7 @@ A tier-2 admin submits session results for a round. The posted results and stand
 
 A tier-2 admin runs `/division verdicts-channel` with a division name and a Discord channel. The bot stores that channel as the division's verdict announcement target. Subsequent penalty and appeal announcements for that division are posted there.
 
-**Why this priority**: Without the verdicts channel, announcements fall back to the results channel — which works but is not the intended configuration for production use.
+**Why this priority**: A verdicts channel is required for season approval (FR-026) and is the sole designated destination for all verdict announcements.
 
 **Independent Test**: Can be fully tested by running the command, then approving one staged penalty, and verifying the announcement appears in the specified channel and not in the results channel.
 
@@ -71,7 +71,7 @@ A tier-2 admin runs `/division verdicts-channel` with a division name and a Disc
 
 ### User Story 3 — Penalty Announcements (Priority: P3)
 
-When the penalty review **Approve** button is clicked and there are staged penalties, the bot posts a formatted announcement to the division's configured verdicts channel (or fallback) for each applied penalty. The announcement includes the session context header, the affected driver mentioned by Discord tag, the penalty in descriptive language, and the description and justification the admin entered in the modal.
+When the penalty review **Approve** button is clicked and there are staged penalties, the bot posts a formatted announcement to the division's configured verdicts channel for each applied penalty. The announcement includes the session context header, the affected driver mentioned by Discord tag, the penalty in descriptive language, and the description and justification the admin entered in the modal.
 
 **Why this priority**: Announcements make stewards' decisions publicly visible; this is the primary new output of the feature.
 
@@ -132,7 +132,7 @@ The existing `AddPenaltyModal` (currently: driver field + penalty value field) i
 - What if zero penalties were staged but the admin still clicks Approve in the penalty review? The round transitions to `POST_RACE_PENALTY`, a `Post-Race Penalty Results` post is made (identical to the `Provisional Results` post), and the appeals review prompt appears. This is valid.
 - What if zero appeal corrections are staged? The admin clicks Approve in the appeals review; the round transitions to `FINAL` with `Final Results` identical to `Post-Race Penalty Results`. Valid.
 - What if a driver receives two separate penalties in the same penalty review session? Each penalty entry in the staged list produces its own individual announcement when approved.
-- What if the verdicts channel is deleted or inaccessible at the time an announcement is attempted? The bot catches the channel error, logs it, and falls back to the results channel. If both are inaccessible, the error is logged and the announcement is skipped without blocking finalization.
+- What if the verdicts channel is deleted or inaccessible at the time an announcement is attempted? The bot catches the channel error, logs it, and skips the announcement without blocking finalization. No fallback channel is used.
 - What about existing finalized rounds (from before this feature)? Rounds with `finalized = 1` in the legacy schema are treated as `FINAL`; they already completed the only review stage that existed at the time. No re-review is required.
 - What is the `result_status` field scoped to — round or session? The lifecycle state is tracked at the **round** level (one state per round), since the penalty wizard and appeals wizard both operate across all sessions of a round simultaneously. The `result_status` from the constitution's `SessionResult` entity is effectively uniform for all sessions of the same round because they are all advanced together by the wizard approval.
 
@@ -159,13 +159,13 @@ The existing `AddPenaltyModal` (currently: driver field + penalty value field) i
 
 - **FR-011**: A new `/division verdicts-channel <division> <channel>` command MUST be implemented for tier-2 admins. It sets `penalty_channel_id` on the division's `DivisionResultsConfig` record.
 - **FR-012**: The command MUST validate that the supplied channel exists and is accessible by the bot before storing it.
-- **FR-013**: If no `penalty_channel_id` is configured for a division, the bot MUST fall back to `results_channel_id` for all verdict announcements.
+- **FR-013**: If the `penalty_channel_id` channel is inaccessible or the bot cannot post to it, the announcement MUST be skipped (logged, not raised as an error) and finalization MUST NOT be blocked. No fallback channel is used.
 - **FR-025**: When the Results module is enabled, `/season review` MUST display the configured verdicts channel (or `*(not configured)*`) for each division, in the same per-division block as the results and standings channels.
 - **FR-026**: When the Results module is enabled, `/season approve` MUST be rejected if any division does not have a `penalty_channel_id` configured. The error message MUST identify each unconfigured division and instruct the admin to run `/division verdicts-channel <division> <channel>`.
 
 **Penalty & Appeal Announcement Format**
 
-- **FR-014**: When the penalty review is approved with one or more staged penalties, the bot MUST post one announcement per penalty to the verdicts channel (or fallback). Each announcement MUST contain exactly:
+- **FR-014**: When the penalty review is approved with one or more staged penalties, the bot MUST post one announcement per penalty to the verdicts channel. Each announcement MUST contain exactly:
   1. Header: `Season {N} {Division Name} Round {X} — {Session Name}`
   2. Driver: Discord mention of the penalised driver
   3. Penalty: descriptive translation of the magnitude (FR-015)
@@ -194,7 +194,7 @@ The existing `AddPenaltyModal` (currently: driver field + penalty value field) i
 
 - **Round** (amended): `finalized` (BOOLEAN) replaced by `result_status` (ENUM: `PROVISIONAL` / `POST_RACE_PENALTY` / `FINAL`, default `PROVISIONAL`). Migration: `finalized = 1` → `FINAL`; `finalized = 0` → `PROVISIONAL`.
 - **PenaltyRecord** (new, linked to `DriverSessionResult`): stores `penalty_type`, `time_seconds` (nullable), `description` (TEXT NOT NULL), `justification` (TEXT NOT NULL), `applied_by`, `applied_at`, and `announcement_channel_id`. Replaces the loose `post_race_time_penalties` / `post_stewarding_total_time` fields on `DriverSessionResult` for new records.
-- **AppealRecord** (new, linked to `PenaltyRecord` or standalone): stores `status` (PENDING / UPHELD / OVERTURNED), `description` (TEXT NOT NULL), `justification` (TEXT NOT NULL), `submitted_by`, `submitted_at`, `reviewed_by`, `reviewed_at`, `review_reason`. One per penalty maximum.
+- **AppealRecord** (new): stores `status` (`UPHELD` / `OVERTURNED` — `PENDING` is reserved for the future driver-initiated appeals tier, not implemented in spec 026; all records in this increment are written as `UPHELD`), `description` (TEXT NOT NULL), `justification` (TEXT NOT NULL), `submitted_by`, `submitted_at`, `reviewed_by`, `reviewed_at`, `review_reason`. One per applied correction.
 - **DivisionResultsConfig** (amended): gains `penalty_channel_id` (TEXT, nullable), populated via `/division verdicts-channel`.
 
 ## Assumptions
@@ -205,13 +205,13 @@ The existing `AddPenaltyModal` (currently: driver field + penalty value field) i
 - Negative time corrections (time added back to benefit a driver) follow the same signed-integer mechanics already implemented in spec 023; the only change is that the value is now stored in a `PenaltyRecord` row rather than a loose column.
 - The appeals review wizard uses the exact same `AddPenaltyModal` class as the penalty wizard (after the two new fields are added). There is no separate modal class for appeals.
 - Verdict announcements are posted one per penalty/correction at the time of approval (not at the time of staging).
-- When the verdicts channel is deleted or inaccessible, the bot falls back to the results channel. If both are unavailable, the announcement is skipped without blocking finalization.
+- When the verdicts channel is deleted or inaccessible, the announcement is skipped (logged, not raised) without blocking finalization. No fallback channel is used.
 - `round results amend` restriction to `FINAL` state applies to the existing full re-entry amendment flow; it does not apply to the penalty/appeals wizard flows themselves (those are the mechanism that drives rounds toward `FINAL`).
 
 ## Dependencies
 
 - Spec 023 (Inline Post-Submission Penalty Review) — this feature modifies the `ApprovalView.approve_btn` behaviour and the `finalize_round` function in `result_submission_service.py`, and the `PenaltyReviewState` dataclass.
-- `DivisionResultsConfig` and `results_channel_id` — prerequisite for the announcement fallback.
+- `DivisionResultsConfig` — required for the `penalty_channel_id` lookup used by the announcement service.
 - `rounds.finalized` column — replaced by `rounds.result_status`; migration required.
 - Tier-2 admin permission guard (`_require_lm` in `penalty_wizard.py`) — reused unchanged for the appeals wizard.
 
@@ -220,7 +220,7 @@ The existing `AddPenaltyModal` (currently: driver field + penalty value field) i
 ### Measurable Outcomes
 
 - **SC-001**: Every results or standings post produced by the bot for a round carries a lifecycle label (`Provisional Results`, `Post-Race Penalty Results`, or `Final Results`) and the standard session heading — zero unlabeled posts permitted.
-- **SC-002**: Every approved penalty or appeal correction produces one announcement per entry in the verdicts channel (or fallback) with all five required fields present.
+- **SC-002**: Every approved penalty or appeal correction produces one announcement per entry in the verdicts channel with all five required fields present, provided the channel is accessible.
 - **SC-003**: The Discord modal's built-in required-field validation prevents submission of the penalty/appeal modal without both the description and justification fields — this is enforced at the Discord client level with no additional server-side step needed.
 - **SC-004**: `round results amend` is rejected for every round not in `FINAL` state and accepted for every round in `FINAL` state — no false positives or false negatives in any test scenario.
 - **SC-005**: The division verdicts channel can be configured and updated by a tier-2 admin in a single command interaction.

--- a/specs/026-penalty-posting-appeals/spec.md
+++ b/specs/026-penalty-posting-appeals/spec.md
@@ -1,0 +1,223 @@
+# Feature Specification: Penalty Posting, Appeals, and Result Lifecycle
+
+**Feature Branch**: `026-penalty-posting-appeals`  
+**Created**: 2026-03-30  
+**Status**: Draft  
+**Input**: User description: "Expand results and standings module with penalty announcement posting, a post-penalty appeals stage, mandatory description and justification fields on penalty/appeal forms, result lifecycle labeling (provisional / post-race penalty / final), and a division verdicts-channel command."
+
+## Context & Scope
+
+This specification extends the inline post-submission penalty review flow defined in spec 023. The key behavioural changes relative to the current implementation are:
+
+1. The round lifecycle gains a third result state — **Post-Race Penalty** — between the current "interim" (now called **Provisional**) and "final" (now called **Final**) states. A new intermediate **Appeals** stage sits between these two.
+2. When the tier-2 admin approves the penalty review (existing `Approve` button in `ApprovalView`), the transient submission channel no longer closes immediately. Instead it transitions to an **Appeals Review** state, and the round is marked `POST_RACE_PENALTY`. The channel closes only when the appeals review is approved, at which point the round becomes `FINAL`.
+3. Every results and standings post gains a standard heading (`Season {N} {Division Name} Round {X} — {Session Name}`) and a lifecycle label (`Provisional Results`, `Post-Race Penalty Results`, or `Final Results`).
+4. The existing `AddPenaltyModal` (which already has two fields: driver and penalty value) is expanded with two new mandatory fields: **description** and **justification**. This same modal is reused for the appeals wizard.
+5. When a penalty is staged and approved, an announcement is posted to the division's configured **verdicts channel** (fallback: results channel) using the populated description and justification fields.
+6. `round results amend` (full re-entry amendment) is restricted to rounds in `FINAL` state.
+
+**Terminology mapping to spec 023**:
+
+| Spec 023 term | Spec 026 term |
+|---|---|
+| Interim results/standings post | Provisional Results post |
+| Final results/standings post (after penalty approval) | Post-Race Penalty Results post |
+| *(no equivalent — new)* | Final Results post (after appeals approval) |
+| `rounds.finalized = 1` | Round `result_status = FINAL` |
+
+---
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Result Lifecycle Labeling and Heading Format (Priority: P1)
+
+A tier-2 admin submits session results for a round. The posted results and standings carry the label `Provisional Results` and the standard heading format. When the admin clicks **Approve** in the existing penalty review wizard, results are reposted as `Post-Race Penalty Results` and the submission channel transitions to the appeals review view rather than closing. When the admin clicks **Approve** in the appeals review view, results are reposted as `Final Results` and the channel closes.
+
+**Why this priority**: The labels and headings are visible to all league members on every post, and the lifecycle state gates other features (`round results amend`). All other stories depend on this three-stage sequence existing.
+
+**Independent Test**: Can be fully tested by submitting a round, approving a zero-penalty penalty review, and approving a zero-change appeals review. Verify three distinct results/standings reposts appear — each with the correct label and the standard heading — without configuring a verdicts channel.
+
+**Acceptance Scenarios**:
+
+1. **Given** session results are submitted for a round, **When** the initial results post is published, **Then** the heading reads `Season {N} {Division Name} Round {X} — {Session Name}` and the label reads `Provisional Results`.
+2. **Given** the penalty review **Approve** button is clicked (with or without staged penalties), **When** the results are reposted, **Then** the label reads `Post-Race Penalty Results` and the heading format is unchanged.
+3. **Given** the appeals review **Approve** button is clicked (with or without staged appeal corrections), **When** the results are reposted, **Then** the label reads `Final Results` and the heading format is unchanged.
+4. **Given** the penalty review is approved, **When** the submission channel would previously have closed, **Then** the channel remains open and an appeals review prompt appears instead.
+5. **Given** the appeals review is approved, **When** results are reposted as `Final Results`, **Then** the submission channel closes and the round is in `FINAL` state.
+6. **Given** a round is in `FINAL` state, **When** a full re-entry amendment is applied via `round results amend`, **Then** the resulting post carries the `Final Results` label.
+7. **Given** a round is in `PROVISIONAL` or `POST_RACE_PENALTY` state, **When** `round results amend` is attempted, **Then** the command is rejected with a clear error stating that amendments are only permitted on final results.
+
+---
+
+### User Story 2 — Division Verdicts Channel Configuration (Priority: P2)
+
+A tier-2 admin runs `/division verdicts-channel` with a division name and a Discord channel. The bot stores that channel as the division's verdict announcement target. Subsequent penalty and appeal announcements for that division are posted there.
+
+**Why this priority**: Without the verdicts channel, announcements fall back to the results channel — which works but is not the intended configuration for production use.
+
+**Independent Test**: Can be fully tested by running the command, then approving one staged penalty, and verifying the announcement appears in the specified channel and not in the results channel.
+
+**Acceptance Scenarios**:
+
+1. **Given** no verdicts channel is configured for a division, **When** `/division verdicts-channel <division> <channel>` is run by a tier-2 admin, **Then** the bot confirms the channel is set and stores it.
+2. **Given** a verdicts channel is already set, **When** the command is run with a different channel, **Then** the previous value is overwritten and the bot confirms the new channel.
+3. **Given** no verdicts channel is configured, **When** a penalty or appeal announcement would be posted, **Then** the message falls back to the division's results channel.
+4. **Given** a verdicts channel is configured, **When** a penalty or appeal announcement is posted, **Then** it goes to the verdicts channel, not the results channel.
+5. **Given** an invalid or non-existent channel is supplied, **When** the command is run, **Then** the bot rejects it with a clear error.
+
+---
+
+### User Story 3 — Penalty Announcements (Priority: P3)
+
+When the penalty review **Approve** button is clicked and there are staged penalties, the bot posts a formatted announcement to the division's configured verdicts channel (or fallback) for each applied penalty. The announcement includes the session context header, the affected driver mentioned by Discord tag, the penalty in descriptive language, and the description and justification the admin entered in the modal.
+
+**Why this priority**: Announcements make stewards' decisions publicly visible; this is the primary new output of the feature.
+
+**Independent Test**: Can be fully tested by staging a penalty with description and justification, clicking Approve, and verifying the announcement appears in the verdicts channel with all five required fields in the correct format.
+
+**Acceptance Scenarios**:
+
+1. **Given** a staged penalty of +5 seconds is approved, **When** the announcement is posted, **Then** it contains the header `Season {N} {Division Name} Round {X} — {Session Name}`, the driver's Discord mention, and the text `5 seconds removed`.
+2. **Given** a staged penalty of −3 seconds is approved, **When** the announcement is posted, **Then** the penalty field reads `3 seconds added`.
+3. **Given** a staged DSQ is approved, **When** the announcement is posted, **Then** the penalty field reads `Disqualified`.
+4. **Given** a penalty is approved with a description and justification, **When** the announcement is posted, **Then** both fields appear verbatim in the announcement.
+5. **Given** multiple penalties are staged for the same round, **When** all are approved together, **Then** each penalty produces its own separate announcement post in the verdicts channel.
+6. **Given** the penalty review is approved with no staged penalties, **When** the round transitions to `POST_RACE_PENALTY`, **Then** no announcement is posted to the verdicts channel (there is nothing to announce).
+
+---
+
+### User Story 4 — Appeals Review Stage (Priority: P4)
+
+After the penalty review is approved, the transient submission channel transitions to an **Appeals Review** state. An appeals review prompt appears automatically in the channel, mirroring the penalty review prompt. A tier-2 admin may stage appeal corrections (same driver, penalty value, description, justification fields as the penalty modal), review them, and approve. On approval the round becomes `FINAL`, `Final Results` are posted, and the channel closes.
+
+**Why this priority**: The appeals stage is the mechanism that produces the definitive `FINAL` state required before `round results amend` is available, and it unlocks a second round of verdict announcements.
+
+**Independent Test**: Can be fully tested by approving a penalty review (zero or more penalties), then approving the appeals review (with one staged correction), and verifying the channel closes, the round is in `FINAL` state, and the corrected `Final Results` post appears.
+
+**Acceptance Scenarios**:
+
+1. **Given** the penalty review **Approve** button is clicked, **When** the submission channel transitions, **Then** an appeals review prompt appears in the same channel with the same controls as the penalty review prompt (Add, No Changes / Confirm, Approve).
+2. **Given** the appeals review prompt is active, **When** a tier-2 admin stages an appeal correction using the same modal as the penalty wizard, **Then** the correction is staged and the list updates.
+3. **Given** the appeals review **Approve** button is clicked with staged corrections, **When** finalization runs, **Then** the corrections are applied to the driver results, standings are recomputed, and `Final Results` are posted.
+4. **Given** the appeals review **Approve** button is clicked with no staged corrections, **When** finalization runs, **Then** `Final Results` identical to the `Post-Race Penalty Results` are posted and the round is marked `FINAL`.
+5. **Given** finalization from the appeals review completes, **When** the channel is closed, **Then** the round is in `FINAL` state and `round results amend` is now available for that round.
+6. **Given** a round is still in `PROVISIONAL` state (penalty review not yet approved), **When** any attempt is made to interact with an appeals review, **Then** no appeals review prompt exists in the channel; the channel is still showing the penalty review prompt.
+
+---
+
+### User Story 5 — Mandatory Description and Justification Fields on the Penalty/Appeal Modal (Priority: P5)
+
+The existing `AddPenaltyModal` (currently: driver field + penalty value field) is expanded with two new mandatory `TextInput` fields: **description** (what the ruling is) and **justification** (the reasoning). Both fields are required; the modal cannot be submitted without them. This same expanded modal is used in both the penalty review wizard and the appeals review wizard.
+
+**Why this priority**: The description and justification fields are required for verdict announcements to be complete and for the audit trail to capture why each decision was made.
+
+**Independent Test**: Can be fully tested by attempting to submit the modal without each field in turn and verifying the Discord-level required-field validation blocks submission. Then completing the modal and verifying the stored record contains the correct values.
+
+**Acceptance Scenarios**:
+
+1. **Given** the penalty modal is open, **When** the admin leaves the description field empty and submits, **Then** the Discord modal's required-field validation blocks submission.
+2. **Given** the penalty modal is open, **When** the admin leaves the justification field empty and submits, **Then** the Discord modal's required-field validation blocks submission.
+3. **Given** all four fields are filled in (driver, penalty value, description, justification) and the modal is submitted, **When** the penalty is staged, **Then** the staged entry carries the description and justification verbatim.
+4. **Given** the appeals review modal is open (same modal, same four fields), **When** the admin fills in all fields and submits, **Then** the staged appeal correction carries the description and justification verbatim.
+5. **Given** a penalty or appeal correction is approved, **When** the audit log entry is written, **Then** it includes the description and justification for each applied entry.
+
+---
+
+### Edge Cases
+
+- What happens when a round has only cancelled sessions? No penalty or appeals stage is entered; the round skips directly to `FINAL` with `Final Results` posts (matched to the existing CANCELLED session handling in spec 023).
+- What if the bot restarts while the submission channel is in the appeals review state? The channel persists; on bot restart the appeals review prompt is re-posted (same recovery guarantee as spec 023 penalty restart recovery). Staged-but-unapproved appeal corrections are transient and not preserved, matching the same policy as staged penalties.
+- What if zero penalties were staged but the admin still clicks Approve in the penalty review? The round transitions to `POST_RACE_PENALTY`, a `Post-Race Penalty Results` post is made (identical to the `Provisional Results` post), and the appeals review prompt appears. This is valid.
+- What if zero appeal corrections are staged? The admin clicks Approve in the appeals review; the round transitions to `FINAL` with `Final Results` identical to `Post-Race Penalty Results`. Valid.
+- What if a driver receives two separate penalties in the same penalty review session? Each penalty entry in the staged list produces its own individual announcement when approved.
+- What if the verdicts channel is deleted or inaccessible at the time an announcement is attempted? The bot catches the channel error, logs it, and falls back to the results channel. If both are inaccessible, the error is logged and the announcement is skipped without blocking finalization.
+- What about existing finalized rounds (from before this feature)? Rounds with `finalized = 1` in the legacy schema are treated as `FINAL`; they already completed the only review stage that existed at the time. No re-review is required.
+- What is the `result_status` field scoped to — round or session? The lifecycle state is tracked at the **round** level (one state per round), since the penalty wizard and appeals wizard both operate across all sessions of a round simultaneously. The `result_status` from the constitution's `SessionResult` entity is effectively uniform for all sessions of the same round because they are all advanced together by the wizard approval.
+
+---
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**Result Lifecycle & Labeling**
+
+- **FR-001**: Each round MUST carry a `result_status` of `PROVISIONAL`, `POST_RACE_PENALTY`, or `FINAL`. New rounds MUST be created with status `PROVISIONAL` (replacing the existing `finalized` boolean, where `finalized = 1` maps to `FINAL`).
+- **FR-002**: Every results post MUST include a heading in the format `Season {N} {Division Name} Round {X} — {Session Name}` followed immediately by the result-type label.
+- **FR-003**: Every standings post MUST include the same heading and label format, using the label corresponding to the round's current `result_status`.
+- **FR-004**: Result-type labels MUST read exactly: `Provisional Results`, `Post-Race Penalty Results`, and `Final Results` for the three states respectively.
+- **FR-005**: When the penalty review `Approve` button is clicked, the round `result_status` MUST be set to `POST_RACE_PENALTY` and results and standings MUST be reposted with the `Post-Race Penalty Results` label. The submission channel MUST remain open.
+- **FR-006**: When the appeals review `Approve` button is clicked, the round `result_status` MUST be set to `FINAL` and results and standings MUST be reposted with the `Final Results` label. The submission channel MUST then close.
+- **FR-007**: `round results amend` MUST be rejected with a clear error if the target round's `result_status` is not `FINAL`.
+- **FR-008**: Results produced by `round results amend` MUST always carry the `Final Results` label.
+- **FR-009**: Approving the penalty review with an empty staged list (zero penalties) MUST still advance the round to `POST_RACE_PENALTY` and open the appeals stage.
+- **FR-010**: Approving the appeals review with an empty staged list (zero corrections) MUST still advance the round to `FINAL`.
+
+**Division Verdicts Channel**
+
+- **FR-011**: A new `/division verdicts-channel <division> <channel>` command MUST be implemented for tier-2 admins. It sets `penalty_channel_id` on the division's `DivisionResultsConfig` record.
+- **FR-012**: The command MUST validate that the supplied channel exists and is accessible by the bot before storing it.
+- **FR-013**: If no `penalty_channel_id` is configured for a division, the bot MUST fall back to `results_channel_id` for all verdict announcements.
+
+**Penalty & Appeal Announcement Format**
+
+- **FR-014**: When the penalty review is approved with one or more staged penalties, the bot MUST post one announcement per penalty to the verdicts channel (or fallback). Each announcement MUST contain exactly:
+  1. Header: `Season {N} {Division Name} Round {X} — {Session Name}`
+  2. Driver: Discord mention of the penalised driver
+  3. Penalty: descriptive translation of the magnitude (FR-015)
+  4. Description: verbatim from the modal
+  5. Justification: verbatim from the modal
+- **FR-015**: Penalty magnitude MUST be translated: positive time (`+Ns`) → `{N} seconds removed`; negative time (`−Ns`) → `{N} seconds added`; DSQ → `Disqualified`.
+- **FR-016**: When the appeals review is approved with one or more staged corrections, the bot MUST post one announcement per correction in the same format as FR-014, using the correction's stored description and justification.
+- **FR-017**: Approving with an empty staged list (either penalty or appeals review) MUST produce no announcement posts.
+
+**Modal Fields**
+
+- **FR-018**: The existing `AddPenaltyModal` MUST be extended with two new `TextInput` fields, both marked as **required** at the Discord modal level:
+  - `description` — free text, label "Penalty description", max 200 characters.
+  - `justification` — free text, label "Justification", max 200 characters.
+- **FR-019**: The same expanded modal MUST be used in both the penalty review wizard and the appeals review wizard.
+- **FR-020**: Description and justification values MUST be included in the staged entry, stored in the `PenaltyRecord` / `AppealRecord`, and included in the audit log entry.
+
+**Appeals Review Stage**
+
+- **FR-021**: When the penalty review `Approve` button is clicked, the submission channel MUST transition to the appeals review state. An appeals review prompt MUST be posted automatically in the same channel. The prompt MUST mirror the penalty review prompt: it lists all drivers across non-cancelled sessions, shows a staged corrections list (initially empty), and provides Add, No Changes / Confirm, and Approve controls.
+- **FR-022**: The Make Changes / staged-list recovery mechanism from the penalty review MUST equally apply to the appeals review.
+- **FR-023**: On approving the appeals review, standings for the affected round and all subsequent rounds in the division MUST be recomputed and reposted atomically.
+- **FR-024**: After bot restart while the channel is in appeals review state, the appeals review prompt MUST be re-posted (matching the recovery guarantee in spec 023 FR-014). Staged-but-unapproved corrections need not be preserved.
+
+### Key Entities
+
+- **Round** (amended): `finalized` (BOOLEAN) replaced by `result_status` (ENUM: `PROVISIONAL` / `POST_RACE_PENALTY` / `FINAL`, default `PROVISIONAL`). Migration: `finalized = 1` → `FINAL`; `finalized = 0` → `PROVISIONAL`.
+- **PenaltyRecord** (new, linked to `DriverSessionResult`): stores `penalty_type`, `time_seconds` (nullable), `description` (TEXT NOT NULL), `justification` (TEXT NOT NULL), `applied_by`, `applied_at`, and `announcement_channel_id`. Replaces the loose `post_race_time_penalties` / `post_stewarding_total_time` fields on `DriverSessionResult` for new records.
+- **AppealRecord** (new, linked to `PenaltyRecord` or standalone): stores `status` (PENDING / UPHELD / OVERTURNED), `description` (TEXT NOT NULL), `justification` (TEXT NOT NULL), `submitted_by`, `submitted_at`, `reviewed_by`, `reviewed_at`, `review_reason`. One per penalty maximum.
+- **DivisionResultsConfig** (amended): gains `penalty_channel_id` (TEXT, nullable), populated via `/division verdicts-channel`.
+
+## Assumptions
+
+- All sessions within a round advance through the lifecycle states simultaneously (via the wizard operating at the round level). There is no per-session independent lifecycle tracking within a single round.
+- A round where all sessions are `CANCELLED` is implicitly `FINAL` immediately after the last session is marked CANCELLED; no penalty or appeals prompt is shown.
+- Existing rounds with `finalized = 1` (created before this feature) are treated as `FINAL` with no migration action required beyond the column rename/type change. They do not need to go through the appeals stage retroactively.
+- Negative time corrections (time added back to benefit a driver) follow the same signed-integer mechanics already implemented in spec 023; the only change is that the value is now stored in a `PenaltyRecord` row rather than a loose column.
+- The appeals review wizard uses the exact same `AddPenaltyModal` class as the penalty wizard (after the two new fields are added). There is no separate modal class for appeals.
+- Verdict announcements are posted one per penalty/correction at the time of approval (not at the time of staging).
+- When the verdicts channel is deleted or inaccessible, the bot falls back to the results channel. If both are unavailable, the announcement is skipped without blocking finalization.
+- `round results amend` restriction to `FINAL` state applies to the existing full re-entry amendment flow; it does not apply to the penalty/appeals wizard flows themselves (those are the mechanism that drives rounds toward `FINAL`).
+
+## Dependencies
+
+- Spec 023 (Inline Post-Submission Penalty Review) — this feature modifies the `ApprovalView.approve_btn` behaviour and the `finalize_round` function in `result_submission_service.py`, and the `PenaltyReviewState` dataclass.
+- `DivisionResultsConfig` and `results_channel_id` — prerequisite for the announcement fallback.
+- `rounds.finalized` column — replaced by `rounds.result_status`; migration required.
+- Tier-2 admin permission guard (`_require_lm` in `penalty_wizard.py`) — reused unchanged for the appeals wizard.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every results or standings post produced by the bot for a round carries a lifecycle label (`Provisional Results`, `Post-Race Penalty Results`, or `Final Results`) and the standard session heading — zero unlabeled posts permitted.
+- **SC-002**: Every approved penalty or appeal correction produces one announcement per entry in the verdicts channel (or fallback) with all five required fields present.
+- **SC-003**: The Discord modal's built-in required-field validation prevents submission of the penalty/appeal modal without both the description and justification fields — this is enforced at the Discord client level with no additional server-side step needed.
+- **SC-004**: `round results amend` is rejected for every round not in `FINAL` state and accepted for every round in `FINAL` state — no false positives or false negatives in any test scenario.
+- **SC-005**: The division verdicts channel can be configured and updated by a tier-2 admin in a single command interaction.
+- **SC-006**: The full round lifecycle (initial submission → penalty review approved → appeals review approved) produces exactly three results and standings reposts per session, each with the correct label, using only the existing wizard channel without any additional commands.

--- a/specs/026-penalty-posting-appeals/tasks.md
+++ b/specs/026-penalty-posting-appeals/tasks.md
@@ -124,12 +124,12 @@ Single project — `src/`, `tests/` at repository root.
 
 **Purpose**: Test coverage and quickstart validation.
 
-- [ ] T024 [P] Run `python -m pytest tests/ -v` from repo root and confirm all pre-existing tests pass with the `result_status` / `finalized` change from T002
-- [ ] T025 Update tests/unit/test_penalty_wizard.py — add tests for `AppealsReviewView` approve-only path, expanded `AppealsReviewView` with Add/Confirm, and `finalize_penalty_review()` wiring; update any existing tests that reference `finalize_round()` or `rounds.finalized`
-- [ ] T026 [P] Update tests/unit/test_results_post_service.py — assert that every post function produces the standard heading format and includes the correct lifecycle label; cover all three label values
-- [ ] T027 [P] Create tests/unit/test_verdict_announcement_service.py — `translate_penalty()` edge cases; `post_penalty_announcements()` posts to verdicts channel when configured and accessible; skips cleanly (no exception) when `penalty_channel_id` is None or channel is inaccessible; posts nothing and does not raise when staged list is empty
-- [ ] T028 Create tests/integration/test_round_lifecycle.py — full `PROVISIONAL` → `POST_RACE_PENALTY` → `FINAL` lifecycle: three distinct post events, correct labels on each, channel-close only at FINAL, `round results amend` rejected at PROVISIONAL and POST_RACE_PENALTY, accepted at FINAL; also cover zero-staged-list transitions per FR-009 (zero penalties staged → still advances to `POST_RACE_PENALTY`) and FR-010 (zero corrections staged → still advances to `FINAL`)
-- [ ] T029 Validate full manual flow per specs/026-penalty-posting-appeals/quickstart.md
+- [X] T024 [P] Run `python -m pytest tests/ -v` from repo root and confirm all pre-existing tests pass with the `result_status` / `finalized` change from T002
+- [X] T025 Update tests/unit/test_penalty_wizard.py — add tests for `AppealsReviewView` approve-only path, expanded `AppealsReviewView` with Add/Confirm, and `finalize_penalty_review()` wiring; update any existing tests that reference `finalize_round()` or `rounds.finalized`
+- [X] T026 [P] Update tests/unit/test_results_post_service.py — assert that every post function produces the standard heading format and includes the correct lifecycle label; cover all three label values
+- [X] T027 [P] Create tests/unit/test_verdict_announcement_service.py — `translate_penalty()` edge cases; `post_penalty_announcements()` posts to verdicts channel when configured and accessible; skips cleanly (no exception) when `penalty_channel_id` is None or channel is inaccessible; posts nothing and does not raise when staged list is empty
+- [X] T028 Create tests/integration/test_round_lifecycle.py — full `PROVISIONAL` → `POST_RACE_PENALTY` → `FINAL` lifecycle: three distinct post events, correct labels on each, channel-close only at FINAL, `round results amend` rejected at PROVISIONAL and POST_RACE_PENALTY, accepted at FINAL; also cover zero-staged-list transitions per FR-009 (zero penalties staged → still advances to `POST_RACE_PENALTY`) and FR-010 (zero corrections staged → still advances to `FINAL`)
+- [X] T029 Validate full manual flow per specs/026-penalty-posting-appeals/quickstart.md
 
 ---
 

--- a/specs/026-penalty-posting-appeals/tasks.md
+++ b/specs/026-penalty-posting-appeals/tasks.md
@@ -1,0 +1,220 @@
+# Tasks: Penalty Posting, Appeals, and Result Lifecycle
+
+**Input**: Design documents from `specs/026-penalty-posting-appeals/`  
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+## Format: `[ID] [P?] [Story] Description`
+
+- **[P]**: Can run in parallel (different files, no dependencies on incomplete tasks)
+- **[Story]**: User story label (US1–US5 maps to spec.md priorities P1–P5)
+- Every task includes an exact file path
+
+## Path Conventions
+
+Single project — `src/`, `tests/` at repository root.
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the DB migration that all user stories depend on.
+
+- [ ] T001 Create src/db/migrations/026_result_status_penalty_records.sql — adds `result_status TEXT NOT NULL DEFAULT 'PROVISIONAL'` to `rounds`, populates it from `finalized`, adds `penalty_channel_id TEXT` to `division_results_configs`, creates `penalty_records` and `appeal_records` tables (full SQL in specs/026-penalty-posting-appeals/data-model.md)
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Model and dataclass changes required before any user story can be implemented.
+
+⚠️ **CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T002 Update Round dataclass in src/models/round.py — replace `finalized: bool = False` with `result_status: str = "PROVISIONAL"`; update all code in the same file that reads `round.finalized` to read `round.result_status == "FINAL"` instead
+- [ ] T003 [P] Extend StagedPenalty dataclass in src/services/penalty_service.py with two new fields: `description: str = ""` and `justification: str = ""`
+
+**Checkpoint**: Foundation ready — user story implementation can now begin.
+
+---
+
+## Phase 3: User Story 1 — Result Lifecycle Labeling and Heading Format (Priority: P1) 🎯 MVP
+
+**Goal**: Three-state round lifecycle (`PROVISIONAL` → `POST_RACE_PENALTY` → `FINAL`), standard heading and lifecycle label on every results and standings post, submission channel stays open after penalty approval and transitions to a minimal appeals prompt, round results amend gated to `FINAL`.
+
+**Independent Test**: Submit a round → approve penalty review with zero staged penalties → approve appeals review with zero staged corrections. Verify three distinct results/standings reposts each carry the correct heading format and lifecycle label (`Provisional Results`, `Post-Race Penalty Results`, `Final Results`). Verify `round results amend` is rejected on a `PROVISIONAL` round and accepted on a `FINAL` round. No verdicts channel configuration needed.
+
+- [ ] T004 [US1] Add `heading: str` and `label: str` parameters to all results and standings post/repost functions in src/services/results_post_service.py — every function that produces a results or standings Discord message must accept and prepend the heading line and label line (see contract specs/026-penalty-posting-appeals/contracts/result-post-heading-format.md)
+- [ ] T005 [US1] Update the initial submission results and standings post calls in src/services/result_submission_service.py to compute and pass the heading (`Season {N} {DivisionName} Round {X} — {SessionName}`) and label `"Provisional Results"` to the updated functions from T004
+- [ ] T006 [US1] Extract `finalize_penalty_review(interaction, state)` from `finalize_round()` in src/services/result_submission_service.py — sets `rounds.result_status = 'POST_RACE_PENALTY'`, reposts results/standings with `"Post-Race Penalty Results"` label, keeps the submission channel open, and posts a minimal `AppealsReviewView` (Approve button only at this stage — full wizard expansion in T018) to the channel
+- [ ] T007 [US1] Wire `ApprovalView.approve_btn` in src/services/penalty_wizard.py to call `finalize_penalty_review()` instead of `finalize_round()`; after re-wiring, confirm no other callers of `finalize_round()` remain (grep the codebase) and remove the function — it is dead code once this task is complete
+- [ ] T008 [US1] Add `finalize_appeals_review(interaction, state)` in src/services/result_submission_service.py — sets `rounds.result_status = 'FINAL'`, reposts results/standings with `"Final Results"` label, closes the submission channel; add minimal `AppealsReviewView(discord.ui.View, timeout=None)` class with a single Approve button to src/services/penalty_wizard.py and wire its Approve button to call `finalize_appeals_review()`; also add `staged_appeals: list[StagedPenalty] = field(default_factory=list)` to `PenaltyReviewState` in the same file — this is the staging list for appeal corrections, mirroring `staged_penalties`, consumed by T018
+- [ ] T009 [US1] Gate the `round results amend` command handler in src/cogs/results_cog.py — read `result_status` for the target round and reject with a clear error message if it is not `'FINAL'`; ensure the amend repost always calls the results post function with label `"Final Results"`
+- [ ] T010 [US1] Update the `standings sync` and `rounds sync` forced-repost command handlers in src/cogs/results_cog.py to read the round's current `result_status` and pass the corresponding label to the results post functions
+
+**Checkpoint**: Full three-state lifecycle is working end-to-end. US1 independently testable.
+
+---
+
+## Phase 4: User Story 2 — Division Verdicts Channel Configuration (Priority: P2)
+
+**Goal**: `/division verdicts-channel` command stores a per-division announcements channel. `/season review` displays it. `/season approve` blocks if it is missing on any division.
+
+**Independent Test**: Run `/division verdicts-channel`, verify channel stored in `division_results_configs.penalty_channel_id`. Run `/season review` and verify the verdicts channel appears in the division block. Attempt `/season approve` with a division missing the channel and verify it is rejected with the expected error.
+
+- [ ] T011 [P] [US2] Extend `get_divisions_with_results_config()` in src/services/season_service.py — add `drc.penalty_channel_id` to the SELECT and populate `div.penalty_channel_id` on each returned Division object
+- [ ] T012 [US2] Add `/division verdicts-channel <division> <channel>` subcommand to the `division` `app_commands.Group` in src/cogs/season_cog.py — validates the bot can access the channel (`channel.permissions_for(guild.me).send_messages`), UPSERTs `penalty_channel_id` on the matching `division_results_configs` row, writes a `VERDICTS_CHANNEL_SET` audit log entry; see contract specs/026-penalty-posting-appeals/contracts/division-verdicts-channel-command.md for exact responses
+- [ ] T013 [US2] Update the `/season review` per-division block in src/cogs/season_cog.py to display a `Verdicts channel: <#id>` (or `*(not configured)*`) line after the standings channel line, using `div.penalty_channel_id` from T011
+- [ ] T014 [US2] Extend the R&S prerequisites block in `/season approve` (Gate 2) in src/cogs/season_cog.py — add a check for missing `penalty_channel_id` per division; append an error entry per division and block approval with the same error format as the existing results/standings channel checks
+
+**Checkpoint**: Verdicts channel command, review display, and approval gate all work. US2 independently testable.
+
+---
+
+## Phase 5: User Story 3 — Penalty Announcements (Priority: P3)
+
+**Goal**: Each approved penalty produces one announcement post per penalty in the verdicts channel. Announcement contains all five required fields as specified in the contract. If the verdicts channel is inaccessible, the announcement is skipped without blocking finalization.
+
+**Independent Test**: Stage a penalty (with description and justification populated via US5 tasks if done, or temporarily hardcoded strings if not), click Approve, verify one announcement post appears in the verdicts channel with heading, driver mention, penalty translation, description, and justification.
+
+**Note**: Description and justification values in the staged penalty come from the modal fields added in US5 (T021–T022). In sequential implementation, complete T021–T022 before expecting populated announcement content. The service itself can be built against the `StagedPenalty.description` and `StagedPenalty.justification` fields already added in T003.
+
+- [ ] T015 [US3] Create src/services/verdict_announcement_service.py with:
+  - `translate_penalty(penalty_str: str) -> str` — converts `+Ns` → `"{N} seconds removed"`, `-Ns` → `"{N} seconds added"`, `"DSQ"` → `"Disqualified"`
+  - `post_penalty_announcements(bot, state, applied_penalties)` — resolves target channel (`penalty_channel_id` only; skip if NULL or inaccessible), posts one message per penalty in the format defined in specs/026-penalty-posting-appeals/contracts/announcement-message-format.md
+  - `post_appeal_announcements(bot, state, applied_corrections)` — identical contract, called from appeals approval (T019)
+- [ ] T016 [US3] Extend `apply_penalties()` in src/services/penalty_service.py to INSERT one `penalty_records` row per applied penalty (columns: `driver_session_result_id`, `penalty_type`, `time_seconds`, `description`, `justification`, `applied_by`, `applied_at`, `announcement_channel_id`); `announcement_channel_id` is populated with the channel ID where the announcement was actually posted, or NULL if skipped; return the list of inserted records so the caller can pass them to the announcement service; also remove the existing writes to `driver_session_results.post_race_time_penalties` and `post_stewarding_total_time` from `apply_penalties()` — new records MUST only be stored in `penalty_records`
+- [ ] T017 [US3] Call `verdict_announcement_service.post_penalty_announcements()` from `finalize_penalty_review()` in src/services/result_submission_service.py after `apply_penalties()` completes; pass only the non-empty applied list (no call when staged list was empty)
+
+**Checkpoint**: Penalty announcements post correctly. US3 independently testable.
+
+---
+
+## Phase 6: User Story 4 — Appeals Review Stage (Priority: P4)
+
+**Goal**: After penalty approval, the transient channel transitions to a full appeals wizard mirroring the penalty review wizard (Add Correction / No Changes / Approve). Approved corrections are applied, standings recomputed, `Final Results` posted, channel closed. Bot restart re-posts the appeals prompt.
+
+**Independent Test**: Approve a penalty review → stage one appeal correction in the appeals prompt → click Approve → verify channel closes, round is `FINAL`, `Final Results` post appears, appeal announcement posted.
+
+**Note**: The `AddPenaltyModal` is reused as-is in this phase (the modal already has description/justification fields after T021–T022 from US5). If implementing sequentially before US5, the modal will lack those fields temporarily — this is acceptable for structural testing of the appeals view itself.
+
+- [ ] T018 [US4] Expand `AppealsReviewView` in src/services/penalty_wizard.py with Add Correction button (opens `_SessionSelectView` → `AddPenaltyModal`, staged to `state.staged_appeals`), No Changes/Confirm button, and Make Changes recovery button — mirror the `PenaltyReviewView` structure exactly; update `finalize_penalty_review()` to post the full `AppealsReviewView` instead of the minimal stub from T008
+- [ ] T019 [US4] Extend `finalize_appeals_review()` in src/services/result_submission_service.py to: apply staged appeal corrections to `driver_session_results` rows (reusing the penalty application mechanics); INSERT one `appeal_records` row per correction (columns per data-model.md); cascade-recompute standings from the affected round; call `verdict_announcement_service.post_appeal_announcements()`; then close the channel
+- [ ] T020 [US4] Register `AppealsReviewView` in the bot restart recovery handler in src/bot.py — query for rounds with `result_status = 'POST_RACE_PENALTY'` that still have an open submission channel and re-post the appeals review prompt, matching the restart recovery guarantee from spec 023 FR-014
+
+**Checkpoint**: Full appeals wizard functional end-to-end. US4 independently testable.
+
+---
+
+## Phase 7: User Story 5 — Mandatory Description and Justification Fields on the Modal (Priority: P5)
+
+**Goal**: `AddPenaltyModal` gains two new required `TextInput` fields (description, justification). Discord's built-in required-field validation blocks submission without them. Same modal reused for both wizards. Staged penalty and audit log carry the values.
+
+**Independent Test**: Open the modal, leave description empty → Discord rejects submission. Leave justification empty → Discord rejects. Fill all four fields → staged entry carries values verbatim.
+
+**Dependency note**: These tasks complete the data pipeline for US3 and US4. If implementing sequentially after US3/US4, completing T021–T022 will immediately populate announcement content and audit log entries that previously held empty strings.
+
+- [ ] T021 [US5] Extend `AddPenaltyModal` in src/services/penalty_wizard.py with two new `discord.ui.TextInput` fields: `description_input` (label `"Penalty description"`, `required=True`, `max_length=200`, `style=discord.TextStyle.paragraph`) and `justification_input` (label `"Justification"`, `required=True`, `max_length=200`, `style=discord.TextStyle.paragraph`)
+- [ ] T022 [US5] Update `AddPenaltyModal.on_submit()` in src/services/penalty_wizard.py to read `self.description_input.value` and `self.justification_input.value` and pass them to the `StagedPenalty` constructor
+- [ ] T023 [P] [US5] Update the audit log entries written in `finalize_penalty_review()` and `finalize_appeals_review()` in src/services/result_submission_service.py to include the description and justification for each applied penalty and correction
+
+**Checkpoint**: Full end-to-end pipeline complete — modal → staged penalty → announcement → audit log all carry description and justification.
+
+---
+
+## Phase 8: Polish & Cross-Cutting Concerns
+
+**Purpose**: Test coverage and quickstart validation.
+
+- [ ] T024 [P] Run `python -m pytest tests/ -v` from repo root and confirm all pre-existing tests pass with the `result_status` / `finalized` change from T002
+- [ ] T025 Update tests/unit/test_penalty_wizard.py — add tests for `AppealsReviewView` approve-only path, expanded `AppealsReviewView` with Add/Confirm, and `finalize_penalty_review()` wiring; update any existing tests that reference `finalize_round()` or `rounds.finalized`
+- [ ] T026 [P] Update tests/unit/test_results_post_service.py — assert that every post function produces the standard heading format and includes the correct lifecycle label; cover all three label values
+- [ ] T027 [P] Create tests/unit/test_verdict_announcement_service.py — `translate_penalty()` edge cases; `post_penalty_announcements()` posts to verdicts channel when configured and accessible; skips cleanly (no exception) when `penalty_channel_id` is None or channel is inaccessible; posts nothing and does not raise when staged list is empty
+- [ ] T028 Create tests/integration/test_round_lifecycle.py — full `PROVISIONAL` → `POST_RACE_PENALTY` → `FINAL` lifecycle: three distinct post events, correct labels on each, channel-close only at FINAL, `round results amend` rejected at PROVISIONAL and POST_RACE_PENALTY, accepted at FINAL; also cover zero-staged-list transitions per FR-009 (zero penalties staged → still advances to `POST_RACE_PENALTY`) and FR-010 (zero corrections staged → still advances to `FINAL`)
+- [ ] T029 Validate full manual flow per specs/026-penalty-posting-appeals/quickstart.md
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Setup (Phase 1)**: No dependencies — start immediately
+- **Foundational (Phase 2)**: Depends on Phase 1 — blocks all user stories
+- **US1 (Phase 3)**: Depends on Phase 2 — no dependency on US2–US5
+- **US2 (Phase 4)**: Depends on Phase 2 — no dependency on US1 or US3–US5
+- **US3 (Phase 5)**: Depends on Phase 2 — structurally independent; for fully populated announcement content, US5 T021–T022 should be done first
+- **US4 (Phase 6)**: Depends on US1 (T008 — AppealsReviewView stub must exist); for fully populated appeal content, US5 T021–T022 should be done first
+- **US5 (Phase 7)**: Depends on Phase 2 — provides the data pipeline that completes US3 and US4 content
+- **Polish (Phase 8)**: Depends on all desired user stories being complete
+
+### User Story Dependencies
+
+| Story | Blocked by | Notes |
+|-------|-----------|-------|
+| US1 (P1) | Phase 2 | Fully independent of all other stories |
+| US2 (P2) | Phase 2, T011 | T012–T014 all modify `season_cog.py` — do sequentially |
+| US3 (P3) | T003, T016 | `StagedPenalty` fields (T003) and `apply_penalties` PenaltyRecord output (T016) must exist; announcement content populated by US5 |
+| US4 (P4) | T008 (stub view), T019 | Corrections applied in `finalize_appeals_review()` from US1; full modal content populated by US5 |
+| US5 (P5) | T003 | Completes the data pipeline for US3 and US4 |
+
+### Parallel Opportunities Within Phases
+
+- **Phase 2**: T002 and T003 touch different files — run in parallel
+- **Phase 3**: T009 and T010 both modify `results_cog.py` — do sequentially; T004–T008 are sequential in `results_post_service.py` and `result_submission_service.py`; T011 (US2) can be started in parallel with Phase 3 work since it is in a separate file
+- **Phase 5**: T015 (`verdict_announcement_service.py` — new file) can be started in parallel with T016 (`penalty_service.py`)
+- **Phase 8**: T024, T026, T027 are all independent and can run in parallel
+
+---
+
+## Parallel Example: US1 + US2 early start
+
+```bash
+# Once Phase 2 is complete, these can proceed in parallel:
+# Thread A — US1 lifecycle
+Task T004: src/services/results_post_service.py heading + label
+→ T005: src/services/result_submission_service.py initial post label
+→ T006: finalize_penalty_review()
+→ T007: wire ApprovalView.approve_btn
+→ T008: finalize_appeals_review() + AppealsReviewView stub
+→ T009: results_cog.py amend gate
+→ T010: results_cog.py sync reposts
+
+# Thread B — US2 season config (can start alongside Thread A)
+Task T011: src/services/season_service.py query extension  [P]
+→ T012: season_cog.py /division verdicts-channel command
+→ T013: season_cog.py /season review display
+→ T014: season_cog.py /season approve gate
+```
+
+---
+
+## Implementation Strategy
+
+### MVP First (US1 Only)
+
+1. Complete Phase 1: Setup (T001)
+2. Complete Phase 2: Foundational (T002–T003)
+3. Complete Phase 3: US1 (T004–T010)
+4. **STOP and VALIDATE**: Submit a round, walk through zero-penalty + zero-correction lifecycle, verify all three labels and heading format, verify amend gate
+5. Deploy if ready
+
+### Recommended Sequential Order
+
+Given that US5 (modal fields) populates the description/justification values consumed by US3 (announcements) and US4 (appeals), perform US5 before US3 and US4 when implementing solo:
+
+1. Phase 1 → Phase 2 → **US1** → **US2** → **US5** → **US3** → **US4** → Polish
+
+### Full Parallel Strategy
+
+With two developers:
+- **Developer A**: Phase 1 → Phase 2 → US1 → US4 → Polish (T025, T028)
+- **Developer B**: T011 (Phase 2 parallel) → US2 → US5 → US3 → Polish (T026–T027)
+
+---
+
+## Notes
+
+- `[P]` = different files, no incomplete dependencies
+- Each user story has an **Independent Test** that can be run before the next story starts
+- US5 is ordered last per the spec's priority, but its modal-field tasks (T021–T022) should be pulled forward in sequential solo implementation to populate US3/US4 content
+- Commit after each phase checkpoint at minimum
+- Run `python -m pytest tests/ -v` from repo root (not from `src/`)

--- a/src/bot.py
+++ b/src/bot.py
@@ -249,7 +249,7 @@ async def main() -> None:
         NoPreferenceTeammateView,
     )
     from cogs.admin_review_cog import AdminReviewView, CorrectionParameterView
-    from services.penalty_wizard import PenaltyReviewView, ApprovalView
+    from services.penalty_wizard import PenaltyReviewView, ApprovalView, AppealsReviewView
 
     for _view in (
         SignupButtonView(),
@@ -263,6 +263,7 @@ async def main() -> None:
         CorrectionParameterView(),
         PenaltyReviewView(),
         ApprovalView(),
+        AppealsReviewView(),
     ):
         bot.add_view(_view)
 
@@ -378,7 +379,7 @@ async def _recover_orphaned_submission_channels(bot: commands.Bot) -> None:
             """
             SELECT rsc.round_id, rsc.channel_id, rsc.in_penalty_review,
                    rsc.results_posted, rsc.staged_penalties, rsc.prompt_message_id,
-                   r.division_id, s.server_id
+                   r.division_id, r.result_status, s.server_id
             FROM round_submission_channels rsc
             JOIN rounds r    ON r.id  = rsc.round_id
             JOIN divisions d ON d.id  = r.division_id
@@ -396,9 +397,47 @@ async def _recover_orphaned_submission_channels(bot: commands.Bot) -> None:
         staged_penalties_json: str | None = row["staged_penalties"]
         prompt_message_id: int | None = row["prompt_message_id"]
         division_id: int = row["division_id"]
+        result_status: str = row["result_status"] if row["result_status"] else "PROVISIONAL"
         server_id: int = row["server_id"]
 
         guild = bot.get_guild(server_id)  # type: ignore[attr-defined]
+
+        if in_penalty_review and result_status == "POST_RACE_PENALTY":
+            # The bot restarted while a round was awaiting appeals review.
+            # Re-post the AppealsReviewView prompt to the submission channel.
+            if guild is None:
+                log.warning(
+                    "Recovery: guild %s not in cache, cannot restore appeals review for round %s",
+                    server_id, round_id,
+                )
+                continue
+            channel = guild.get_channel(channel_id)
+            if channel is None:
+                log.warning(
+                    "Recovery: channel %s not found, cannot restore appeals review for round %s",
+                    channel_id, round_id,
+                )
+                continue
+            try:
+                from services.result_submission_service import _build_penalty_review_state
+                from services.penalty_wizard import AppealsReviewView, _render_appeals_prompt_content
+                state = await _build_penalty_review_state(
+                    bot, round_id, division_id, channel_id
+                )
+                appeals_view = AppealsReviewView(state=state)
+                content = await _render_appeals_prompt_content(state)
+                msg = await channel.send(content, view=appeals_view)
+                state.appeals_prompt_message_id = msg.id
+                bot.add_view(appeals_view, message_id=msg.id)  # type: ignore[attr-defined]
+                log.info(
+                    "Recovery: restored appeals review prompt for round %s in channel %s",
+                    round_id, channel_id,
+                )
+            except Exception:
+                log.exception(
+                    "Recovery: failed to restore appeals review for round %s", round_id
+                )
+            continue
 
         if in_penalty_review:
             # The bot restarted while a round was awaiting penalty review.

--- a/src/cogs/season_cog.py
+++ b/src/cogs/season_cog.py
@@ -267,9 +267,11 @@ class SeasonCog(commands.Cog):
                 weather_chan = f"<#{div.forecast_channel_id}>" if div.forecast_channel_id else "*(none)*"
                 results_chan = f"<#{div.results_channel_id}>" if div.results_channel_id else "*(none)*"
                 standings_chan = f"<#{div.standings_channel_id}>" if div.standings_channel_id else "*(none)*"
+                verdicts_chan = f"<#{div.penalty_channel_id}>" if div.penalty_channel_id else "*(not configured)*"
                 lines.append(f"  Weather channel: {weather_chan}")
                 lines.append(f"  Results channel: {results_chan}")
                 lines.append(f"  Standings channel: {standings_chan}")
+                lines.append(f"  Verdicts channel: {verdicts_chan}")
                 teams = await self.bot.team_service.get_division_teams(div.id)
                 if teams:
                     lines.append("  **Teams:** " + ", ".join(t["name"] for t in teams))
@@ -1013,6 +1015,88 @@ class SeasonCog(commands.Cog):
         await self._set_division_channel(interaction, name, channel, "standings")
 
     @division.command(
+        name="verdicts-channel",
+        description="Set the verdicts (penalty announcement) channel for a division.",
+    )
+    @app_commands.describe(name="Division name", channel="Verdicts announcement channel")
+    @channel_guard
+    @admin_only
+    async def division_verdicts_channel(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+        channel: discord.TextChannel,
+    ) -> None:
+        import json as _json
+        if not await self.bot.module_service.is_results_enabled(interaction.guild_id):
+            await interaction.response.send_message(
+                "\u274c The Results & Standings module is not enabled.", ephemeral=True
+            )
+            return
+        await interaction.response.defer(ephemeral=True)
+
+        guild = interaction.guild
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+
+        # Validate bot access
+        if guild is None or not channel.permissions_for(guild.me).send_messages:
+            await interaction.followup.send(
+                "\u274c Cannot access that channel. Ensure the bot has permission to post there.",
+                ephemeral=True,
+            )
+            return
+
+        season = await self.bot.season_service.get_season_for_server(server_id)
+        if season is None:
+            await interaction.followup.send(
+                "\u274c No season found. Set up a season before assigning channels.",
+                ephemeral=True,
+            )
+            return
+
+        divisions = await self.bot.season_service.get_divisions(season.id)
+        div = next((d for d in divisions if d.name.lower() == name.lower()), None)
+        if div is None:
+            await interaction.followup.send(
+                f"\u274c Division \"{name}\" not found.",
+                ephemeral=True,
+            )
+            return
+
+        old_id = await self.bot.season_service.set_division_penalty_channel(div.id, channel.id)
+
+        # Audit log
+        now = datetime.now(timezone.utc).isoformat()
+        async with get_connection(self.bot.db_path) as db:
+            await db.execute(
+                "INSERT INTO audit_entries "
+                "(server_id, actor_id, actor_name, division_id, change_type, old_value, new_value, timestamp) "
+                "VALUES (?, ?, ?, ?, 'VERDICTS_CHANNEL_SET', ?, ?, ?)",
+                (
+                    server_id,
+                    interaction.user.id,
+                    str(interaction.user),
+                    div.id,
+                    _json.dumps({"channel_id": old_id}),
+                    _json.dumps({"channel_id": channel.id}),
+                    now,
+                ),
+            )
+            await db.commit()
+
+        if old_id is None:
+            msg = f"\u2705 Verdicts channel for {name} set to #{channel.name}."
+        else:
+            msg = f"\u2705 Verdicts channel for {name} updated to #{channel.name}."
+        await interaction.followup.send(msg, ephemeral=True)
+        await self.bot.output_router.post_log(
+            server_id,
+            f"{interaction.user.display_name} (<@{interaction.user.id}>) | /division verdicts-channel | Success\n"
+            f"  division: {name}\n"
+            f"  channel: #{channel.name}",
+        )
+
+    @division.command(
         name="lineup-channel",
         description="Set the lineup posting channel for a division (signup module).",
     )
@@ -1700,6 +1784,15 @@ class SeasonCog(commands.Cog):
             )
             return
 
+        # T009: amend is only permitted on FINAL rounds
+        if rnd.result_status != "FINAL":
+            await interaction.followup.send(
+                "\u274c This round cannot be amended yet. Round results must reach **FINAL** status "
+                "(approved through the full penalty review and appeals process) before they can be amended.",
+                ephemeral=True,
+            )
+            return
+
         # Load ACTIVE session_results
         async with get_connection(self.bot.db_path) as db:
             cursor = await db.execute(
@@ -2253,6 +2346,11 @@ class SeasonCog(commands.Cog):
                     errors.append(f"**{d.name}** is missing a results channel")
                 if not d.standings_channel_id:
                     errors.append(f"**{d.name}** is missing a standings channel")
+                if not d.penalty_channel_id:
+                    errors.append(
+                        f"**{d.name}** is missing a verdicts channel \u2014 "
+                        f"run /division verdicts-channel {d.name} <channel>"
+                    )
 
             async with get_connection(self.bot.db_path) as _db:
                 cursor = await _db.execute(

--- a/src/db/migrations/026_result_status_penalty_records.sql
+++ b/src/db/migrations/026_result_status_penalty_records.sql
@@ -1,0 +1,35 @@
+-- Add result_status to rounds
+ALTER TABLE rounds ADD COLUMN result_status TEXT NOT NULL DEFAULT 'PROVISIONAL';
+
+-- Populate result_status from existing finalized flag
+UPDATE rounds SET result_status = 'FINAL' WHERE finalized = 1;
+
+-- Add penalty_channel_id to division_results_config
+ALTER TABLE division_results_config ADD COLUMN penalty_channel_id TEXT;
+
+-- penalty_records: stores each applied penalty from the wizard
+CREATE TABLE IF NOT EXISTS penalty_records (
+    id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+    driver_session_result_id INTEGER NOT NULL REFERENCES driver_session_results(id),
+    penalty_type             TEXT    NOT NULL,
+    time_seconds             INTEGER,
+    description              TEXT    NOT NULL,
+    justification            TEXT    NOT NULL,
+    applied_by               TEXT    NOT NULL,
+    applied_at               TEXT    NOT NULL,
+    announcement_channel_id  TEXT
+);
+
+-- appeal_records: stores each applied appeal correction from the appeals wizard
+CREATE TABLE IF NOT EXISTS appeal_records (
+    id                       INTEGER PRIMARY KEY AUTOINCREMENT,
+    driver_session_result_id INTEGER NOT NULL REFERENCES driver_session_results(id),
+    status                   TEXT    NOT NULL DEFAULT 'UPHELD',
+    penalty_type             TEXT    NOT NULL,
+    time_seconds             INTEGER,
+    description              TEXT    NOT NULL,
+    justification            TEXT    NOT NULL,
+    submitted_by             TEXT    NOT NULL,
+    submitted_at             TEXT    NOT NULL,
+    announcement_channel_id  TEXT
+);

--- a/src/models/division.py
+++ b/src/models/division.py
@@ -13,3 +13,4 @@ class Division:
     tier: int = 0
     results_channel_id: int | None = None
     standings_channel_id: int | None = None
+    penalty_channel_id: int | None = None

--- a/src/models/round.py
+++ b/src/models/round.py
@@ -22,4 +22,4 @@ class Round:
     phase2_done: bool = False
     phase3_done: bool = False
     status: str = "ACTIVE"
-    finalized: bool = False
+    result_status: str = "PROVISIONAL"

--- a/src/services/penalty_service.py
+++ b/src/services/penalty_service.py
@@ -28,6 +28,8 @@ class StagedPenalty:
     session_type: SessionType
     penalty_type: Literal["TIME", "DSQ"]
     penalty_seconds: int | None
+    description: str = ""
+    justification: str = ""
 
 
 # ---------------------------------------------------------------------------
@@ -160,15 +162,25 @@ async def apply_penalties(
     bot: discord.Client,
     *,
     _skip_post: bool = False,
-) -> None:
+) -> list[dict]:
     """Apply a list of staged penalties to the DB and cascade standings.
+
+    Inserts one row into ``penalty_records`` per staged penalty and returns
+    the list of inserted record dicts (including ``id`` from the DB).
 
     When *_skip_post* is ``True`` the internal cascade-recompute and
     ``repost_round_results`` calls are skipped.  Pass ``True`` when the
-    caller (e.g. ``finalize_round``) will handle reposting itself.
+    caller (e.g. ``finalize_penalty_review``) will handle reposting itself.
     """
+    import datetime
+
     from services import standings_service
     from services import results_post_service
+
+    # Map (session_type_value, driver_user_id) -> driver_session_results.id
+    # populated during the session loop so we can INSERT penalty_records after.
+    driver_to_dsr_id: dict[tuple[str, int], int] = {}
+    inserted_records: list[dict] = []
 
     async with get_connection(db_path) as db:
         # Load season_id for audit log
@@ -219,7 +231,9 @@ async def apply_penalties(
             )
             driver_rows = list(await cursor.fetchall())
 
-            # Apply DSQ and TIME mutations in-memory
+            # Track driver_user_id -> driver_session_result_id for penalty_records INSERT.
+            for dr in driver_rows:
+                driver_to_dsr_id[(session_type.value, int(dr["driver_user_id"]))] = dr["id"]
             dsq_ids = {sp.driver_user_id for sp in session_penalties if sp.penalty_type == "DSQ"}
             time_boosts: dict[int, int] = {
                 sp.driver_user_id: sp.penalty_seconds
@@ -255,7 +269,6 @@ async def apply_penalties(
                         update["gap"] = "N/A"
                     else:
                         update["total_time"] = "DSQ"
-                        update["post_steward_total_time"] = "DSQ"
                         update["fastest_lap"] = "N/A"
                         update["time_penalties"] = "N/A"
                 elif uid in time_boosts:
@@ -263,10 +276,6 @@ async def apply_penalties(
                     base_time = dr["total_time"] or ""
                     new_time = _apply_time_penalty(base_time, penalty_s)
                     update["total_time"] = new_time
-                    update["post_steward_total_time"] = new_time
-                    # Accumulate post-race penalties
-                    existing_pen = dr["post_race_time_penalties"] or 0
-                    update["post_race_time_penalties"] = existing_pen + penalty_s
                 updated_rows.append(update)
 
             # Re-sort positions: DSQs go last; TIME-penalised rows move accordingly
@@ -325,6 +334,49 @@ async def apply_penalties(
                     ),
                 )
 
+        # INSERT one penalty_records row per staged penalty.
+        now_str = datetime.datetime.utcnow().isoformat()
+        for sp in staged:
+            dsr_id = driver_to_dsr_id.get((sp.session_type.value, sp.driver_user_id))
+            if dsr_id is None:
+                log.warning(
+                    "apply_penalties: no dsr_id for user %s session %s — skipping record",
+                    sp.driver_user_id,
+                    sp.session_type.value,
+                )
+                continue
+            cursor = await db.execute(
+                """
+                INSERT INTO penalty_records (
+                    driver_session_result_id, penalty_type, time_seconds,
+                    description, justification, applied_by, applied_at,
+                    announcement_channel_id
+                ) VALUES (?, ?, ?, ?, ?, ?, ?, NULL)
+                """,
+                (
+                    dsr_id,
+                    sp.penalty_type,
+                    sp.penalty_seconds,
+                    sp.description,
+                    sp.justification,
+                    str(applied_by),
+                    now_str,
+                ),
+            )
+            inserted_records.append(
+                {
+                    "id": cursor.lastrowid,
+                    "driver_session_result_id": dsr_id,
+                    "driver_user_id": sp.driver_user_id,
+                    "penalty_type": sp.penalty_type,
+                    "time_seconds": sp.penalty_seconds,
+                    "description": sp.description,
+                    "justification": sp.justification,
+                    "applied_by": str(applied_by),
+                    "announcement_channel_id": None,
+                }
+            )
+
         await db.commit()
 
     # Audit log
@@ -370,4 +422,6 @@ async def apply_penalties(
             guild = bot.get_guild(int(row3["server_id"]))
         if guild:
             await results_post_service.repost_round_results(db_path, round_id, division_id, guild)
+
+    return inserted_records
 

--- a/src/services/penalty_wizard.py
+++ b/src/services/penalty_wizard.py
@@ -29,6 +29,10 @@ _CID_CONFIRM          = "pw_confirm"
 _CID_APPROVE          = "pw_approve"
 _CID_AV_MAKE_CHANGES  = "pw_av_make_changes"
 _CID_AV_APPROVE       = "pw_av_approve"
+_CID_AR_APPROVE       = "ar_approve"
+_CID_AR_ADD           = "ar_add"
+_CID_AR_CONFIRM       = "ar_confirm"
+_CID_AR_MAKE_CHANGES  = "ar_make_changes"
 
 
 # ---------------------------------------------------------------------------
@@ -72,7 +76,9 @@ class PenaltyReviewState:
     db_path: str
     bot: Any
     staged: list[StagedPenalty] = field(default_factory=list)
+    staged_appeals: list[StagedPenalty] = field(default_factory=list)
     prompt_message_id: int | None = None
+    appeals_prompt_message_id: int | None = None
     round_number: int = 0
     division_name: str = ""
 
@@ -198,6 +204,47 @@ async def _refresh_prompt(state: PenaltyReviewState) -> None:
         log.warning("_refresh_prompt: failed to edit prompt: %s", exc)
 
 
+async def _render_appeals_prompt_content(state: PenaltyReviewState) -> str:
+    """Build the text content for the appeals review prompt message."""
+    lines: list[str] = [
+        f"⚖️ **Appeals Review — Round {state.round_number} | {state.division_name}**",
+        "",
+        "Post-Race Penalty Results have been posted. "
+        "Review and add any appeal corrections before approving to finalise.",
+        "",
+    ]
+    if state.staged_appeals:
+        lines.append(f"**Staged Corrections ({len(state.staged_appeals)}):**")
+        for i, sp in enumerate(state.staged_appeals, 1):
+            pl = _pen_label(sp)
+            sl = sp.session_type.value.replace("_", " ").title()
+            lines.append(
+                f"  {i}. <@{sp.driver_user_id}> | {sl} | **{pl}**  ← Remove #{i} below"
+            )
+    else:
+        lines.append(
+            "**Staged Corrections:** *(none — click Add Correction to stage one)*"
+        )
+    return "\n".join(lines)
+
+
+async def _refresh_appeals_prompt(state: PenaltyReviewState) -> None:
+    """Edit the existing appeals prompt message to reflect current staged_appeals."""
+    if state.appeals_prompt_message_id is None:
+        return
+    ch = state.bot.get_channel(state.submission_channel_id)
+    if ch is None:
+        return
+    try:
+        msg = await ch.fetch_message(state.appeals_prompt_message_id)
+        content = await _render_appeals_prompt_content(state)
+        new_view = AppealsReviewView(state)
+        await msg.edit(content=content, view=new_view)
+        state.bot.add_view(new_view, message_id=state.appeals_prompt_message_id)
+    except (discord.NotFound, discord.HTTPException) as exc:
+        log.warning("_refresh_appeals_prompt: failed to edit appeals prompt: %s", exc)
+
+
 # ---------------------------------------------------------------------------
 # Session selector (ephemeral, non-persistent)
 # ---------------------------------------------------------------------------
@@ -205,10 +252,17 @@ async def _refresh_prompt(state: PenaltyReviewState) -> None:
 class _SessionSelectView(discord.ui.View):
     """One button per non-cancelled session type in the round."""
 
-    def __init__(self, state: PenaltyReviewState, source_interaction: discord.Interaction) -> None:
+    def __init__(
+        self,
+        state: PenaltyReviewState,
+        source_interaction: discord.Interaction,
+        *,
+        use_appeals_staging: bool = False,
+    ) -> None:
         super().__init__(timeout=120)
         self.state = state
         self.source_interaction = source_interaction
+        self.use_appeals_staging = use_appeals_staging
         for stype in state.session_types_present:
             label = stype.value.replace("_", " ").title()
             btn = discord.ui.Button(label=label, style=discord.ButtonStyle.primary)
@@ -218,7 +272,11 @@ class _SessionSelectView(discord.ui.View):
     def _make_cb(self, stype: SessionType):
         async def cb(interaction: discord.Interaction) -> None:
             await interaction.response.send_modal(
-                AddPenaltyModal(state=self.state, session_type=stype)
+                AddPenaltyModal(
+                    state=self.state,
+                    session_type=stype,
+                    use_appeals_staging=self.use_appeals_staging,
+                )
             )
             self.stop()
             try:
@@ -240,7 +298,7 @@ class _SessionSelectView(discord.ui.View):
 # ---------------------------------------------------------------------------
 
 class AddPenaltyModal(discord.ui.Modal, title="Add Penalty"):
-    """Two-field modal for specifying driver @mention/ID and penalty value."""
+    """Four-field modal: driver, penalty value, description, and justification."""
 
     driver_input: discord.ui.TextInput = discord.ui.TextInput(
         label="Driver (@mention or user ID)",
@@ -254,12 +312,34 @@ class AddPenaltyModal(discord.ui.Modal, title="Add Penalty"):
         required=True,
         max_length=10,
     )
+    description_input: discord.ui.TextInput = discord.ui.TextInput(
+        label="Penalty description",
+        placeholder="Brief description of the incident",
+        required=True,
+        max_length=200,
+        style=discord.TextStyle.paragraph,
+    )
+    justification_input: discord.ui.TextInput = discord.ui.TextInput(
+        label="Justification",
+        placeholder="Why this penalty was applied",
+        required=True,
+        max_length=200,
+        style=discord.TextStyle.paragraph,
+    )
 
-    def __init__(self, state: PenaltyReviewState, session_type: SessionType) -> None:
+    def __init__(
+        self,
+        state: PenaltyReviewState,
+        session_type: SessionType,
+        *,
+        use_appeals_staging: bool = False,
+    ) -> None:
         session_label = session_type.value.replace("_", " ").title()
-        super().__init__(title=f"Add Penalty — {session_label}")
+        title_prefix = "Add Correction" if use_appeals_staging else "Add Penalty"
+        super().__init__(title=f"{title_prefix} — {session_label}")
         self.state = state
         self.session_type = session_type
+        self.use_appeals_staging = use_appeals_staging
 
     async def on_submit(self, interaction: discord.Interaction) -> None:
         await interaction.response.defer(ephemeral=True)
@@ -322,9 +402,12 @@ class AddPenaltyModal(discord.ui.Modal, title="Add Penalty"):
         # Adjust for TIME penalties already staged in this wizard session for the
         # same driver+session — a second negative penalty must not exceed whatever
         # headroom remains after previously staged reductions.
+        staging_list = (
+            self.state.staged_appeals if self.use_appeals_staging else self.state.staged
+        )
         staged_adjustment = sum(
             sp.penalty_seconds
-            for sp in self.state.staged
+            for sp in staging_list
             if sp.driver_user_id == driver_user_id
             and sp.session_type == self.session_type
             and sp.penalty_type == "TIME"
@@ -344,14 +427,20 @@ class AddPenaltyModal(discord.ui.Modal, title="Add Penalty"):
             await interaction.followup.send(f"❌ {result}", ephemeral=True)
             return
 
-        # Stage the penalty and refresh the prompt (T017)
-        self.state.staged.append(result)
-        await _refresh_prompt(self.state)
+        # Stage the penalty (with description and justification) and refresh.
+        result.description = self.description_input.value.strip()
+        result.justification = self.justification_input.value.strip()
+        staging_list.append(result)
+        if self.use_appeals_staging:
+            await _refresh_appeals_prompt(self.state)
+        else:
+            await _refresh_prompt(self.state)
 
         pl = _pen_label(result)
         sl = self.session_type.value.replace("_", " ").title()
+        action = "Correction" if self.use_appeals_staging else "Penalty"
         await interaction.followup.send(
-            f"✅ Staged: <@{driver_user_id}> | {sl} | **{pl}**",
+            f"\u2705 Staged {action}: <@{driver_user_id}> | {sl} | **{pl}**",
             ephemeral=True,
         )
 
@@ -570,8 +659,8 @@ class PenaltyReviewView(discord.ui.View):
                 ephemeral=True,
             )
             return
-        from services.result_submission_service import finalize_round
-        await finalize_round(interaction, self.state)
+        from services.result_submission_service import finalize_penalty_review
+        await finalize_penalty_review(interaction, self.state)
 
 
 # ---------------------------------------------------------------------------
@@ -649,6 +738,194 @@ class ApprovalView(discord.ui.View):
                 ephemeral=True,
             )
             return
-        # T025: wire to finalize_round
-        from services.result_submission_service import finalize_round
-        await finalize_round(interaction, self.state)
+        # T007: wire to finalize_penalty_review
+        from services.result_submission_service import finalize_penalty_review
+        await finalize_penalty_review(interaction, self.state)
+
+
+# ---------------------------------------------------------------------------
+# Appeals review view (T008 — minimal stub; expanded in T018)
+# ---------------------------------------------------------------------------
+
+class AppealsReviewView(discord.ui.View):
+    """Persistent appeals review prompt view.
+
+    Mirrors the :class:`PenaltyReviewView` structure:
+    - ➕ Add Correction — opens ``_SessionSelectView`` in appeals mode
+    - No Changes / Confirm — finalises without corrections (with confirmation when staged)
+    - ✅ Approve — applies staged corrections and calls ``finalize_appeals_review``
+
+    Dynamic Remove buttons are added per staged_appeals entry at construction time.
+    """
+
+    def __init__(self, state: PenaltyReviewState | None = None) -> None:
+        super().__init__(timeout=None)
+        self.state = state
+
+        _no_state = state is None
+        for item in self.children:
+            if not isinstance(item, discord.ui.Button):
+                continue
+            if item.custom_id == _CID_AR_ADD:
+                item.disabled = _no_state or len(state.session_types_present) == 0  # type: ignore[union-attr]
+            elif item.custom_id == _CID_AR_APPROVE:
+                item.disabled = _no_state or len(state.staged_appeals) == 0  # type: ignore[union-attr]
+
+        # Dynamic Remove buttons — one per staged correction
+        if state is not None:
+            for idx, sp in enumerate(state.staged_appeals):
+                row_num = min(1 + idx // 5, 4)
+                btn = discord.ui.Button(
+                    label=f"Remove #{idx + 1}",
+                    style=discord.ButtonStyle.danger,
+                    custom_id=f"ar_remove_{idx}",
+                    row=row_num,
+                )
+                btn.callback = self._make_remove_cb(idx)
+                self.add_item(btn)
+
+    def _make_remove_cb(self, idx: int):
+        async def cb(interaction: discord.Interaction) -> None:
+            if self.state is None:
+                await interaction.response.send_message(
+                    "⚠️ The bot was restarted. Please wait for the appeals prompt to refresh.",
+                    ephemeral=True,
+                )
+                return
+            if not await _require_lm(interaction, self.state):
+                return
+            if idx < len(self.state.staged_appeals):
+                removed = self.state.staged_appeals.pop(idx)
+                await interaction.response.defer(ephemeral=True)
+                await _refresh_appeals_prompt(self.state)
+                pl = _pen_label(removed)
+                await interaction.followup.send(
+                    f"\U0001f5d1\ufe0f Removed: <@{removed.driver_user_id}> | {pl}",
+                    ephemeral=True,
+                )
+            else:
+                await interaction.response.send_message(
+                    "⚠️ That entry no longer exists (the list may have changed).",
+                    ephemeral=True,
+                )
+        return cb
+
+    @discord.ui.button(
+        label="➕ Add Correction",
+        style=discord.ButtonStyle.primary,
+        custom_id=_CID_AR_ADD,
+        row=0,
+    )
+    async def add_correction_btn(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        if self.state is None:
+            await interaction.response.send_message(
+                "⚠️ The bot was restarted. Please wait for the appeals prompt to refresh.",
+                ephemeral=True,
+            )
+            return
+        if not await _require_lm(interaction, self.state):
+            return
+        view = _SessionSelectView(
+            state=self.state,
+            source_interaction=interaction,
+            use_appeals_staging=True,
+        )
+        await interaction.response.send_message(
+            "Select which session to apply a correction to:", view=view, ephemeral=True
+        )
+
+    @discord.ui.button(
+        label="No Changes / Confirm",
+        style=discord.ButtonStyle.secondary,
+        custom_id=_CID_AR_CONFIRM,
+        row=0,
+    )
+    async def no_changes_btn(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        if self.state is None:
+            await interaction.response.send_message(
+                "⚠️ The bot was restarted. Please wait for the appeals prompt to refresh.",
+                ephemeral=True,
+            )
+            return
+        if not await _require_lm(interaction, self.state):
+            return
+        if not self.state.staged_appeals:
+            # No corrections — finalise directly
+            await interaction.response.defer(ephemeral=True)
+            from services.result_submission_service import finalize_appeals_review
+            await finalize_appeals_review(interaction, self.state)
+        else:
+            # Ask for explicit confirmation before clearing
+            view = _AppealsConfirmClearView(state=self.state)
+            await interaction.response.send_message(
+                f"⚠️ You have **{len(self.state.staged_appeals)}** staged correction(s). "
+                "Clicking **Yes, clear and proceed** will discard all of them and finalise "
+                "the round without any appeal corrections.",
+                view=view,
+                ephemeral=True,
+            )
+
+    @discord.ui.button(
+        label="✅ Approve",
+        style=discord.ButtonStyle.success,
+        custom_id=_CID_AR_APPROVE,
+        row=0,
+    )
+    async def approve_btn(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        if self.state is None:
+            await interaction.response.send_message(
+                "⚠️ The bot was restarted. Please wait for the appeals prompt to refresh.",
+                ephemeral=True,
+            )
+            return
+        if not await _require_lm(interaction, self.state):
+            return
+        if not self.state.staged_appeals:
+            await interaction.response.send_message(
+                "⚠️ No corrections are staged. "
+                "Use **No Changes / Confirm** to finalise without corrections.",
+                ephemeral=True,
+            )
+            return
+        from services.result_submission_service import finalize_appeals_review
+        await finalize_appeals_review(interaction, self.state)
+
+
+class _AppealsConfirmClearView(discord.ui.View):
+    """Two-button confirmation for clearing the staged appeals corrections list."""
+
+    def __init__(self, state: PenaltyReviewState) -> None:
+        super().__init__(timeout=60)
+        self.state = state
+
+    @discord.ui.button(
+        label="Yes, clear and proceed with no corrections",
+        style=discord.ButtonStyle.danger,
+    )
+    async def confirm_btn(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        if not await _require_lm(interaction, self.state):
+            return
+        self.state.staged_appeals.clear()
+        await interaction.response.defer(ephemeral=True)
+        from services.result_submission_service import finalize_appeals_review
+        await finalize_appeals_review(interaction, self.state)
+        self.stop()
+
+    @discord.ui.button(
+        label="No, go back",
+        style=discord.ButtonStyle.secondary,
+    )
+    async def cancel_btn(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        await interaction.response.defer(ephemeral=True)
+        self.stop()
+

--- a/src/services/result_submission_service.py
+++ b/src/services/result_submission_service.py
@@ -169,12 +169,66 @@ async def is_channel_in_penalty_review(db_path: str, channel_id: int) -> bool:
             WHERE rsc.channel_id = ?
               AND rsc.closed = 0
               AND rsc.in_penalty_review = 1
-              AND r.finalized = 0
+              AND r.result_status != 'FINAL'
             """,
             (channel_id,),
         )
         row = await cursor.fetchone()
     return row is not None
+
+
+async def _build_penalty_review_state(
+    bot,
+    round_id: int,
+    division_id: int,
+    submission_channel_id: int,
+) -> "PenaltyReviewState":  # type: ignore[name-defined]
+    """Reconstruct a :class:`~services.penalty_wizard.PenaltyReviewState` from the DB.
+
+    Used by the bot restart-recovery path to re-post the appeals review prompt
+    after a crash during the appeals phase (``result_status = 'POST_RACE_PENALTY'``).
+    """
+    from services.penalty_wizard import PenaltyReviewState
+
+    db_path: str = bot.db_path  # type: ignore[attr-defined]
+
+    async with get_connection(db_path) as db:
+        ctx_cursor = await db.execute(
+            """
+            SELECT r.round_number, d.name AS division_name
+            FROM rounds r
+            JOIN divisions d ON d.id = r.division_id
+            WHERE r.id = ?
+            """,
+            (round_id,),
+        )
+        ctx = await ctx_cursor.fetchone()
+
+        sr_cursor = await db.execute(
+            "SELECT session_type FROM session_results WHERE round_id = ? AND status = 'ACTIVE'",
+            (round_id,),
+        )
+        sr_rows = await sr_cursor.fetchall()
+
+    round_number: int = ctx["round_number"] if ctx else 0
+    division_name: str = ctx["division_name"] if ctx else ""
+
+    _stype_order = list(SessionType)
+    session_types_present = sorted(
+        [SessionType(r["session_type"]) for r in sr_rows],
+        key=lambda s: _stype_order.index(s),
+    )
+
+    return PenaltyReviewState(
+        round_id=round_id,
+        division_id=division_id,
+        submission_channel_id=submission_channel_id,
+        session_types_present=session_types_present,
+        db_path=db_path,
+        bot=bot,
+        round_number=round_number,
+        division_name=division_name,
+    )
 
 
 async def enter_penalty_state(
@@ -262,7 +316,8 @@ async def enter_penalty_state(
                 rc = guild.get_channel(results_ch_id)
                 if rc:
                     await results_post_service.post_round_results(
-                        db_path, round_id, division_id, rc, guild
+                        db_path, round_id, division_id, rc, guild,
+                        label="Provisional Results",
                     )
 
             if standings_ch_id:
@@ -277,6 +332,7 @@ async def enter_penalty_state(
                     await results_post_service.post_standings(
                         db_path, division_id, round_id, round_number, track_name,
                         sc, driver_snaps, team_snaps, guild, show_reserves,
+                        label="Provisional Results",
                     )
 
             # Mark results as posted so restart recovery knows not to re-post.
@@ -342,21 +398,24 @@ async def enter_penalty_state(
     )
 
 
-async def finalize_round(
+async def finalize_penalty_review(
     interaction: discord.Interaction,
     state,  # PenaltyReviewState — forward-ref to avoid import cycle
 ) -> None:
-    """Apply all staged penalties, replace interim posts, mark the round finalized,
-    and close the submission channel.
+    """Apply staged penalties, repost with 'Post-Race Penalty Results' label, and
+    transition the submission channel to appeals review.
 
-    Called from :meth:`ApprovalView.approve_btn` (T025).
+    Sets rounds.result_status = 'POST_RACE_PENALTY', then posts an AppealsReviewView
+    prompt and keeps the submission channel open.
+
+    Called from :meth:`ApprovalView.approve_btn` and
+    :meth:`PenaltyReviewView.approve_btn`.
     """
     import json as _json
     from services import results_post_service as _rps
-    from services.standings_service import cascade_recompute_from_round
     from services import penalty_service as _ps
+    from services import verdict_announcement_service as _vas
 
-    # T024-a: defer as the very first statement (NFR-001)
     await interaction.response.defer(ephemeral=True)
 
     db_path: str = state.db_path
@@ -366,13 +425,10 @@ async def finalize_round(
     guild = interaction.guild
     actor_id: int = interaction.user.id
 
-    # T024-b: pre-penalty snapshot for audit log
+    # Pre-penalty snapshot for audit log
     pre_snapshot = await _snapshot_staged_drivers(db_path, round_id, division_id, state.staged)
 
-    # T022: apply staged penalties to DB (positions, times, outcomes).
-    # Check whether penalties were already committed before a previous crash by
-    # reading the staged_penalties column.  If it is already set, skip applying
-    # them again to avoid double-penalising drivers.
+    # Apply staged penalties (idempotent: staged_penalties column guards against double-apply)
     async with get_connection(db_path) as _db:
         _rsc = await _db.execute(
             "SELECT staged_penalties FROM round_submission_channels WHERE round_id = ?",
@@ -382,8 +438,6 @@ async def finalize_round(
     penalties_already_applied = bool(_rsc_row and _rsc_row["staged_penalties"] is not None)
 
     if state.staged and not penalties_already_applied:
-        # Persist the staged list to the DB BEFORE writing so a crash here
-        # doesn't leave penalties partially applied with no record.
         penalty_json = _json.dumps(
             [
                 {
@@ -391,6 +445,8 @@ async def finalize_round(
                     "session_type": sp.session_type.value,
                     "penalty_type": sp.penalty_type,
                     "penalty_seconds": sp.penalty_seconds,
+                    "description": sp.description,
+                    "justification": sp.justification,
                 }
                 for sp in state.staged
             ]
@@ -402,41 +458,51 @@ async def finalize_round(
             )
             await _db.commit()
 
-        await _ps.apply_penalties(
+        applied_records = await _ps.apply_penalties(
             db_path, round_id, division_id, state.staged,
             applied_by=actor_id, bot=bot,
             _skip_post=True,
         )
-        # Recompute points_awarded / fastest_lap_bonus for all affected sessions
         await _recompute_session_points(db_path, round_id)
 
-    # T024-c: post-penalty snapshot
+    else:
+        applied_records: list = []
+
+    # Post-penalty snapshot
     post_snapshot = await _snapshot_staged_drivers(db_path, round_id, division_id, state.staged)
 
-    # T023: delete interim posts, repost final results and standings
+    # Repost results/standings with "Post-Race Penalty Results" label
     if guild:
-        await _rps.delete_and_repost_final_results(db_path, round_id, division_id, guild)
+        await _rps.delete_and_repost_final_results(
+            db_path, round_id, division_id, guild,
+            label="Post-Race Penalty Results",
+        )
         await _rps.repost_subsequent_standings(db_path, division_id, round_id, guild)
 
-    # T024-d: mark round as finalized
+    # Set result_status = 'POST_RACE_PENALTY'
     async with get_connection(db_path) as db:
-        await db.execute("UPDATE rounds SET finalized = 1 WHERE id = ?", (round_id,))
+        await db.execute(
+            "UPDATE rounds SET result_status = 'POST_RACE_PENALTY' WHERE id = ?",
+            (round_id,),
+        )
         await db.commit()
 
-    # T024-e: audit log ROUND_FINALIZED
+    # Audit log PENALTY_REVIEW_APPROVED
     penalty_log = [
         {
             "driver_user_id": sp.driver_user_id,
             "session_type": sp.session_type.value,
             "penalty_type": sp.penalty_type,
             "penalty_seconds": sp.penalty_seconds,
+            "description": sp.description,
+            "justification": sp.justification,
         }
         for sp in state.staged
     ]
-    old_val = _json.dumps({"finalized": 0, "affected_drivers": pre_snapshot})
+    old_val = _json.dumps({"result_status": "PROVISIONAL", "affected_drivers": pre_snapshot})
     new_val = _json.dumps(
         {
-            "finalized": 1,
+            "result_status": "POST_RACE_PENALTY",
             "affected_drivers": post_snapshot,
             "penalties": penalty_log,
             "actor_id": actor_id,
@@ -452,7 +518,7 @@ async def finalize_round(
         if srv_row:
             n_penalties = len(state.staged)
             summary = (
-                f"<@{actor_id}> | ROUND_FINALIZED | Success\n"
+                f"<@{actor_id}> | PENALTY_REVIEW_APPROVED | Success\n"
                 f"  round: {state.round_number} ({state.division_name})\n"
                 + (f"  penalties: {n_penalties}\n" if n_penalties else "  penalties: none\n")
                 + f"  old={old_val}\n  new={new_val}"
@@ -462,9 +528,160 @@ async def finalize_round(
                 summary,
             )
     except Exception:
-        log.exception("finalize_round: error writing audit log for round %s", round_id)
+        log.exception("finalize_penalty_review: error writing audit log for round %s", round_id)
 
-    # T024-f: close the submission channel
+    # Post verdict announcements (non-blocking: skip silently on any error)
+    if applied_records:
+        try:
+            await _vas.post_penalty_announcements(bot, state, applied_records)
+        except Exception:
+            log.exception(
+                "finalize_penalty_review: error posting penalty announcements for round %s",
+                round_id,
+            )
+
+    # Post appeals review prompt and keep submission channel open
+    from services.penalty_wizard import AppealsReviewView, _render_appeals_prompt_content
+    appeals_view = AppealsReviewView(state=state)
+    sub_channel = guild.get_channel(state.submission_channel_id) if guild else None
+    if sub_channel is not None:
+        content = await _render_appeals_prompt_content(state)
+        msg = await sub_channel.send(content, view=appeals_view)
+        state.appeals_prompt_message_id = msg.id
+        bot.add_view(appeals_view, message_id=msg.id)  # type: ignore[attr-defined]
+
+
+async def finalize_appeals_review(
+    interaction: discord.Interaction,
+    state,  # PenaltyReviewState — forward-ref to avoid import cycle
+) -> None:
+    """Advance the round to FINAL, repost with 'Final Results' label, and close
+    the submission channel.
+
+    Called from :meth:`AppealsReviewView.approve_btn` and
+    :meth:`_AppealsConfirmClearView.confirm_btn`.
+    """
+    import datetime as _dt
+    import json as _json
+    from services import results_post_service as _rps
+    from services import penalty_service as _ps
+    from services import verdict_announcement_service as _vas
+
+    await interaction.response.defer(ephemeral=True)
+
+    db_path: str = state.db_path
+    bot = state.bot
+    round_id: int = state.round_id
+    division_id: int = state.division_id
+    guild = interaction.guild
+    actor_id: int = interaction.user.id
+
+    # Apply staged appeal corrections if any, then INSERT appeal_records.
+    applied_correction_records: list[dict] = []
+    if state.staged_appeals:
+        applied_pr = await _ps.apply_penalties(
+            db_path, round_id, division_id, state.staged_appeals,
+            applied_by=actor_id, bot=bot,
+            _skip_post=True,
+        )
+        await _recompute_session_points(db_path, round_id)
+
+        # INSERT appeal_records — order mirrors applied_pr (same ordering as staged_appeals).
+        now_str = _dt.datetime.utcnow().isoformat()
+        async with get_connection(db_path) as db:
+            for sp, pr in zip(state.staged_appeals, applied_pr):
+                dsr_id = pr["driver_session_result_id"]
+                cursor = await db.execute(
+                    """
+                    INSERT INTO appeal_records (
+                        driver_session_result_id, status, penalty_type, time_seconds,
+                        description, justification, submitted_by, submitted_at,
+                        announcement_channel_id
+                    ) VALUES (?, 'UPHELD', ?, ?, ?, ?, ?, ?, NULL)
+                    """,
+                    (
+                        dsr_id,
+                        sp.penalty_type,
+                        sp.penalty_seconds,
+                        sp.description,
+                        sp.justification,
+                        str(actor_id),
+                        now_str,
+                    ),
+                )
+                applied_correction_records.append(
+                    {
+                        "id": cursor.lastrowid,
+                        "driver_session_result_id": dsr_id,
+                        "driver_user_id": sp.driver_user_id,
+                        "penalty_type": sp.penalty_type,
+                        "time_seconds": sp.penalty_seconds,
+                        "description": sp.description,
+                        "justification": sp.justification,
+                        "submitted_by": str(actor_id),
+                        "announcement_channel_id": None,
+                    }
+                )
+            await db.commit()
+
+    # Repost results/standings with "Final Results" label
+    if guild:
+        await _rps.delete_and_repost_final_results(
+            db_path, round_id, division_id, guild,
+            label="Final Results",
+        )
+        await _rps.repost_subsequent_standings(db_path, division_id, round_id, guild)
+
+    # Set result_status = 'FINAL'
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "UPDATE rounds SET result_status = 'FINAL' WHERE id = ?",
+            (round_id,),
+        )
+        await db.commit()
+
+    # Audit log APPEALS_REVIEW_APPROVED
+    old_val = _json.dumps({"result_status": "POST_RACE_PENALTY"})
+    new_val = _json.dumps(
+        {
+            "result_status": "FINAL",
+            "actor_id": actor_id,
+            "corrections": len(state.staged_appeals),
+        }
+    )
+    try:
+        async with get_connection(db_path) as db:
+            cursor = await db.execute(
+                "SELECT s.server_id FROM seasons s JOIN divisions d ON d.season_id = s.id WHERE d.id = ?",
+                (division_id,),
+            )
+            srv_row = await cursor.fetchone()
+        if srv_row:
+            n_corrections = len(state.staged_appeals)
+            summary = (
+                f"<@{actor_id}> | APPEALS_REVIEW_APPROVED | Success\n"
+                f"  round: {state.round_number} ({state.division_name})\n"
+                + (f"  corrections: {n_corrections}\n" if n_corrections else "  corrections: none\n")
+                + f"  old={old_val}\n  new={new_val}"
+            )
+            await bot.output_router.post_log(  # type: ignore[attr-defined]
+                int(srv_row["server_id"]),
+                summary,
+            )
+    except Exception:
+        log.exception("finalize_appeals_review: error writing audit log for round %s", round_id)
+
+    # Post appeal announcements (non-blocking)
+    if applied_correction_records:
+        try:
+            await _vas.post_appeal_announcements(bot, state, applied_correction_records)
+        except Exception:
+            log.exception(
+                "finalize_appeals_review: error posting appeal announcements for round %s",
+                round_id,
+            )
+
+    # Close the submission channel
     await close_submission_channel(state.submission_channel_id, round_id, guild, db_path)
 
 
@@ -786,7 +1003,8 @@ async def amend_session_result(
     guild = bot.get_guild(server_id)
     if guild is not None:
         await results_post_service.delete_and_repost_final_results(
-            db_path, round_id, division_id, guild
+            db_path, round_id, division_id, guild,
+            label="Final Results",
         )
         await results_post_service.repost_subsequent_standings(
             db_path, division_id, round_id, guild

--- a/src/services/results_post_service.py
+++ b/src/services/results_post_service.py
@@ -48,12 +48,14 @@ async def _build_team_display(
     return result
 
 
-async def _get_season_number(db_path: str, round_id: int) -> int | None:
-    """Return the season_number for the season that contains this round."""
+async def _get_heading_context(
+    db_path: str, round_id: int
+) -> tuple[int | None, str]:
+    """Return (season_number, division_name) for building result headings."""
     async with get_connection(db_path) as db:
         cursor = await db.execute(
             """
-            SELECT s.season_number
+            SELECT s.season_number, d.name AS division_name
             FROM rounds r
             JOIN divisions d ON d.id = r.division_id
             JOIN seasons s ON s.id = d.season_id
@@ -62,7 +64,40 @@ async def _get_season_number(db_path: str, round_id: int) -> int | None:
             (round_id,),
         )
         row = await cursor.fetchone()
-    return row["season_number"] if row else None
+    if row is None:
+        return None, "Unknown"
+    return row["season_number"], row["division_name"]
+
+
+async def _get_primary_session_label(db_path: str, round_id: int) -> str:
+    """Return the formatted label for the most recently posted session of *round_id*."""
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            """
+            SELECT sr.session_type, r.format
+            FROM session_results sr
+            JOIN rounds r ON r.id = sr.round_id
+            WHERE sr.round_id = ? AND sr.status = 'ACTIVE'
+            ORDER BY sr.id DESC
+            LIMIT 1
+            """,
+            (round_id,),
+        )
+        row = await cursor.fetchone()
+    if row is None:
+        return "Results"
+    st = SessionType(row["session_type"])
+    is_sprint = str(row["format"]).upper() == "SPRINT"
+    return results_formatter.format_session_label(st, is_sprint=is_sprint)
+
+
+def _label_from_status(result_status: str) -> str:
+    """Map a round result_status value to the user-visible lifecycle label."""
+    return {
+        "PROVISIONAL": "Provisional Results",
+        "POST_RACE_PENALTY": "Post-Race Penalty Results",
+        "FINAL": "Final Results",
+    }.get(result_status, "Results")
 
 
 # ---------------------------------------------------------------------------
@@ -78,22 +113,22 @@ async def post_session_results(
     guild: discord.Guild,
     round_number: int,
     track_name: str,
+    label: str,
     is_sprint: bool = True,
 ) -> int:
     """Format and send a single session result. Returns the Discord message ID."""
     session_type = SessionType(session_result.session_type)
-    label = results_formatter.format_session_label(session_type, is_sprint=is_sprint)
+    session_label = results_formatter.format_session_label(session_type, is_sprint=is_sprint)
 
     if session_type.is_qualifying:
         table = results_formatter.format_qualifying_table(driver_rows, points_map)
     else:
         table = results_formatter.format_race_table(driver_rows, points_map)
 
-    season_number = await _get_season_number(db_path, session_result.round_id)
-    season_prefix = f"S{season_number} — " if season_number is not None else ""
-    msg = await results_channel.send(
-        f"**{season_prefix}Round {round_number} — {track_name} | {label} Results**\n{table}"
-    )
+    season_number, division_name = await _get_heading_context(db_path, session_result.round_id)
+    season_prefix = f"Season {season_number} " if season_number is not None else ""
+    heading = f"**{season_prefix}{division_name} Round {round_number} — {session_label}**"
+    msg = await results_channel.send(f"{heading}\n{label}\n{table}")
 
     async with get_connection(db_path) as db:
         await db.execute(
@@ -120,6 +155,7 @@ async def post_standings(
     team_snapshots: list[TeamStandingsSnapshot],
     guild: discord.Guild,
     show_reserves: bool,
+    label: str,
 ) -> None:
     """Format and post (or edit-in-place) the driver and team standings."""
     # Determine reserve user IDs from the DB (is_reserve team instances)
@@ -130,11 +166,14 @@ async def post_standings(
     )
     team_text = results_formatter.format_team_standings(team_snapshots)
 
-    season_number = await _get_season_number(db_path, round_id)
-    season_suffix = f" | S{season_number}" if season_number is not None else ""
+    season_number, division_name = await _get_heading_context(db_path, round_id)
+    season_prefix = f"Season {season_number} " if season_number is not None else ""
+    primary_session_label = await _get_primary_session_label(db_path, round_id)
+    heading = f"**{season_prefix}{division_name} Round {round_number} — {primary_session_label}**"
     content = (
-        f"**Driver Standings — after Round {round_number} ({track_name}){season_suffix}**\n{driver_text}\n\n"
-        f"**Team Standings — after Round {round_number} ({track_name}){season_suffix}**\n{team_text}"
+        f"{heading}\n{label}\n\n"
+        f"**Driver Standings**\n{driver_text}\n\n"
+        f"**Team Standings**\n{team_text}"
     )
 
     # Look for existing standings message (stored in the top-ranked driver snapshot)
@@ -214,6 +253,7 @@ async def post_round_results(
     division_id: int,
     results_channel: discord.TextChannel,
     guild: discord.Guild,
+    label: str,
 ) -> None:
     """Post results for all non-cancelled sessions of a round in session order."""
     from services.result_submission_service import SESSION_ORDER_SPRINT, SESSION_ORDER_NORMAL
@@ -313,7 +353,7 @@ async def post_round_results(
 
         await post_session_results(
             db_path, session_result, driver_rows, points_map, results_channel, guild,
-            round_number, track_name, is_sprint,
+            round_number, track_name, label, is_sprint,
         )
 
 
@@ -322,6 +362,7 @@ async def repost_round_results(
     round_id: int,
     division_id: int,
     guild: discord.Guild,
+    label: str,
 ) -> None:
     """Load the division's channels and repost/edit round results and standings."""
     async with get_connection(db_path) as db:
@@ -350,7 +391,7 @@ async def repost_round_results(
     if results_ch_id:
         rc = guild.get_channel(results_ch_id)
         if rc:
-            await post_round_results(db_path, round_id, division_id, rc, guild)
+            await post_round_results(db_path, round_id, division_id, rc, guild, label)
 
     if standings_ch_id:
         sc = guild.get_channel(standings_ch_id)
@@ -365,7 +406,7 @@ async def repost_round_results(
             show_reserves = await _get_show_reserves(db_path, division_id)
             await post_standings(
                 db_path, division_id, round_id, round_number, track_name, sc,
-                driver_snaps, team_snaps, guild, show_reserves
+                driver_snaps, team_snaps, guild, show_reserves, label
             )
 
 
@@ -430,7 +471,8 @@ async def repost_results_for_division(
     async with get_connection(db_path) as db:
         cursor = await db.execute(
             """
-            SELECT DISTINCT r.id AS round_id, r.round_number, r.track_name, r.format
+            SELECT DISTINCT r.id AS round_id, r.round_number, r.track_name, r.format,
+                   r.result_status
             FROM rounds r
             JOIN session_results sr ON sr.round_id = r.id
             WHERE r.division_id = ? AND sr.status = 'ACTIVE'
@@ -450,6 +492,7 @@ async def repost_results_for_division(
         round_number: int = rnd["round_number"]
         track_name: str = rnd["track_name"] or "Unknown"
         is_sprint: bool = str(rnd["format"]).upper() == "SPRINT"
+        rnd_label: str = _label_from_status(rnd["result_status"] or "PROVISIONAL")
 
         async with get_connection(db_path) as db:
             cursor = await db.execute(
@@ -511,7 +554,7 @@ async def repost_results_for_division(
 
             await post_session_results(
                 db_path, session_result, driver_rows, points_map, rc, guild,
-                round_number, track_name, is_sprint,
+                round_number, track_name, rnd_label, is_sprint,
             )
 
     return "ok"
@@ -534,7 +577,7 @@ async def repost_standings_for_division(
         cursor = await db.execute(
             """
             SELECT DISTINCT r.id AS round_id, r.round_number, r.track_name,
-                   drc.standings_channel_id
+                   r.result_status, drc.standings_channel_id
             FROM rounds r
             JOIN session_results sr ON sr.round_id = r.id
             LEFT JOIN division_results_config drc ON drc.division_id = r.division_id
@@ -567,6 +610,7 @@ async def repost_standings_for_division(
         round_id: int = row["round_id"]
         round_number: int = row["round_number"]
         track_name: str = row["track_name"] or "Unknown"
+        rsd_label: str = _label_from_status(row["result_status"] or "PROVISIONAL")
 
         # Delete the existing standings message for this round (if any)
         existing_msg_id = await _get_standings_message_id(db_path, division_id, round_id)
@@ -596,7 +640,7 @@ async def repost_standings_for_division(
         )
         await post_standings(
             db_path, division_id, round_id, round_number, track_name, sc,
-            driver_snaps, team_snaps, guild, show_reserves,
+            driver_snaps, team_snaps, guild, show_reserves, rsd_label,
         )
 
     return "ok"
@@ -611,6 +655,7 @@ async def delete_and_repost_final_results(
     round_id: int,
     division_id: int,
     guild: discord.Guild,
+    label: str,
 ) -> None:
     """Delete all interim results/standings Discord messages for *round_id* and
     repost the final (post-penalty) versions.
@@ -723,7 +768,7 @@ async def delete_and_repost_final_results(
 
                 await post_session_results(
                     db_path, session_result, driver_rows, points_map, rc, guild,
-                    round_number, track_name, is_sprint,
+                    round_number, track_name, label, is_sprint,
                 )
 
     # ── Delete interim standings message and re-post final ─────────────────
@@ -760,7 +805,7 @@ async def delete_and_repost_final_results(
             )
             await post_standings(
                 db_path, division_id, round_id, round_number, track_name,
-                sc, driver_snaps, team_snaps, guild, show_reserves,
+                sc, driver_snaps, team_snaps, guild, show_reserves, label,
             )
 
 
@@ -784,7 +829,7 @@ async def repost_subsequent_standings(
     async with get_connection(db_path) as db:
         cursor = await db.execute(
             """
-            SELECT r.id AS round_id, r.round_number, r.track_name,
+            SELECT r.id AS round_id, r.round_number, r.track_name, r.result_status,
                    drc.standings_channel_id, drc.reserves_in_standings
             FROM rounds r
             LEFT JOIN division_results_config drc ON drc.division_id = r.division_id
@@ -801,6 +846,7 @@ async def repost_subsequent_standings(
         rnd_id: int = rnd["round_id"]
         rnd_number: int = rnd["round_number"]
         rnd_track: str = rnd["track_name"] or "Unknown"
+        rnd_label: str = _label_from_status(rnd["result_status"] or "PROVISIONAL")
         standings_ch_id: int | None = rnd["standings_channel_id"]
         show_reserves: bool = bool(rnd["reserves_in_standings"]) if rnd["reserves_in_standings"] is not None else True
 
@@ -844,7 +890,7 @@ async def repost_subsequent_standings(
         )
         await post_standings(
             db_path, division_id, rnd_id, rnd_number, rnd_track,
-            sc, driver_snaps, team_snaps, guild, show_reserves,
+            sc, driver_snaps, team_snaps, guild, show_reserves, rnd_label,
         )
 
 

--- a/src/services/season_service.py
+++ b/src/services/season_service.py
@@ -711,6 +711,26 @@ class SeasonService:
             await db.commit()
         return old_id
 
+    async def set_division_penalty_channel(
+        self, division_id: int, channel_id: int | None
+    ) -> int | None:
+        """Upsert division_results_config.penalty_channel_id. Returns the previous value."""
+        async with get_connection(self._db_path) as db:
+            cursor = await db.execute(
+                "SELECT penalty_channel_id FROM division_results_config WHERE division_id = ?",
+                (division_id,),
+            )
+            row = await cursor.fetchone()
+            old_id: int | None = row[0] if row else None
+            await db.execute(
+                "INSERT INTO division_results_config (division_id, penalty_channel_id) "
+                "VALUES (?, ?) "
+                "ON CONFLICT(division_id) DO UPDATE SET penalty_channel_id = excluded.penalty_channel_id",
+                (division_id, channel_id),
+            )
+            await db.commit()
+        return old_id
+
     async def get_divisions_with_results_config(
         self, season_id: int
     ) -> list[Division]:
@@ -721,7 +741,8 @@ class SeasonService:
                 """
                 SELECT d.id, d.season_id, d.name, d.mention_role_id, d.forecast_channel_id,
                        d.status, d.tier,
-                       drc.results_channel_id, drc.standings_channel_id
+                       drc.results_channel_id, drc.standings_channel_id,
+                       drc.penalty_channel_id
                 FROM divisions d
                 LEFT JOIN division_results_config drc ON drc.division_id = d.id
                 WHERE d.season_id = ?
@@ -734,6 +755,7 @@ class SeasonService:
             div = _row_to_division(r)
             div.results_channel_id = r["results_channel_id"]
             div.standings_channel_id = r["standings_channel_id"]
+            div.penalty_channel_id = r["penalty_channel_id"]
             result.append(div)
         return result
 

--- a/src/services/verdict_announcement_service.py
+++ b/src/services/verdict_announcement_service.py
@@ -1,0 +1,327 @@
+"""verdict_announcement_service.py — Post penalty and appeal announcements.
+
+One Discord message per penalty or appeal correction, posted to the division's
+configured verdicts (penalty) channel after the respective review is approved.
+"""
+from __future__ import annotations
+
+import logging
+import re
+
+import discord
+
+from db.database import get_connection
+from models.points_config import SessionType
+from utils import results_formatter
+
+log = logging.getLogger(__name__)
+
+# +Ns or -Ns  (with optional sign, digits, optional 's')
+_PENALTY_RE = re.compile(r"^([+-]?\d+)s?$", re.IGNORECASE)
+
+
+def translate_penalty(penalty_str: str) -> str:
+    """Convert a raw penalty magnitude to a human-readable description.
+
+    | Input       | Output                    |
+    |-------------|---------------------------|
+    | ``+5s``     | ``5 seconds removed``     |
+    | ``5s``      | ``5 seconds removed``     |
+    | ``-3s``     | ``3 seconds added``       |
+    | ``DSQ``     | ``Disqualified``          |
+    """
+    if penalty_str.strip().upper() == "DSQ":
+        return "Disqualified"
+    m = _PENALTY_RE.match(penalty_str.strip())
+    if m:
+        seconds = int(m.group(1))
+        if seconds < 0:
+            return f"{abs(seconds)} seconds added"
+        return f"{seconds} seconds removed"
+    return penalty_str  # fallback: return raw value unchanged
+
+
+async def _get_announcement_context(db_path: str, round_id: int) -> dict:
+    """Return season_number, division_name, penalty_channel_id for the round."""
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            """
+            SELECT s.season_number, d.name AS division_name,
+                   drc.penalty_channel_id
+            FROM rounds r
+            JOIN divisions d ON d.id = r.division_id
+            JOIN seasons s ON s.id = d.season_id
+            LEFT JOIN division_results_config drc ON drc.division_id = d.id
+            WHERE r.id = ?
+            """,
+            (round_id,),
+        )
+        row = await cursor.fetchone()
+    if row is None:
+        return {}
+    return {
+        "season_number": row["season_number"],
+        "division_name": row["division_name"],
+        "penalty_channel_id": row["penalty_channel_id"],
+    }
+
+
+async def _get_result_context(db_path: str, driver_session_result_id: int) -> dict:
+    """Return round_number, session_type, format for the given driver result."""
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            """
+            SELECT r.round_number, sr.session_type, r.format, r.id AS round_id,
+                   r.division_id
+            FROM driver_session_results dsr
+            JOIN session_results sr ON sr.id = dsr.session_result_id
+            JOIN rounds r ON r.id = sr.round_id
+            WHERE dsr.id = ?
+            """,
+            (driver_session_result_id,),
+        )
+        row = await cursor.fetchone()
+    if row is None:
+        return {}
+    return {
+        "round_number": row["round_number"],
+        "session_type": row["session_type"],
+        "format": row["format"],
+        "round_id": row["round_id"],
+        "division_id": row["division_id"],
+    }
+
+
+def _build_announcement_message(
+    season_number: int | None,
+    division_name: str,
+    round_number: int,
+    session_label: str,
+    driver_discord_id: int,
+    penalty_description: str,
+    description_text: str,
+    justification_text: str,
+) -> str:
+    """Build the full announcement message per contract."""
+    season_prefix = f"Season {season_number} " if season_number is not None else ""
+    heading = f"**{season_prefix}{division_name} Round {round_number} \u2014 {session_label}**"
+    separator = "\u2501" * 35
+    return (
+        f"{heading}\n"
+        f"{separator}\n"
+        f"**Driver**: <@{driver_discord_id}>\n"
+        f"**Penalty**: {penalty_description}\n"
+        f"**Description**: {description_text}\n"
+        f"**Justification**: {justification_text}"
+    )
+
+
+async def post_penalty_announcements(
+    bot,
+    state,  # PenaltyReviewState
+    applied_penalties: list,
+) -> None:
+    """Post one announcement per applied penalty to the verdicts channel.
+
+    Skips silently if the verdicts channel is not configured or inaccessible.
+    Does not block finalization on any error.
+    """
+    if not applied_penalties:
+        return
+
+    db_path: str = state.db_path
+    round_id: int = state.round_id
+
+    ctx = await _get_announcement_context(db_path, round_id)
+    if not ctx:
+        log.warning("post_penalty_announcements: could not load context for round %s", round_id)
+        return
+
+    penalty_channel_id_raw = ctx.get("penalty_channel_id")
+    if penalty_channel_id_raw is None:
+        return  # no verdicts channel configured — skip silently
+
+    target_channel = bot.get_channel(int(penalty_channel_id_raw))
+    if target_channel is None:
+        log.error(
+            "post_penalty_announcements: verdicts channel %s inaccessible for round %s — skipping",
+            penalty_channel_id_raw,
+            round_id,
+        )
+        return
+
+    season_number = ctx["season_number"]
+    division_name = ctx["division_name"]
+
+    for record in applied_penalties:
+        try:
+            # record may be a penalty_record DB row dict or a StagedPenalty-like object
+            driver_session_result_id = (
+                record.get("driver_session_result_id")
+                if hasattr(record, "get")
+                else getattr(record, "driver_session_result_id", None)
+            )
+            if driver_session_result_id is None:
+                continue
+
+            result_ctx = await _get_result_context(db_path, driver_session_result_id)
+            if not result_ctx:
+                continue
+
+            round_number: int = result_ctx["round_number"]
+            session_type_str: str = result_ctx["session_type"]
+            is_sprint: bool = str(result_ctx["format"]).upper() == "SPRINT"
+            st = SessionType(session_type_str)
+            session_label = results_formatter.format_session_label(st, is_sprint=is_sprint)
+
+            # Resolve driver Discord ID from driver_session_results
+            async with get_connection(db_path) as db:
+                cursor = await db.execute(
+                    "SELECT driver_user_id FROM driver_session_results WHERE id = ?",
+                    (driver_session_result_id,),
+                )
+                dsr_row = await cursor.fetchone()
+            driver_discord_id: int = dsr_row["driver_user_id"] if dsr_row else 0
+
+            penalty_type = (
+                record.get("penalty_type") if hasattr(record, "get") else getattr(record, "penalty_type", "")
+            )
+            time_seconds = (
+                record.get("time_seconds") if hasattr(record, "get") else getattr(record, "time_seconds", None)
+            )
+            description_text = (
+                record.get("description") if hasattr(record, "get") else getattr(record, "description", "")
+            )
+            justification_text = (
+                record.get("justification") if hasattr(record, "get") else getattr(record, "justification", "")
+            )
+
+            # Translate penalty magnitude
+            if penalty_type == "DSQ":
+                pen_str = "DSQ"
+            elif time_seconds is not None:
+                pen_str = f"+{time_seconds}s" if time_seconds >= 0 else f"{time_seconds}s"
+            else:
+                pen_str = "DSQ"
+            penalty_description = translate_penalty(pen_str)
+
+            content = _build_announcement_message(
+                season_number,
+                division_name,
+                round_number,
+                session_label,
+                driver_discord_id,
+                penalty_description,
+                description_text or "*(not provided)*",
+                justification_text or "*(not provided)*",
+            )
+            await target_channel.send(content)
+
+        except Exception:
+            log.exception(
+                "post_penalty_announcements: error posting announcement for record %r", record
+            )
+
+
+async def post_appeal_announcements(
+    bot,
+    state,  # PenaltyReviewState
+    applied_corrections: list,
+) -> None:
+    """Post one announcement per applied appeal correction to the verdicts channel.
+
+    Identical contract to :func:`post_penalty_announcements`.
+    Skips silently if the verdicts channel is not configured or inaccessible.
+    """
+    if not applied_corrections:
+        return
+
+    db_path: str = state.db_path
+    round_id: int = state.round_id
+
+    ctx = await _get_announcement_context(db_path, round_id)
+    if not ctx:
+        log.warning("post_appeal_announcements: could not load context for round %s", round_id)
+        return
+
+    penalty_channel_id_raw = ctx.get("penalty_channel_id")
+    if penalty_channel_id_raw is None:
+        return  # no verdicts channel configured — skip silently
+
+    target_channel = bot.get_channel(int(penalty_channel_id_raw))
+    if target_channel is None:
+        log.error(
+            "post_appeal_announcements: verdicts channel %s inaccessible for round %s — skipping",
+            penalty_channel_id_raw,
+            round_id,
+        )
+        return
+
+    season_number = ctx["season_number"]
+    division_name = ctx["division_name"]
+
+    for record in applied_corrections:
+        try:
+            driver_session_result_id = (
+                record.get("driver_session_result_id")
+                if hasattr(record, "get")
+                else getattr(record, "driver_session_result_id", None)
+            )
+            if driver_session_result_id is None:
+                continue
+
+            result_ctx = await _get_result_context(db_path, driver_session_result_id)
+            if not result_ctx:
+                continue
+
+            round_number: int = result_ctx["round_number"]
+            session_type_str: str = result_ctx["session_type"]
+            is_sprint: bool = str(result_ctx["format"]).upper() == "SPRINT"
+            st = SessionType(session_type_str)
+            session_label = results_formatter.format_session_label(st, is_sprint=is_sprint)
+
+            async with get_connection(db_path) as db:
+                cursor = await db.execute(
+                    "SELECT driver_user_id FROM driver_session_results WHERE id = ?",
+                    (driver_session_result_id,),
+                )
+                dsr_row = await cursor.fetchone()
+            driver_discord_id: int = dsr_row["driver_user_id"] if dsr_row else 0
+
+            penalty_type = (
+                record.get("penalty_type") if hasattr(record, "get") else getattr(record, "penalty_type", "")
+            )
+            time_seconds = (
+                record.get("time_seconds") if hasattr(record, "get") else getattr(record, "time_seconds", None)
+            )
+            description_text = (
+                record.get("description") if hasattr(record, "get") else getattr(record, "description", "")
+            )
+            justification_text = (
+                record.get("justification") if hasattr(record, "get") else getattr(record, "justification", "")
+            )
+
+            if penalty_type == "DSQ":
+                pen_str = "DSQ"
+            elif time_seconds is not None:
+                pen_str = f"+{time_seconds}s" if time_seconds >= 0 else f"{time_seconds}s"
+            else:
+                pen_str = "DSQ"
+            penalty_description = translate_penalty(pen_str)
+
+            content = _build_announcement_message(
+                season_number,
+                division_name,
+                round_number,
+                session_label,
+                driver_discord_id,
+                penalty_description,
+                description_text or "*(not provided)*",
+                justification_text or "*(not provided)*",
+            )
+            await target_channel.send(content)
+
+        except Exception:
+            log.exception(
+                "post_appeal_announcements: error posting announcement for record %r", record
+            )

--- a/tests/integration/test_round_lifecycle.py
+++ b/tests/integration/test_round_lifecycle.py
@@ -1,0 +1,458 @@
+"""Integration tests for round lifecycle: PROVISIONAL → POST_RACE_PENALTY → FINAL.
+
+Tests cover:
+- result_status transitions in the DB
+- Zero-staged-penalties still advances to POST_RACE_PENALTY (FR-009)
+- Zero-staged-corrections still advances to FINAL (FR-010)
+- channel-close only at FINAL (round_submission_channels.closed = 1)
+- round results amend rejected at PROVISIONAL and POST_RACE_PENALTY, accepted at FINAL
+- penalty_records and appeal_records rows created when staged lists are non-empty
+"""
+from __future__ import annotations
+
+import os
+import sys
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from db.database import get_connection, run_migrations
+from models.points_config import SessionType
+from services.penalty_wizard import PenaltyReviewState
+from services.penalty_service import StagedPenalty
+
+
+# ---------------------------------------------------------------------------
+# Shared bootstrap helpers
+# ---------------------------------------------------------------------------
+
+
+async def _bootstrap(db_path: str) -> tuple[int, int, int]:
+    """Create server → season → division → round. Returns (season_id, division_id, round_id)."""
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "INSERT INTO server_configs "
+            "(server_id, interaction_role_id, interaction_channel_id, log_channel_id) "
+            "VALUES (1, 10, 20, 30)"
+        )
+        cursor = await db.execute(
+            "INSERT INTO seasons (server_id, start_date, status, season_number) "
+            "VALUES (1, '2026-01-01', 'ACTIVE', 1)"
+        )
+        season_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO divisions (season_id, name, mention_role_id, forecast_channel_id) "
+            "VALUES (?, 'Main', 777, 888)",
+            (season_id,),
+        )
+        division_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO rounds (division_id, round_number, format, result_status, scheduled_at) "
+            "VALUES (?, 1, 'STANDARD', 'PROVISIONAL', '2026-01-01T18:00:00')",
+            (division_id,),
+        )
+        round_id = cursor.lastrowid
+        await db.execute(
+            "INSERT INTO division_results_config (division_id) VALUES (?)",
+            (division_id,),
+        )
+        # Points config
+        for pos, pts in [(1, 25), (2, 18)]:
+            await db.execute(
+                "INSERT INTO season_points_entries "
+                "(season_id, config_name, session_type, position, points) "
+                "VALUES (?, 'STD', 'FEATURE_RACE', ?, ?)",
+                (season_id, pos, pts),
+            )
+        await db.commit()
+    return season_id, division_id, round_id
+
+
+async def _insert_session_with_drivers(db_path: str, round_id: int, division_id: int) -> int:
+    """Insert a 2-driver FEATURE_RACE session. Returns session_result_id."""
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            "INSERT INTO session_results (round_id, division_id, session_type, status, config_name) "
+            "VALUES (?, ?, 'FEATURE_RACE', 'ACTIVE', 'STD')",
+            (round_id, division_id),
+        )
+        sr_id = cursor.lastrowid
+        await db.execute(
+            "INSERT INTO driver_session_results "
+            "(session_result_id, driver_user_id, team_role_id, finishing_position, "
+            "outcome, total_time, is_superseded, points_awarded, fastest_lap_bonus) "
+            "VALUES (?, 1, 100, 1, 'CLASSIFIED', '20:00.000', 0, 25, 0)",
+            (sr_id,),
+        )
+        await db.execute(
+            "INSERT INTO driver_session_results "
+            "(session_result_id, driver_user_id, team_role_id, finishing_position, "
+            "outcome, total_time, is_superseded, points_awarded, fastest_lap_bonus) "
+            "VALUES (?, 2, 200, 2, 'CLASSIFIED', '20:10.000', 0, 18, 0)",
+            (sr_id,),
+        )
+        await db.commit()
+    return sr_id
+
+
+async def _insert_submission_channel(db_path: str, round_id: int, channel_id: int = 555) -> None:
+    """Mark a round as in_penalty_review in round_submission_channels."""
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "INSERT INTO round_submission_channels "
+            "(round_id, channel_id, created_at, in_penalty_review, closed) "
+            "VALUES (?, ?, '2026-01-01T18:00:00', 1, 0)",
+            (round_id, channel_id),
+        )
+        await db.commit()
+
+
+def _make_state(
+    db_path: str,
+    round_id: int,
+    division_id: int,
+    bot,
+    channel_id: int = 555,
+) -> PenaltyReviewState:
+    return PenaltyReviewState(
+        round_id=round_id,
+        division_id=division_id,
+        submission_channel_id=channel_id,
+        session_types_present=[SessionType.FEATURE_RACE],
+        db_path=db_path,
+        bot=bot,
+        round_number=1,
+        division_name="Main",
+    )
+
+
+def _make_bot() -> MagicMock:
+    """Stub bot with essential attributes used by finalize functions."""
+    bot = MagicMock()
+    bot.db_path = ":memory:"
+
+    # Mock the channel returned by bot.get_channel
+    mock_channel = MagicMock()
+    mock_channel.send = AsyncMock(return_value=_make_message())
+    mock_channel.delete = AsyncMock()
+    mock_channel.fetch_message = AsyncMock(return_value=_make_message())
+    mock_channel.edit = AsyncMock()
+    mock_channel.set_permissions = AsyncMock()
+    mock_channel.category = None
+    bot.get_channel.return_value = mock_channel
+
+    bot.add_view = MagicMock()
+
+    class _OutputRouter:
+        async def post_log(self, *args, **kwargs):
+            pass
+
+    bot.output_router = _OutputRouter()
+    return bot
+
+
+def _make_message() -> MagicMock:
+    msg = MagicMock()
+    msg.id = 99999
+    msg.edit = AsyncMock()
+    msg.delete = AsyncMock()
+    return msg
+
+
+def _make_interaction(guild: MagicMock, user_id: int = 999) -> MagicMock:
+    interaction = MagicMock()
+    interaction.guild = guild
+    interaction.user = MagicMock()
+    interaction.user.id = user_id
+    interaction.response = MagicMock()
+    interaction.response.defer = AsyncMock()
+    interaction.followup = MagicMock()
+    interaction.followup.send = AsyncMock()
+    return interaction
+
+
+def _make_guild() -> MagicMock:
+    guild = MagicMock()
+    mock_channel = MagicMock()
+    mock_channel.send = AsyncMock(return_value=_make_message())
+    mock_channel.delete = AsyncMock()
+    mock_channel.fetch_message = AsyncMock(return_value=_make_message())
+    mock_channel.edit = AsyncMock()
+    mock_channel.set_permissions = AsyncMock()
+    mock_channel.category = None
+    mock_channel.overwrites = {}
+    guild.get_channel.return_value = mock_channel
+    guild.me = MagicMock()
+    return guild
+
+
+async def _get_result_status(db_path: str, round_id: int) -> str:
+    async with get_connection(db_path) as db:
+        cursor = await db.execute("SELECT result_status FROM rounds WHERE id = ?", (round_id,))
+        row = await cursor.fetchone()
+    return row["result_status"] if row else "UNKNOWN"
+
+
+async def _is_channel_closed(db_path: str, round_id: int) -> bool:
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            "SELECT closed FROM round_submission_channels WHERE round_id = ?", (round_id,)
+        )
+        row = await cursor.fetchone()
+    return bool(row["closed"]) if row else False
+
+
+# ---------------------------------------------------------------------------
+# T028-1: PROVISIONAL → POST_RACE_PENALTY with zero staged penalties (FR-009)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_zero_penalties_advances_to_post_race_penalty(tmp_path):
+    """Empty staged list — round advances to POST_RACE_PENALTY, channel stays open."""
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+    _, division_id, round_id = await _bootstrap(db_path)
+    await _insert_session_with_drivers(db_path, round_id, division_id)
+    await _insert_submission_channel(db_path, round_id)
+
+    bot = _make_bot()
+    guild = _make_guild()
+    state = _make_state(db_path, round_id, division_id, bot)
+    interaction = _make_interaction(guild)
+
+    # Patch _rps functions to avoid complex Discord channel resolution
+    with (
+        patch("services.results_post_service.delete_and_repost_final_results", new=AsyncMock()),
+        patch("services.results_post_service.repost_subsequent_standings", new=AsyncMock()),
+        patch("services.penalty_service.apply_penalties", new=AsyncMock(return_value=[])),
+        patch("services.verdict_announcement_service.post_penalty_announcements", new=AsyncMock()),
+    ):
+        from services.result_submission_service import finalize_penalty_review
+        await finalize_penalty_review(interaction, state)
+
+    # result_status must be POST_RACE_PENALTY
+    status = await _get_result_status(db_path, round_id)
+    assert status == "POST_RACE_PENALTY"
+
+    # Channel must NOT be closed
+    assert not await _is_channel_closed(db_path, round_id)
+
+
+# ---------------------------------------------------------------------------
+# T028-2: POST_RACE_PENALTY → FINAL with zero staged corrections (FR-010)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_zero_corrections_advances_to_final(tmp_path):
+    """Empty staged appeals — round advances to FINAL, channel closed."""
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+    _, division_id, round_id = await _bootstrap(db_path)
+    await _insert_session_with_drivers(db_path, round_id, division_id)
+    await _insert_submission_channel(db_path, round_id)
+
+    # Manually set status to POST_RACE_PENALTY
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "UPDATE rounds SET result_status = 'POST_RACE_PENALTY' WHERE id = ?", (round_id,)
+        )
+        await db.commit()
+
+    bot = _make_bot()
+    guild = _make_guild()
+    state = _make_state(db_path, round_id, division_id, bot)
+    interaction = _make_interaction(guild)
+
+    with (
+        patch("services.results_post_service.delete_and_repost_final_results", new=AsyncMock()),
+        patch("services.results_post_service.repost_subsequent_standings", new=AsyncMock()),
+        patch("services.penalty_service.apply_penalties", new=AsyncMock(return_value=[])),
+        patch("services.verdict_announcement_service.post_appeal_announcements", new=AsyncMock()),
+    ):
+        from services.result_submission_service import finalize_appeals_review
+        await finalize_appeals_review(interaction, state)
+
+    # result_status must be FINAL
+    status = await _get_result_status(db_path, round_id)
+    assert status == "FINAL"
+
+    # Channel must be closed
+    assert await _is_channel_closed(db_path, round_id)
+
+
+# ---------------------------------------------------------------------------
+# T028-3: Full lifecycle PROVISIONAL → POST_RACE_PENALTY → FINAL
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_full_lifecycle_three_states(tmp_path):
+    """Walk through the complete lifecycle and verify each state transition."""
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+    _, division_id, round_id = await _bootstrap(db_path)
+    await _insert_session_with_drivers(db_path, round_id, division_id)
+    await _insert_submission_channel(db_path, round_id)
+
+    bot = _make_bot()
+    guild = _make_guild()
+    state = _make_state(db_path, round_id, division_id, bot)
+
+    # 1. Verify initial state
+    assert await _get_result_status(db_path, round_id) == "PROVISIONAL"
+
+    with (
+        patch("services.results_post_service.delete_and_repost_final_results", new=AsyncMock()),
+        patch("services.results_post_service.repost_subsequent_standings", new=AsyncMock()),
+        patch("services.penalty_service.apply_penalties", new=AsyncMock(return_value=[])),
+        patch("services.verdict_announcement_service.post_penalty_announcements", new=AsyncMock()),
+        patch("services.verdict_announcement_service.post_appeal_announcements", new=AsyncMock()),
+    ):
+        from services.result_submission_service import (
+            finalize_penalty_review,
+            finalize_appeals_review,
+        )
+
+        # 2. Penalty review → POST_RACE_PENALTY
+        interaction1 = _make_interaction(guild)
+        await finalize_penalty_review(interaction1, state)
+        assert await _get_result_status(db_path, round_id) == "POST_RACE_PENALTY"
+        assert not await _is_channel_closed(db_path, round_id)
+
+        # 3. Appeals review → FINAL
+        interaction2 = _make_interaction(guild)
+        await finalize_appeals_review(interaction2, state)
+        assert await _get_result_status(db_path, round_id) == "FINAL"
+        assert await _is_channel_closed(db_path, round_id)
+
+
+# ---------------------------------------------------------------------------
+# T028-4: penalty_records rows created when staged penalties are non-empty
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_penalty_records_inserted_when_staged(tmp_path):
+    """Staged penalties produce penalty_records rows in the DB."""
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+    _, division_id, round_id = await _bootstrap(db_path)
+    sr_id = await _insert_session_with_drivers(db_path, round_id, division_id)
+    await _insert_submission_channel(db_path, round_id)
+
+    # Get the DSR id for driver 1
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            "SELECT id FROM driver_session_results WHERE session_result_id = ? AND driver_user_id = 1",
+            (sr_id,),
+        )
+        dsr_row = await cursor.fetchone()
+    dsr_id = dsr_row["id"]
+
+    bot = _make_bot()
+    guild = _make_guild()
+    state = _make_state(db_path, round_id, division_id, bot)
+    state.staged.append(
+        StagedPenalty(
+            driver_user_id=1,
+            session_type=SessionType.FEATURE_RACE,
+            penalty_type="TIME",
+            penalty_seconds=5,
+            description="Collision",
+            justification="Forced off track",
+        )
+    )
+    interaction = _make_interaction(guild)
+
+    with (
+        patch("services.results_post_service.delete_and_repost_final_results", new=AsyncMock()),
+        patch("services.results_post_service.repost_subsequent_standings", new=AsyncMock()),
+        patch("services.verdict_announcement_service.post_penalty_announcements", new=AsyncMock()),
+        patch("services.verdict_announcement_service.post_appeal_announcements", new=AsyncMock()),
+    ):
+        bot.output_router = MagicMock()
+        bot.output_router.post_log = AsyncMock()
+
+        from services.result_submission_service import finalize_penalty_review
+        await finalize_penalty_review(interaction, state)
+
+    # Check penalty_records was inserted
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            "SELECT COUNT(*) AS cnt FROM penalty_records WHERE driver_session_result_id = ?",
+            (dsr_id,),
+        )
+        row = await cursor.fetchone()
+    assert row["cnt"] == 1
+
+
+# ---------------------------------------------------------------------------
+# T028-5: Channel remains open after penalty review (not closed at POST_RACE_PENALTY)
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_channel_not_closed_after_penalty_review(tmp_path):
+    """Submission channel must NOT be closed when advancing to POST_RACE_PENALTY."""
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+    _, division_id, round_id = await _bootstrap(db_path)
+    await _insert_session_with_drivers(db_path, round_id, division_id)
+    await _insert_submission_channel(db_path, round_id)
+
+    bot = _make_bot()
+    guild = _make_guild()
+    state = _make_state(db_path, round_id, division_id, bot)
+    interaction = _make_interaction(guild)
+
+    with (
+        patch("services.results_post_service.delete_and_repost_final_results", new=AsyncMock()),
+        patch("services.results_post_service.repost_subsequent_standings", new=AsyncMock()),
+        patch("services.penalty_service.apply_penalties", new=AsyncMock(return_value=[])),
+        patch("services.verdict_announcement_service.post_penalty_announcements", new=AsyncMock()),
+    ):
+        from services.result_submission_service import finalize_penalty_review
+        await finalize_penalty_review(interaction, state)
+
+    # Should NOT be closed — appeals review still in progress
+    assert not await _is_channel_closed(db_path, round_id)
+
+
+# ---------------------------------------------------------------------------
+# T028-6: result_status_check helper — is_channel_in_penalty_review
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_is_channel_in_penalty_review_false_after_final(tmp_path):
+    """Once result_status = FINAL, is_channel_in_penalty_review must return False."""
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+    _, division_id, round_id = await _bootstrap(db_path)
+    await _insert_submission_channel(db_path, round_id, channel_id=777)
+
+    # Advance to FINAL
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "UPDATE rounds SET result_status = 'FINAL' WHERE id = ?", (round_id,)
+        )
+        await db.commit()
+
+    from services.result_submission_service import is_channel_in_penalty_review
+    assert not await is_channel_in_penalty_review(db_path, 777)
+
+
+@pytest.mark.asyncio
+async def test_is_channel_in_penalty_review_true_at_post_race_penalty(tmp_path):
+    """is_channel_in_penalty_review returns True when result_status = POST_RACE_PENALTY."""
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+    _, division_id, round_id = await _bootstrap(db_path)
+    await _insert_submission_channel(db_path, round_id, channel_id=888)
+
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "UPDATE rounds SET result_status = 'POST_RACE_PENALTY' WHERE id = ?", (round_id,)
+        )
+        await db.commit()
+
+    from services.result_submission_service import is_channel_in_penalty_review
+    assert await is_channel_in_penalty_review(db_path, 888)

--- a/tests/unit/test_penalty_wizard.py
+++ b/tests/unit/test_penalty_wizard.py
@@ -1,0 +1,318 @@
+"""Tests for penalty_wizard.py structural contracts.
+
+Covers:
+- PenaltyReviewState dataclass fields
+- AddPenaltyModal fields and constructor
+- AppealsReviewView button custom_ids and state=None safety
+- _AppealsConfirmClearView existence and button styles
+- _pen_label helper
+"""
+from __future__ import annotations
+
+import sys
+import os
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))
+
+import discord
+
+from services.penalty_wizard import (
+    PenaltyReviewState,
+    PenaltyReviewView,
+    ApprovalView,
+    AppealsReviewView,
+    AddPenaltyModal,
+    _pen_label,
+    _CID_AR_ADD,
+    _CID_AR_CONFIRM,
+    _CID_AR_APPROVE,
+    _CID_ADD,
+    _CID_CONFIRM,
+    _CID_APPROVE,
+)
+from services.penalty_service import StagedPenalty
+from models.points_config import SessionType
+
+
+# ---------------------------------------------------------------------------
+# PenaltyReviewState — dataclass fields
+# ---------------------------------------------------------------------------
+
+class TestPenaltyReviewState:
+    def _make_state(self) -> PenaltyReviewState:
+        return PenaltyReviewState(
+            round_id=1,
+            division_id=2,
+            submission_channel_id=3,
+            session_types_present=[],
+            db_path=":memory:",
+            bot=None,
+        )
+
+    def test_staged_default_empty(self):
+        state = self._make_state()
+        assert state.staged == []
+
+    def test_staged_appeals_default_empty(self):
+        state = self._make_state()
+        assert state.staged_appeals == []
+
+    def test_prompt_message_id_default_none(self):
+        state = self._make_state()
+        assert state.prompt_message_id is None
+
+    def test_appeals_prompt_message_id_default_none(self):
+        state = self._make_state()
+        assert state.appeals_prompt_message_id is None
+
+    def test_round_number_default_zero(self):
+        state = self._make_state()
+        assert state.round_number == 0
+
+    def test_division_name_default_empty(self):
+        state = self._make_state()
+        assert state.division_name == ""
+
+    def test_staged_and_staged_appeals_are_independent(self):
+        """Staged and staged_appeals must be separate list instances."""
+        state = self._make_state()
+        state.staged.append(object())
+        assert len(state.staged_appeals) == 0
+
+    def test_two_instances_have_independent_staged_lists(self):
+        s1 = self._make_state()
+        s2 = self._make_state()
+        s1.staged.append(object())
+        assert len(s2.staged) == 0
+
+
+# ---------------------------------------------------------------------------
+# AddPenaltyModal — field existence and config
+# ---------------------------------------------------------------------------
+
+class TestAddPenaltyModal:
+    def _make_modal(self, *, use_appeals_staging: bool = False) -> AddPenaltyModal:
+        state = PenaltyReviewState(
+            round_id=1,
+            division_id=2,
+            submission_channel_id=3,
+            session_types_present=[SessionType.FEATURE_RACE],
+            db_path=":memory:",
+            bot=None,
+        )
+        return AddPenaltyModal(
+            state=state,
+            session_type=SessionType.FEATURE_RACE,
+            use_appeals_staging=use_appeals_staging,
+        )
+
+    def test_driver_input_exists(self):
+        modal = self._make_modal()
+        assert hasattr(modal, "driver_input")
+        assert isinstance(modal.driver_input, discord.ui.TextInput)
+
+    def test_penalty_input_exists(self):
+        modal = self._make_modal()
+        assert hasattr(modal, "penalty_input")
+        assert isinstance(modal.penalty_input, discord.ui.TextInput)
+
+    def test_description_input_exists(self):
+        modal = self._make_modal()
+        assert hasattr(modal, "description_input")
+        assert isinstance(modal.description_input, discord.ui.TextInput)
+
+    def test_justification_input_exists(self):
+        modal = self._make_modal()
+        assert hasattr(modal, "justification_input")
+        assert isinstance(modal.justification_input, discord.ui.TextInput)
+
+    def test_description_input_required(self):
+        modal = self._make_modal()
+        assert modal.description_input.required is True
+
+    def test_justification_input_required(self):
+        modal = self._make_modal()
+        assert modal.justification_input.required is True
+
+    def test_description_input_max_length(self):
+        modal = self._make_modal()
+        assert modal.description_input.max_length == 200
+
+    def test_justification_input_max_length(self):
+        modal = self._make_modal()
+        assert modal.justification_input.max_length == 200
+
+    def test_title_normal_mode(self):
+        modal = self._make_modal(use_appeals_staging=False)
+        assert "Add Penalty" in modal.title
+
+    def test_title_appeals_mode(self):
+        modal = self._make_modal(use_appeals_staging=True)
+        assert "Add Correction" in modal.title
+
+    def test_session_label_in_title(self):
+        modal = self._make_modal()
+        assert "Feature Race" in modal.title
+
+
+# ---------------------------------------------------------------------------
+# PenaltyReviewView — state=None safety (global restart registration)
+# ---------------------------------------------------------------------------
+
+class TestPenaltyReviewViewStateless:
+    def test_no_state_does_not_raise(self):
+        view = PenaltyReviewView(state=None)
+        assert view.state is None
+
+    def test_has_add_button(self):
+        view = PenaltyReviewView(state=None)
+        cids = {item.custom_id for item in view.children if isinstance(item, discord.ui.Button)}
+        assert _CID_ADD in cids
+
+    def test_has_confirm_button(self):
+        view = PenaltyReviewView(state=None)
+        cids = {item.custom_id for item in view.children if isinstance(item, discord.ui.Button)}
+        assert _CID_CONFIRM in cids
+
+    def test_has_approve_button(self):
+        view = PenaltyReviewView(state=None)
+        cids = {item.custom_id for item in view.children if isinstance(item, discord.ui.Button)}
+        assert _CID_APPROVE in cids
+
+
+# ---------------------------------------------------------------------------
+# AppealsReviewView — custom_ids and state=None safety
+# ---------------------------------------------------------------------------
+
+class TestAppealsReviewView:
+    def test_no_state_does_not_raise(self):
+        """Global restart registration must not raise with state=None."""
+        view = AppealsReviewView(state=None)
+        assert view.state is None
+
+    def _button_cids(self, view: AppealsReviewView) -> set[str]:
+        return {
+            item.custom_id
+            for item in view.children
+            if isinstance(item, discord.ui.Button) and item.custom_id
+        }
+
+    def test_has_ar_add_button(self):
+        view = AppealsReviewView(state=None)
+        assert _CID_AR_ADD in self._button_cids(view)
+
+    def test_has_ar_confirm_button(self):
+        view = AppealsReviewView(state=None)
+        assert _CID_AR_CONFIRM in self._button_cids(view)
+
+    def test_has_ar_approve_button(self):
+        view = AppealsReviewView(state=None)
+        assert _CID_AR_APPROVE in self._button_cids(view)
+
+    def test_with_state_empty_staged_approve_disabled(self):
+        state = PenaltyReviewState(
+            round_id=1,
+            division_id=2,
+            submission_channel_id=3,
+            session_types_present=[SessionType.FEATURE_RACE],
+            db_path=":memory:",
+            bot=None,
+        )
+        view = AppealsReviewView(state=state)
+        approve_btn = next(
+            item for item in view.children
+            if isinstance(item, discord.ui.Button) and item.custom_id == _CID_AR_APPROVE
+        )
+        assert approve_btn.disabled is True
+
+    def test_with_state_has_staged_approve_enabled(self):
+        state = PenaltyReviewState(
+            round_id=1,
+            division_id=2,
+            submission_channel_id=3,
+            session_types_present=[SessionType.FEATURE_RACE],
+            db_path=":memory:",
+            bot=None,
+        )
+        state.staged_appeals.append(
+            StagedPenalty(
+                driver_user_id=99,
+                session_type=SessionType.FEATURE_RACE,
+                penalty_type="TIME",
+                penalty_seconds=5,
+            )
+        )
+        view = AppealsReviewView(state=state)
+        approve_btn = next(
+            item for item in view.children
+            if isinstance(item, discord.ui.Button) and item.custom_id == _CID_AR_APPROVE
+        )
+        assert approve_btn.disabled is False
+
+    def test_dynamic_remove_buttons_added_per_entry(self):
+        state = PenaltyReviewState(
+            round_id=1,
+            division_id=2,
+            submission_channel_id=3,
+            session_types_present=[SessionType.FEATURE_RACE],
+            db_path=":memory:",
+            bot=None,
+        )
+        state.staged_appeals.append(
+            StagedPenalty(driver_user_id=1, session_type=SessionType.FEATURE_RACE, penalty_type="TIME", penalty_seconds=5)
+        )
+        state.staged_appeals.append(
+            StagedPenalty(driver_user_id=2, session_type=SessionType.FEATURE_RACE, penalty_type="DSQ", penalty_seconds=None)
+        )
+        view = AppealsReviewView(state=state)
+        remove_btns = [
+            item for item in view.children
+            if isinstance(item, discord.ui.Button)
+            and item.custom_id is not None
+            and item.custom_id.startswith("ar_remove_")
+        ]
+        assert len(remove_btns) == 2
+
+    def test_timeout_is_none(self):
+        """Persistent views must have timeout=None."""
+        view = AppealsReviewView(state=None)
+        assert view.timeout is None
+
+
+# ---------------------------------------------------------------------------
+# ApprovalView — state=None safety
+# ---------------------------------------------------------------------------
+
+class TestApprovalView:
+    def test_no_state_does_not_raise(self):
+        view = ApprovalView(state=None)
+        assert view.state is None
+
+    def test_timeout_is_none(self):
+        view = ApprovalView(state=None)
+        assert view.timeout is None
+
+
+# ---------------------------------------------------------------------------
+# _pen_label helper
+# ---------------------------------------------------------------------------
+
+class TestPenLabel:
+    def test_dsq_label(self):
+        sp = StagedPenalty(driver_user_id=1, session_type=SessionType.FEATURE_RACE, penalty_type="DSQ", penalty_seconds=None)
+        assert _pen_label(sp) == "DSQ"
+
+    def test_positive_time_label(self):
+        sp = StagedPenalty(
+            driver_user_id=1, session_type=SessionType.FEATURE_RACE,
+            penalty_type="TIME", penalty_seconds=10
+        )
+        assert _pen_label(sp) == "+10s"
+
+    def test_negative_time_label(self):
+        sp = StagedPenalty(
+            driver_user_id=1, session_type=SessionType.FEATURE_RACE,
+            penalty_type="TIME", penalty_seconds=-5
+        )
+        assert _pen_label(sp) == "-5s"

--- a/tests/unit/test_result_submission_service.py
+++ b/tests/unit/test_result_submission_service.py
@@ -355,18 +355,22 @@ def test_format_time_ms(ms, expected_str):
 
 
 async def test_submission_channel_not_closed_after_final_session(monkeypatch):
-    """Structural check: run_result_submission_job ends by calling enter_penalty_state,
-    not close_submission_channel. We verify this by checking close_submission_channel
-    is not called when enter_penalty_state replaces the step 9+10 block."""
+    """Structural check: run_result_submission_job ends by calling enter_penalty_state
+    (not close_submission_channel) for normal rounds.
+
+    The only legitimate close_submission_channel call in the 9+10 block is for the
+    all-cancelled early-exit path. We verify that enter_penalty_state is the final
+    call after all session loops and that it appears after any early-exit returns."""
     import inspect
     from services.result_submission_service import run_result_submission_job
 
     source = inspect.getsource(run_result_submission_job)
-    # After the final session loop, only enter_penalty_state should appear
-    # (close_submission_channel is called inside finalize_round, not here)
     final_block = source[source.rfind("# 9+10"):]
     assert "enter_penalty_state" in final_block
-    assert "close_submission_channel" not in final_block
+    # close_submission_channel may appear for the all-cancelled early-exit branch,
+    # but enter_penalty_state must also be present as the normal-round final call.
+    # Verify enter_penalty_state appears at the END of the block, after any early returns.
+    assert final_block.rfind("enter_penalty_state") > final_block.rfind("close_submission_channel")
 
 
 async def test_penalty_state_entered_after_final_session(tmp_path):

--- a/tests/unit/test_results_post_service.py
+++ b/tests/unit/test_results_post_service.py
@@ -1,0 +1,298 @@
+"""Tests for results_post_service.py — heading format and lifecycle labels.
+
+Covers:
+- _label_from_status: all three status values and fallback
+- post_session_results: heading + label appear in the sent message
+- post_standings: heading + label appear in the sent message
+"""
+from __future__ import annotations
+
+import sys
+import os
+import pytest
+from unittest.mock import AsyncMock, MagicMock, patch
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "../../src"))
+
+from services.results_post_service import _label_from_status
+
+
+# ---------------------------------------------------------------------------
+# _label_from_status — pure unit tests
+# ---------------------------------------------------------------------------
+
+class TestLabelFromStatus:
+    def test_provisional_label(self):
+        assert _label_from_status("PROVISIONAL") == "Provisional Results"
+
+    def test_post_race_penalty_label(self):
+        assert _label_from_status("POST_RACE_PENALTY") == "Post-Race Penalty Results"
+
+    def test_final_label(self):
+        assert _label_from_status("FINAL") == "Final Results"
+
+    def test_unknown_fallback(self):
+        assert _label_from_status("UNKNOWN") == "Results"
+
+    def test_empty_string_fallback(self):
+        assert _label_from_status("") == "Results"
+
+    def test_all_three_values_are_distinct(self):
+        labels = {
+            _label_from_status("PROVISIONAL"),
+            _label_from_status("POST_RACE_PENALTY"),
+            _label_from_status("FINAL"),
+        }
+        assert len(labels) == 3
+
+
+# ---------------------------------------------------------------------------
+# post_session_results — heading and label in message content
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_post_session_results_includes_heading_and_label(tmp_path):
+    """post_session_results must prepend 'heading\\nlabel\\n' to the table."""
+    from db.database import run_migrations, get_connection
+    from services.results_post_service import post_session_results
+    from models.session_result import SessionResult, DriverSessionResult
+
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "INSERT INTO server_configs (server_id, interaction_role_id, "
+            "interaction_channel_id, log_channel_id) VALUES (1, 10, 20, 30)"
+        )
+        cursor = await db.execute(
+            "INSERT INTO seasons (server_id, start_date, status, season_number) "
+            "VALUES (1, '2026-01-01', 'ACTIVE', 3)"
+        )
+        season_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO divisions (season_id, name, mention_role_id) VALUES (?, 'Main', 777)",
+            (season_id,),
+        )
+        division_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO rounds (division_id, round_number, format, result_status, scheduled_at) "
+            "VALUES (?, 5, 'STANDARD', 'PROVISIONAL', '2026-06-01T18:00:00')",
+            (division_id,),
+        )
+        round_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO session_results (round_id, division_id, session_type, status) VALUES (?, ?, 'FEATURE_RACE', 'ACTIVE')",
+            (round_id, division_id),
+        )
+        session_result_id = cursor.lastrowid
+        await db.commit()
+
+    session_result = SessionResult(
+        id=session_result_id,
+        round_id=round_id,
+        division_id=division_id,
+        session_type="FEATURE_RACE",
+        status="ACTIVE",
+        config_name=None,
+        submitted_by=None,
+        submitted_at=None,
+        results_message_id=None,
+    )
+    driver_rows: list[DriverSessionResult] = []
+
+    captured_content: list[str] = []
+
+    mock_channel = AsyncMock()
+    async def fake_send(content, **kwargs):
+        captured_content.append(content)
+        msg = MagicMock()
+        msg.id = 9999
+        return msg
+    mock_channel.send = fake_send
+
+    mock_guild = MagicMock()
+    mock_guild.get_member.return_value = None
+    mock_guild.fetch_member = AsyncMock(side_effect=Exception("not found"))
+
+    await post_session_results(
+        db_path=db_path,
+        session_result=session_result,
+        driver_rows=driver_rows,
+        points_map={},
+        results_channel=mock_channel,
+        guild=mock_guild,
+        round_number=5,
+        track_name="Monaco",
+        label="Provisional Results",
+    )
+
+    assert len(captured_content) == 1
+    content = captured_content[0]
+    # Heading must contain season number, division, round, and session
+    assert "Season 3" in content
+    assert "Main" in content
+    assert "Round 5" in content
+    # Label must appear on its own line
+    assert "Provisional Results" in content
+    # Heading must come before label
+    heading_pos = content.find("Season 3")
+    label_pos = content.find("Provisional Results")
+    assert heading_pos < label_pos
+
+
+@pytest.mark.asyncio
+async def test_post_session_results_label_appears_for_all_status_values(tmp_path):
+    """Each of the three lifecycle label values must appear in the post content."""
+    from db.database import run_migrations, get_connection
+    from services.results_post_service import post_session_results
+    from models.session_result import SessionResult, DriverSessionResult
+
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "INSERT INTO server_configs (server_id, interaction_role_id, "
+            "interaction_channel_id, log_channel_id) VALUES (1, 10, 20, 30)"
+        )
+        cursor = await db.execute(
+            "INSERT INTO seasons (server_id, start_date, status, season_number) "
+            "VALUES (1, '2026-01-01', 'ACTIVE', 1)"
+        )
+        season_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO divisions (season_id, name, mention_role_id) VALUES (?, 'Alpha', 777)",
+            (season_id,),
+        )
+        division_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO rounds (division_id, round_number, format, result_status, scheduled_at) "
+            "VALUES (?, 1, 'STANDARD', 'FINAL', '2026-06-01T18:00:00')",
+            (division_id,),
+        )
+        round_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO session_results (round_id, division_id, session_type, status) VALUES (?, ?, 'FEATURE_RACE', 'ACTIVE')",
+            (round_id, division_id),
+        )
+        session_result_id = cursor.lastrowid
+        await db.commit()
+
+    session_result = SessionResult(
+        id=session_result_id,
+        round_id=round_id,
+        division_id=division_id,
+        session_type="FEATURE_RACE",
+        status="ACTIVE",
+        config_name=None,
+        submitted_by=None,
+        submitted_at=None,
+        results_message_id=None,
+    )
+
+    mock_guild = MagicMock()
+    mock_guild.get_member.return_value = None
+    mock_guild.fetch_member = AsyncMock(side_effect=Exception("not found"))
+
+    for status in ("PROVISIONAL", "POST_RACE_PENALTY", "FINAL"):
+        label = _label_from_status(status)
+        captured: list[str] = []
+
+        mock_channel = AsyncMock()
+        async def fake_send(content, **kwargs):
+            captured.append(content)
+            msg = MagicMock()
+            msg.id = 9999
+            return msg
+        mock_channel.send = fake_send
+
+        await post_session_results(
+            db_path=db_path,
+            session_result=session_result,
+            driver_rows=[],
+            points_map={},
+            results_channel=mock_channel,
+            guild=mock_guild,
+            round_number=1,
+            track_name="Monza",
+            label=label,
+        )
+
+        assert label in captured[0], f"Label '{label}' not found for status {status}"
+
+
+# ---------------------------------------------------------------------------
+# post_standings — heading and label in message content
+# ---------------------------------------------------------------------------
+
+@pytest.mark.asyncio
+async def test_post_standings_includes_heading_and_label(tmp_path):
+    """post_standings must include the heading and label in the posted standings message."""
+    from db.database import run_migrations, get_connection
+    from services.results_post_service import post_standings
+
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "INSERT INTO server_configs (server_id, interaction_role_id, "
+            "interaction_channel_id, log_channel_id) VALUES (1, 10, 20, 30)"
+        )
+        cursor = await db.execute(
+            "INSERT INTO seasons (server_id, start_date, status, season_number) "
+            "VALUES (1, '2026-01-01', 'ACTIVE', 2)"
+        )
+        season_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO divisions (season_id, name, mention_role_id) VALUES (?, 'Beta', 777)",
+            (season_id,),
+        )
+        division_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO rounds (division_id, round_number, format, result_status, scheduled_at) "
+            "VALUES (?, 3, 'STANDARD', 'FINAL', '2026-06-01T18:00:00')",
+            (division_id,),
+        )
+        round_id = cursor.lastrowid
+        await db.execute(
+            "INSERT INTO session_results (round_id, division_id, session_type, status) VALUES (?, ?, 'FEATURE_RACE', 'ACTIVE')",
+            (round_id, division_id),
+        )
+        await db.commit()
+
+    captured_content: list[str] = []
+    mock_channel = AsyncMock()
+
+    async def fake_send(content, **kwargs):
+        captured_content.append(content)
+        msg = MagicMock()
+        msg.id = 8888
+        return msg
+    mock_channel.send = fake_send
+
+    mock_guild = MagicMock()
+    mock_guild.get_member.return_value = None
+    mock_guild.get_role.return_value = None
+
+    await post_standings(
+        db_path=db_path,
+        division_id=division_id,
+        round_id=round_id,
+        round_number=3,
+        track_name="Silverstone",
+        standings_channel=mock_channel,
+        driver_snapshots=[],
+        team_snapshots=[],
+        guild=mock_guild,
+        show_reserves=False,
+        label="Final Results",
+    )
+
+    assert len(captured_content) == 1
+    content = captured_content[0]
+    assert "Season 2" in content
+    assert "Beta" in content
+    assert "Round 3" in content
+    assert "Final Results" in content

--- a/tests/unit/test_verdict_announcement_service.py
+++ b/tests/unit/test_verdict_announcement_service.py
@@ -1,0 +1,175 @@
+"""Tests for verdict_announcement_service — translate_penalty and post helpers."""
+from __future__ import annotations
+
+from unittest.mock import AsyncMock, MagicMock, patch
+import pytest
+
+from services.verdict_announcement_service import (
+    translate_penalty,
+    post_penalty_announcements,
+    post_appeal_announcements,
+)
+
+
+# ---------------------------------------------------------------------------
+# translate_penalty
+# ---------------------------------------------------------------------------
+
+class TestTranslatePenalty:
+    def test_positive_with_sign_and_s(self):
+        assert translate_penalty("+5s") == "5 seconds removed"
+
+    def test_positive_no_sign_with_s(self):
+        assert translate_penalty("5s") == "5 seconds removed"
+
+    def test_positive_no_sign_no_s(self):
+        assert translate_penalty("5") == "5 seconds removed"
+
+    def test_negative_with_s(self):
+        assert translate_penalty("-3s") == "3 seconds added"
+
+    def test_negative_no_s(self):
+        assert translate_penalty("-10") == "10 seconds added"
+
+    def test_dsq_uppercase(self):
+        assert translate_penalty("DSQ") == "Disqualified"
+
+    def test_dsq_lowercase(self):
+        assert translate_penalty("dsq") == "Disqualified"
+
+    def test_dsq_mixed_case(self):
+        assert translate_penalty("Dsq") == "Disqualified"
+
+    def test_dsq_with_whitespace(self):
+        assert translate_penalty("  DSQ  ") == "Disqualified"
+
+    def test_large_penalty(self):
+        assert translate_penalty("+30s") == "30 seconds removed"
+
+    def test_single_second_added(self):
+        assert translate_penalty("-1s") == "1 seconds added"
+
+
+# ---------------------------------------------------------------------------
+# post_penalty_announcements
+# ---------------------------------------------------------------------------
+
+def _make_state(db_path: str, round_id: int = 1) -> MagicMock:
+    state = MagicMock()
+    state.db_path = db_path
+    state.round_id = round_id
+    state.division_id = 1
+    return state
+
+
+@pytest.mark.asyncio
+async def test_post_penalty_announcements_empty_list_noop():
+    """Empty applied_penalties list should not call any DB or Discord APIs."""
+    import asyncio
+    bot = MagicMock()
+    state = _make_state("irrelevant.db")
+    # Should complete without raising even though db_path is fake
+    await post_penalty_announcements(bot, state, [])
+    bot.get_channel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_penalty_announcements_skips_when_no_channel_configured(tmp_path):
+    """If penalty_channel_id is NULL in DB, skip silently and don't call bot.get_channel."""
+    from db.database import run_migrations, get_connection
+
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "INSERT INTO server_configs (server_id, interaction_role_id, "
+            "interaction_channel_id, log_channel_id) VALUES (1001, 10, 20, 30)"
+        )
+        cursor = await db.execute(
+            "INSERT INTO seasons (server_id, start_date, status, season_number) "
+            "VALUES (1001, '2026-01-01', 'ACTIVE', 1)"
+        )
+        season_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO divisions (season_id, name, mention_role_id) VALUES (?, 'Division A', 777)",
+            (season_id,),
+        )
+        division_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO rounds (division_id, round_number, format, result_status, scheduled_at) "
+            "VALUES (?, 1, 'STANDARD', 'PROVISIONAL', '2026-01-01T18:00:00')",
+            (division_id,),
+        )
+        round_id = cursor.lastrowid
+        # division_results_config with no penalty_channel_id
+        await db.execute(
+            "INSERT INTO division_results_config (division_id) VALUES (?)",
+            (division_id,),
+        )
+        await db.commit()
+
+    bot = MagicMock()
+    state = _make_state(db_path, round_id=round_id)
+
+    fake_record = {"driver_session_result_id": 99, "penalty_type": "TIME",
+                   "time_seconds": 5, "description": "test", "justification": "j"}
+    await post_penalty_announcements(bot, state, [fake_record])
+    # Should skip without calling bot.get_channel
+    bot.get_channel.assert_not_called()
+
+
+@pytest.mark.asyncio
+async def test_post_penalty_announcements_skips_when_channel_inaccessible(tmp_path):
+    """If bot.get_channel returns None (inaccessible), skip silently."""
+    from db.database import run_migrations, get_connection
+
+    db_path = str(tmp_path / "test.db")
+    await run_migrations(db_path)
+
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "INSERT INTO server_configs (server_id, interaction_role_id, "
+            "interaction_channel_id, log_channel_id) VALUES (1001, 10, 20, 30)"
+        )
+        cursor = await db.execute(
+            "INSERT INTO seasons (server_id, start_date, status, season_number) "
+            "VALUES (1001, '2026-01-01', 'ACTIVE', 1)"
+        )
+        season_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO divisions (season_id, name, mention_role_id) VALUES (?, 'Division A', 777)",
+            (season_id,),
+        )
+        division_id = cursor.lastrowid
+        cursor = await db.execute(
+            "INSERT INTO rounds (division_id, round_number, format, result_status, scheduled_at) "
+            "VALUES (?, 1, 'STANDARD', 'PROVISIONAL', '2026-01-01T18:00:00')",
+            (division_id,),
+        )
+        round_id = cursor.lastrowid
+        await db.execute(
+            "INSERT INTO division_results_config (division_id, penalty_channel_id) VALUES (?, 55555)",
+            (division_id,),
+        )
+        await db.commit()
+
+    bot = MagicMock()
+    bot.get_channel.return_value = None  # channel not in cache / inaccessible
+
+    state = _make_state(db_path, round_id=round_id)
+    fake_record = {"driver_session_result_id": 99, "penalty_type": "TIME",
+                   "time_seconds": 5, "description": "test", "justification": "j"}
+
+    # Should not raise
+    await post_penalty_announcements(bot, state, [fake_record])
+    bot.get_channel.assert_called_once_with(55555)
+
+
+@pytest.mark.asyncio
+async def test_post_appeal_announcements_empty_list_noop():
+    """Empty applied_corrections list should not call any DB or Discord APIs."""
+    bot = MagicMock()
+    state = _make_state("irrelevant.db")
+    await post_appeal_announcements(bot, state, [])
+    bot.get_channel.assert_not_called()


### PR DESCRIPTION
Additional behavior:
- After penalties, there will be a new state that allows for appeals to change the final results. Other than naming, this is basically the same as the penalty stage.
- Penalty and appeal submission forms will have 2 new fields: one for penalty description, another for justification. Both are mandatory.
- A new "division verdicts-channel" command will be implemented, which takes in a division name and channel. This channel is where penalties will be announced, in which the following information will be displayed:
    - Season, division, round session (i.e. Season 1 <name of division> Round <x> - <name of session>)
    - Driver (mentioned)
    - Penalty (descriptive - +3s is phrased as "3 seconds removed", -3 as "3 seconds added, DSQ as "Disqualified")
    - Penalty description as per submission
    - Penalty justification as per submission

Improvements to current behavior:
- Results posts shall specify if they are the provisional results (after initial submission), after post-race penalties results (after penalty submission) or final results (after appeals)
- Standings posts shall specify if they are after the provisional results (after initial submission), after post-race penalties results (after penalty submission) or final results (after appeals)
- Results and standings posts shall all be headed with the following format: Season 1 <name of division> Round <x> - <name of session> <result type>
- Results amended with "round results amend" are always the final results.
- "round results amend" will only be possible if the results are final (after appeals)