### PR TITLE
029 results weather improvements

### DIFF
--- a/.github/agents/copilot-instructions.md
+++ b/.github/agents/copilot-instructions.md
@@ -29,4 +29,27 @@ Python 3.13.2 (targets 3.8+): Follow standard conventions
 - 002-test-mode: Added Python 3.13.2 (targets 3.8+) + discord.py 2.7.1, aiosqlite ≥ 0.19, APScheduler ≥ 3.10
 
 <!-- MANUAL ADDITIONS START -->
+## Feature 029: Results Resubmission & Weather Phase Configurability
+
+### New files
+- `src/cogs/weather_cog.py` — `/weather` app_commands.Group with nested `config` subgroup; three `phase-N-deadline` subcommands
+- `src/models/weather_config.py` — `WeatherPipelineConfig` dataclass (phase_1_days, phase_2_days, phase_3_hours)
+- `src/services/weather_config_service.py` — CRUD for `weather_pipeline_config`; ordering validation helper
+- `src/db/migrations/028_weather_pipeline_config.sql` — adds `weather_pipeline_config` table
+- `tests/unit/test_weather_config_service.py`
+- `tests/integration/test_weather_config_flow.py`
+
+### Modified files
+- `src/services/penalty_wizard.py` — add `pw_resubmit` button + `_CID_RESUBMIT` constant to `PenaltyReviewView`
+- `src/services/result_submission_service.py` — add `enter_resubmit_flow()`; add `is_resubmission` param to `enter_penalty_state()`
+- `src/services/scheduler_service.py` — `schedule_round()` accepts `phase_1_days`, `phase_2_days`, `phase_3_hours` kwargs (defaults 5/2/2)
+- `src/bot.py` — register `WeatherCog`; pass `WeatherPipelineConfig` values to `schedule_round()` calls
+
+### Key rules for this feature
+- Ordering invariant for phase deadlines: `phase_1_days × 24 > phase_2_days × 24 > phase_3_hours` (strict). Validated before any DB write; reject with explanation naming the conflicting current value.
+- Phase deadline commands are rejected if `season_service.get_active_season()` returns non-None.
+- `schedule_round()` must keep existing behaviour when called without phase kwargs (default values = 5/2/2).
+- `pw_resubmit` button: same LM auth gate as other `PenaltyReviewView` buttons; state=None safety required.
+- Resubmit flow supersedes existing `DriverSessionResult` rows (`is_superseded = 1`) before re-entry; does NOT delete audit log entries.
+- Amended provisional results label: `"Provisional Results (amended)"` — passed via existing `label` param to `post_round_results` and `post_standings`.
 <!-- MANUAL ADDITIONS END -->

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,44 @@
 <!--
 SYNC IMPACT REPORT
 ==================
+[2026-04-02 — Session start: Results & Weather improvements — feature branch created]
+  - Constitution footer corrected from v2.7.0 to v2.8.0. The body already contained
+    v2.8.0 amendments (New Entities v2.8.0, Principle XI v2.8.0 notes) applied during the
+    028-season-signup-flow session; the footer was inadvertently not updated at that time.
+    Last Amended date updated to 2026-04-02 to reflect this correction.
+  - Version bump rationale: no governance content changes this entry; footer is a
+    PATCH-level correction restoring accurate versioning (body and footer now agree at v2.8.0).
+  - Session intent: make targeted improvements to two existing optional modules:
+      1. Results & Standings module — improvements to flexibility and error tolerance
+         (e.g., ability to correct or amend initial submission mistakes more easily).
+      2. Weather generation module — behavioral flexibility improvements
+         (e.g., configurable or more tolerant pipeline behavior).
+    Exact scope to be defined via speckit.specify before implementation begins.
+  - Feature branch: 029-results-weather-improvements (created 2026-04-02 from main).
+  - Implementation status at session start (post-028 merge):
+      ✅ 028-season-signup-flow — fully merged to main (2026-04-02).
+         Covers: signup close-timer scope narrowed to PENDING_SIGNUP_COMPLETION only;
+         lineup_channel_id and calendar_channel_id moved to divisions table;
+         lineup_message_id added to divisions; /division calendar-channel no longer
+         module-gated.
+  - All placeholder tokens remain resolved; constitution is fully resolved at v2.8.0.
+  - No principle amendments required at session start; constitution will be re-evaluated
+    and amended once the scope of each module improvement is formally defined.
+  - All templates confirmed aligned with Principles I–XII:
+      ✅ .specify/templates/plan-template.md       — dynamic Constitution Check; no changes.
+      ✅ .specify/templates/spec-template.md       — generic structure; no stale references.
+      ✅ .specify/templates/tasks-template.md      — generic; aligns with I–XII.
+      ✅ .specify/templates/agent-file-template.md — generic placeholders; no stale names.
+      ✅ .specify/templates/checklist-template.md  — no impact.
+  - Deferred TODOs (carried from v2.7.0):
+      - Exact command naming for appeal submission and review commands to be confirmed
+        against the 026-penalty-posting-appeals implementation.
+      - Whether the existing penalty wizard loose-text fields on DriverSessionResult
+        (post_race_time_penalties, post_stewarding_total_time) have been superseded by
+        PenaltyRecord rows — migration confirmation required.
+  - Pending: user to define exact scope of results and weather improvements; constitution
+    will be re-evaluated and amended once any new governance requirements are identified.
+
 [2025-07-01 — v2.7.0 → v2.8.0: Season-signup flow alignment — close-timer scope + channel ownership]
   Version change    : 2.7.0 → 2.8.0
   Bump rationale    : MINOR — Two targeted amendments to Principle XI (Signup Wizard Integrity):
@@ -1737,4 +1775,4 @@ before merge. Any deliberate violation of a principle MUST be documented in the 
 Complexity Tracking table with a justification for why the simpler compliant path is
 insufficient.
 
-**Version**: 2.7.0 | **Ratified**: 2026-03-03 | **Last Amended**: 2026-03-29
+**Version**: 2.8.0 | **Ratified**: 2026-03-03 | **Last Amended**: 2026-04-02

--- a/specs/029-results-weather-improvements/checklists/requirements.md
+++ b/specs/029-results-weather-improvements/checklists/requirements.md
@@ -1,0 +1,38 @@
+# Specification Quality Checklist: Results Resubmission & Weather Phase Configurability
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-02  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- **Phase 2 unit**: Confirmed by the project owner as **days**. The ordering rule `P1×24 > P2×24 > P3` (P1 and P2 in days, P3 in hours) is correctly reflected in the spec.
+- **Constitution amendments required before planning**:
+  1. **Principle IV (Three-Phase Weather Pipeline) — MINOR**: Principle IV hardcodes phase horizons as T−5d / T−2d / T−2h and marks them "NON-NEGOTIABLE". This feature makes those horizons server-configurable. The principle must be amended to: (a) describe the horizons as server-configurable with mandatory defaults of 5d / 2d / 2h; (b) codify the ordering invariant (P1×24 > P2×24 > P3, strict) as the non-negotiable constraint; (c) restrict deadline changes to periods outside an ACTIVE season; and (d) introduce the `WeatherPipelineConfig` entity in the Data & State Management section. The three-phase sequential structure itself remains non-negotiable.
+  2. **Principle XII (Amendment & Penalty) — PATCH**: The current amendment clause covers full re-entry and targeted penalty application but does not explicitly govern the new in-wizard hotfix resubmission path. A patch amendment is needed to: (a) name the "Resubmit Initial Results" hotfix as a permitted in-wizard action distinct from a post-finalization amendment; (b) mandate staged-penalty discard on resubmission; and (c) require the "(amended)" marker on the updated provisional results post.
+  Both amendments must be ratified in the constitution before `speckit.plan` is run.

--- a/specs/029-results-weather-improvements/contracts/commands.md
+++ b/specs/029-results-weather-improvements/contracts/commands.md
@@ -1,0 +1,122 @@
+# Command Contracts: Results Resubmission & Weather Phase Configurability
+
+**Feature**: `029-results-weather-improvements`  
+**Date**: 2026-04-02  
+**Convention**: All commands follow `/domain action [subaction] [params]` per Bot Behavior Standards.
+
+---
+
+## New Button: "🔄 Resubmit Initial Results"
+
+Not a slash command — a Discord UI button inside the `PenaltyReviewView`.
+
+| Attribute | Value |
+|---|---|
+| Label | `🔄 Resubmit Initial Results` |
+| Style | `ButtonStyle.danger` |
+| `custom_id` | `pw_resubmit` |
+| Row | 0 (alongside Add Penalty / No Penalties / Approve) |
+| Access | League managers only (same gate as other `PenaltyReviewView` buttons) |
+| Availability | Present from when `PenaltyReviewView` is first posted until the penalty wizard is approved/finalised. **Not** present in `AppealsReviewView`. |
+
+**Interaction flow**:
+1. Bot defers the interaction (ephemeral).
+2. Staged penalty discard audit log entry is written.
+3. Existing `DriverSessionResult` rows for the round are superseded.
+4. `session_results` rows are reset / deleted.
+5. `round_submission_channels` columns `in_penalty_review` and `results_posted` reset to 0.
+6. Bot posts a resubmission notice to the submission channel.
+7. First-session collection prompt is re-posted (exactly as on original submission start).
+8. On re-submission completion, `enter_penalty_state` is called with `is_resubmission=True`, which triggers posting with label `"Provisional Results (amended)"`.
+
+**Error cases**:
+- If `state is None` (bot restarted): bot sends ephemeral "⚠️ The bot was restarted. Please wait for the penalty prompt to refresh."
+- If actor is not a league manager: ephemeral "⛔ Only league managers can interact with the penalty review."
+
+---
+
+## New Slash Commands: `/weather config phase-*-deadline`
+
+All three commands live under a new subgroup: `/weather config`.
+
+> **New cog required**: A `WeatherCog` (or equivalent `weather_group` added to an existing cog) must expose the `/weather` top-level group. Given that no `/weather` group currently exists, a new `src/cogs/weather_cog.py` is needed. The three `phase-N-deadline` commands are subcommands of a `config` subgroup within it.
+
+### `/weather config phase-1-deadline <days>`
+
+| Attribute | Value |
+|---|---|
+| Group | `/weather config` |
+| Parameter | `days: int` — positive integer, number of days |
+| Access | Tier-2 admin (league manager role, Principle I) |
+| Response | Ephemeral |
+| Module gate | Weather module must be enabled |
+
+**Pre-conditions / validation** (checked in order, first failure wins):
+1. Weather module is enabled — error: "❌ The weather module is not enabled."
+2. No ACTIVE season — error: "❌ Phase deadline configuration cannot be changed while a season is active."
+3. `days >= 1` — error: "❌ Phase 1 deadline must be at least 1 day."
+4. Ordering rule: `days × 24 > current_phase_2_days × 24` — error: "❌ Phase 1 deadline ({days}d) must be greater than the current Phase 2 deadline ({p2}d). Update Phase 2 first, or choose a value greater than {p2}d."
+
+**On success**:  
+- Upsert `weather_pipeline_config.phase_1_days = days`.
+- Write audit log entry: actor, change type `WEATHER_CONFIG_PHASE1_DEADLINE`, old value, new value.
+- Respond: "✅ Phase 1 deadline set to **{days} day(s)** before round. (Phase 2: {p2}d, Phase 3: {p3}h)"
+
+---
+
+### `/weather config phase-2-deadline <days>`
+
+| Attribute | Value |
+|---|---|
+| Group | `/weather config` |
+| Parameter | `days: int` — positive integer, number of days |
+| Access | Tier-2 admin |
+| Response | Ephemeral |
+| Module gate | Weather module must be enabled |
+
+**Pre-conditions / validation**:
+1. Weather module enabled.
+2. No ACTIVE season.
+3. `days >= 1`.
+4. Ordering rule upper bound: `days × 24 < current_phase_1_days × 24` — error: "❌ Phase 2 deadline ({days}d) must be less than the current Phase 1 deadline ({p1}d). Update Phase 1 first, or choose a value less than {p1}d."
+5. Ordering rule lower bound: `days × 24 > current_phase_3_hours` — error: "❌ Phase 2 deadline ({days}d = {days×24}h) must be greater than the current Phase 3 deadline ({p3}h). Update Phase 3 first, or choose a value where {days}×24 > {p3}."
+
+**On success**:  
+- Upsert `weather_pipeline_config.phase_2_days = days`.
+- Write audit log entry.
+- Respond: "✅ Phase 2 deadline set to **{days} day(s)** before round. (Phase 1: {p1}d, Phase 3: {p3}h)"
+
+---
+
+### `/weather config phase-3-deadline <hours>`
+
+| Attribute | Value |
+|---|---|
+| Group | `/weather config` |
+| Parameter | `hours: int` — positive integer, number of hours |
+| Access | Tier-2 admin |
+| Response | Ephemeral |
+| Module gate | Weather module must be enabled |
+
+**Pre-conditions / validation**:
+1. Weather module enabled.
+2. No ACTIVE season.
+3. `hours >= 1`.
+4. Ordering rule: `hours < current_phase_2_days × 24` — error: "❌ Phase 3 deadline ({hours}h) must be less than the current Phase 2 deadline ({p2}d = {p2×24}h). Update Phase 2 first, or choose a value less than {p2×24}h."
+
+**On success**:  
+- Upsert `weather_pipeline_config.phase_3_hours = hours`.
+- Write audit log entry.
+- Respond: "✅ Phase 3 deadline set to **{hours} hour(s)** before round. (Phase 1: {p1}d, Phase 2: {p2}d)"
+
+---
+
+## Audit Log Change Types (new)
+
+| Change type string | Trigger |
+|---|---|
+| `WEATHER_CONFIG_PHASE1_DEADLINE` | `/weather config phase-1-deadline` succeeds |
+| `WEATHER_CONFIG_PHASE2_DEADLINE` | `/weather config phase-2-deadline` succeeds |
+| `WEATHER_CONFIG_PHASE3_DEADLINE` | `/weather config phase-3-deadline` succeeds |
+| `RESULTS_RESUBMISSION_STAGED_DISCARD` | "Resubmit Initial Results" button pressed — logs discarded staged penalty count |
+| `RESULTS_RESUBMISSION` | Resubmission results validated and accepted — logs before/after session result IDs |

--- a/specs/029-results-weather-improvements/data-model.md
+++ b/specs/029-results-weather-improvements/data-model.md
@@ -1,0 +1,72 @@
+# Data Model: Results Resubmission & Weather Phase Configurability
+
+**Feature**: `029-results-weather-improvements`  
+**Date**: 2026-04-02
+
+## Changed Entities
+
+### WeatherPipelineConfig *(new table: `weather_pipeline_config`)*
+
+One row per server. Stores the three configurable phase horizons. Created on first use (upsert on first weather config command or module enable). Owned by the weather module — row is NOT deleted when the module is disabled (deadline preferences are preserved).
+
+| Column | Type | Default | Notes |
+|---|---|---|---|
+| `server_id` | INTEGER PK | — | FK → `server_configs(server_id)` ON DELETE CASCADE |
+| `phase_1_days` | INTEGER NOT NULL | 5 | T−N days for Phase 1 fire-time |
+| `phase_2_days` | INTEGER NOT NULL | 2 | T−N days for Phase 2 fire-time |
+| `phase_3_hours` | INTEGER NOT NULL | 2 | T−N hours for Phase 3 fire-time |
+
+**Ordering invariant** (validated before any write): `phase_1_days × 24 > phase_2_days × 24 > phase_3_hours` (strict).
+
+**Schema migration**: `028_weather_pipeline_config.sql`
+
+---
+
+## Modified Code (no schema changes)
+
+### `scheduler_service.py` — `SchedulerService.schedule_round()`
+
+**Change**: `schedule_round` currently hardcodes the three horizons as `timedelta(days=5)`, `timedelta(days=2)`, `timedelta(hours=2)`. This method must accept the per-server deadline values. Two options are viable:
+
+- **Option A (preferred)**: Accept optional `phase_days: tuple[int, int, int] | None = None` and `phase_hours_p3: int | None = None` parameters; use defaults when None. Caller (bot restart recovery and `_catchup_and_schedule_weather`) reads from `weather_pipeline_config` and passes values in.
+- **Option B**: Have `schedule_round` do the DB lookup itself (requires `db_path` and `server_id` to be passed).
+
+Option A is preferred: it keeps `schedule_round` synchronous and testable without DB.
+
+**New helper** in `scheduler_service.py` or `config_service.py`: `get_weather_pipeline_config(db_path, server_id) -> WeatherPipelineConfig` — returns config row or default values if absent.
+
+### `penalty_wizard.py` — `PenaltyReviewView`
+
+**Change**: Add a fourth button **"🔄 Resubmit Initial Results"** to `PenaltyReviewView` (row 0 or row 1, after existing static buttons). Button carries a new stable `custom_id` constant (e.g., `pw_resubmit`).
+
+- Button not disabled when `state is None` (restart safety: posts the same "bot was restarted" ephemeral as other buttons when state is None).
+- Callback: confirms intent with a brief ephemeral, clears `state.staged`, then calls a new function `enter_resubmit_flow(interaction, state)` in `result_submission_service.py`.
+
+`PenaltyReviewState` gains no new fields — staged list is cleared in-place.
+
+### `result_submission_service.py`
+
+**New async function** `enter_resubmit_flow(interaction, state: PenaltyReviewState) -> None`:
+
+1. Audit-log the staged-penalty discard (actor, session context, count of discarded entries).
+2. Clear `state.staged`.
+3. Delete the existing `DriverSessionResult` rows for all sessions of the round (set `is_superseded = 1` or delete, consistent with existing supersession pattern), and delete/reset the `session_results` rows so the submission wizard can re-enter from the beginning.
+4. Reset `round_submission_channels.in_penalty_review = 0` and `results_posted = 0` for the round.
+5. Re-post the first session's collection prompt in the submission channel (same path as the original first-session submission).
+6. Post a notice to the submission channel: "⚠️ Results resubmission started. Previous provisional results will be replaced."
+
+**Modification to `enter_penalty_state()`**: After posting the provisional results and standings, add a `label_suffix` mechanism so the results post function can append "(amended)" when called from a resubmit path. Specifically: after resubmission completes, the second call to `enter_penalty_state` is made with a new optional `is_resubmission: bool = False` parameter that causes:
+- `results_post_service.post_round_results(... label="Provisional Results (amended)")` 
+- `results_post_service.post_standings(... label="Provisional Results (amended)")`
+
+### `results_post_service.py`
+
+No structural changes to entity schema. The `label` parameter already accepts arbitrary strings — passing `"Provisional Results (amended)"` is sufficient. No code change needed to this file for the label; the change is in the caller.
+
+---
+
+## New Entity Summary
+
+| Entity | Table | Migration | Scope |
+|---|---|---|---|
+| WeatherPipelineConfig | `weather_pipeline_config` | `028_weather_pipeline_config.sql` | Per-server |

--- a/specs/029-results-weather-improvements/plan.md
+++ b/specs/029-results-weather-improvements/plan.md
@@ -1,0 +1,112 @@
+# Implementation Plan: Results Resubmission & Weather Phase Configurability
+
+**Branch**: `029-results-weather-improvements` | **Date**: 2026-04-02 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `specs/029-results-weather-improvements/spec.md`
+
+## Summary
+
+Two independent, targeted extensions to existing modules:
+
+1. **Results hotfix resubmission** — a new "🔄 Resubmit Initial Results" danger button added to `PenaltyReviewView`. When pressed, it discards any staged (uncommitted) penalties, supersedes existing `DriverSessionResult` rows for the round, and restarts the session collection flow. On re-completion, `enter_penalty_state` is called with `is_resubmission=True`, which posts the updated provisional results with a `"Provisional Results (amended)"` label. Two audit log entries are written (staged-penalty discard + result replacement).
+
+2. **Configurable weather phase deadlines** — a new `WeatherPipelineConfig` entity (table `weather_pipeline_config`) stores per-server phase horizons defaulting to 5d / 2d / 2h. Three new slash commands under a new `/weather config` group allow tier-2 admins to update these values outside an active season, subject to the ordering invariant `P1×24 > P2×24 > P3`. `SchedulerService.schedule_round()` is updated to accept phase deadline kwargs (defaulting to the stored or default values).
+
+## Technical Context
+
+**Language/Version**: Python 3.13.2  
+**Primary Dependencies**: discord.py 2.7.1 (app_commands groups, persistent Views, Modals), aiosqlite ≥ 0.19, APScheduler ≥ 3.10  
+**Storage**: SQLite via aiosqlite; sequential SQL migration files applied on startup (migration 028 added)  
+**Testing**: pytest; `python -m pytest tests/ -v` from repo root  
+**Target Platform**: Raspberry Pi (Linux), developed on Windows  
+**Project Type**: Discord bot (single-process async service)  
+**Performance Goals**: All commands must acknowledge within 3 seconds (deferred response used for any operation that may exceed this)  
+**Constraints**: No new external dependencies; changes must be backward-compatible with existing DB rows (defaults handle absent `weather_pipeline_config` rows)  
+**Scale/Scope**: Small-to-medium Discord servers; no bulk computation paths affected
+
+## Constitution Check
+
+*Evaluated against constitution v2.8.0 — re-evaluated post-design below.*
+
+| Principle | Status | Notes |
+|---|---|---|
+| I — Trusted Configuration Authority | ✅ PASS | All new commands gated behind tier-2 admin (league manager) role. Resubmit button uses same LM gate as existing `PenaltyReviewView` buttons. |
+| II — Multi-Division Isolation | ✅ PASS | No cross-division reads or writes introduced. Resubmit is scoped to a single round/division. `weather_pipeline_config` is per-server (not per-division). |
+| III — Resilient Schedule Management | ✅ PASS | `schedule_round()` now accepts configurable horizons; already uses `replace_existing=True`. No amendment invalidation semantics affected. |
+| IV — Three-Phase Weather Pipeline | ⚠️ NOTE | Principle IV currently hardcodes T−5d/T−2d/T−2h as "NON-NEGOTIABLE". This feature makes the horizons configurable but keeps the sequential three-phase structure non-negotiable. **Constitution amendment required** (MINOR): make horizons configurable with mandatory defaults; codify ordering invariant; restrict changes to non-ACTIVE periods. See checklist. |
+| V — Observability & Change Audit Trail | ✅ PASS | All four new audit change types logged (staged-penalty discard, result replacement, three deadline changes). Actor, old value, new value recorded on all. |
+| VI — Incremental Scope Expansion | ✅ PASS | Both changes fall within ratified domains: Results & Standings (item 8–9) and Weather generation (item 1). No new domain introduced. |
+| VII — Output Channel Discipline | ✅ PASS | Resubmit posts only to the existing transient submission channel. Weather config commands are ephemeral. No new channel categories introduced. |
+| VIII — Driver Profile Integrity | ✅ PASS | No driver state machine involvement. |
+| IX — Team & Division Structural Integrity | ✅ PASS | No team/division structural changes. |
+| X — Modular Feature Architecture | ✅ PASS | New `/weather config` commands check the weather module-enabled flag before executing (Principle X, rule 5). Phase deadline config is owned by the weather module. |
+| XI — Signup Wizard Integrity | ✅ PASS | No signup module involvement. |
+| XII — Race Results & Championship Integrity | ⚠️ NOTE | Principle XII covers amendment and penalty but does not explicitly name in-wizard hotfix resubmission. **Constitution amendment required** (PATCH): name resubmission as a permitted in-wizard action; mandate staged-penalty discard; require "(amended)" marker. |
+
+**Post-design re-evaluation**: No new violations introduced by the design. The two noted amendments (Principle IV + XII) are governance clarifications of existing ratified domains — neither changes the fundamental rules. Both are recorded and flagged for ratification.
+
+**Complexity Tracking**: No constitution violations that require justification. No over-engineered patterns. Both features are strictly additive.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/029-results-weather-improvements/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+├── contracts/
+│   └── commands.md      ← Phase 1 output
+└── tasks.md             ← Phase 2 output (speckit.tasks)
+```
+
+### Source Code
+
+```text
+src/
+├── cogs/
+│   ├── weather_cog.py                   ← NEW
+│   └── (results_cog.py unchanged)
+├── models/
+│   └── weather_config.py                ← NEW
+├── services/
+│   ├── penalty_wizard.py                ← MODIFIED (resubmit button)
+│   ├── result_submission_service.py     ← MODIFIED (resubmit flow, is_resubmission param)
+│   ├── scheduler_service.py             ← MODIFIED (configurable horizons in schedule_round)
+│   └── weather_config_service.py        ← NEW
+├── db/
+│   └── migrations/
+│       └── 028_weather_pipeline_config.sql  ← NEW
+└── bot.py                               ← MODIFIED (register WeatherCog; pass horizons)
+
+tests/
+├── unit/
+│   ├── test_penalty_wizard.py           ← EXTENDED (pw_resubmit button contract)
+│   ├── test_result_submission_service.py ← EXTENDED (resubmit flow)
+│   ├── test_weather_config_service.py   ← NEW
+│   └── test_scheduler_service.py        ← NEW or EXTENDED (configurable horizons)
+└── integration/
+    ├── test_penalty_flow.py             ← EXTENDED (resubmit integration path)
+    └── test_weather_config_flow.py      ← NEW (deadline commands + active-season gate)
+```
+
+**Structure Decision**: Single-project layout; no structural change to existing `src/` tree. All new files follow established module patterns (cogs, models, services, migration files).
+
+## Phase 0: Research
+
+See [research.md](research.md) for full findings. Key decisions:
+
+| Decision | Rationale | Alternatives Considered |
+|---|---|---|
+| `WeatherPipelineConfig` as a separate table (not added to `server_configs`) | Keeps weather module config isolated; easier to clear on future module restructures; mirrors signup_module_config pattern | Adding columns to server_configs — rejected: pollutes the core config table with module-specific data |
+| `schedule_round()` accepts kwargs (not does a DB lookup internally) | Keeps the method synchronous and easily unit-testable; consistent with existing calling pattern | schedule_round does its own DB lookup — rejected: breaks sync signature, requires db_path propagation |
+| New `WeatherCog` (not adding to existing cog) | No existing `/weather` group exists; weather commands are a distinct domain from module enable/disable | Adding to `module_cog.py` — rejected: mixes module lifecycle commands with configuration commands, violating command grouping principle |
+| Resubmit as in-wizard button (not a separate slash command) | Spec requires the fix to happen without leaving the submission channel; avoids disambiguation issues about which session/round to resubmit | `/results resubmit` command — rejected: requires round ID parameter, breaks wizard isolation |
+| Supersede (`is_superseded = 1`) existing DriverSessionResult rows, do not hard-delete | Preserves audit trail of the original submission; consistent with existing supersession pattern used in amendment flow | Hard-delete — rejected: loses the original result data from the audit trail |
+
+## Phase 1: Design
+
+- [data-model.md](data-model.md) — `WeatherPipelineConfig` entity; `schedule_round` signature change; `PenaltyReviewView` button addition; label-suffix mechanism
+- [contracts/commands.md](contracts/commands.md) — `pw_resubmit` button spec; `/weather config phase-1-deadline`, `phase-2-deadline`, `phase-3-deadline` command contracts; audit change type names
+- [quickstart.md](quickstart.md) — implementation sequence, file map, key invariants, test run commands

--- a/specs/029-results-weather-improvements/quickstart.md
+++ b/specs/029-results-weather-improvements/quickstart.md
@@ -1,0 +1,181 @@
+# Developer Quickstart: Results Resubmission & Weather Phase Configurability
+
+**Feature**: `029-results-weather-improvements`  
+**Date**: 2026-04-02
+
+---
+
+## What's changing
+
+Two independent sets of changes in this feature:
+
+1. **Results hotfix resubmission** — a new button in the penalty wizard that lets a tier-2 admin re-enter a session's results from scratch, discarding any staged penalties, without leaving the submission channel.
+2. **Configurable weather phase deadlines** — three new `/weather config phase-N-deadline` commands that let league managers set the T−N horizons for each weather phase, replacing the hardcoded 5d/2d/2h values.
+
+---
+
+## Working areas
+
+```
+src/
+├── cogs/
+│   ├── weather_cog.py          ← NEW: /weather command group
+│   └── results_cog.py          ← no change needed (resubmit is wizard-driven)
+├── models/
+│   └── weather_config.py       ← NEW: WeatherPipelineConfig dataclass
+├── services/
+│   ├── penalty_wizard.py       ← add pw_resubmit button + callback
+│   ├── result_submission_service.py  ← add enter_resubmit_flow()
+│   ├── scheduler_service.py    ← accept phase deadline params in schedule_round()
+│   └── weather_config_service.py    ← NEW: CRUD for weather_pipeline_config
+├── db/
+│   └── migrations/
+│       └── 028_weather_pipeline_config.sql  ← NEW
+tests/
+├── unit/
+│   ├── test_penalty_wizard.py           ← extend: pw_resubmit button contract
+│   ├── test_result_submission_service.py ← extend: resubmit flow helpers
+│   ├── test_weather_config_service.py   ← NEW: CRUD + ordering invariant
+│   └── test_scheduler_service.py        ← NEW or extend: configurable horizons
+└── integration/
+    ├── test_penalty_flow.py             ← extend: resubmit path
+    └── test_weather_config_flow.py      ← NEW: deadline commands + active-season gate
+```
+
+---
+
+## Implementation sequence
+
+### Step 1 — DB migration
+
+Create `src/db/migrations/028_weather_pipeline_config.sql`:
+
+```sql
+CREATE TABLE IF NOT EXISTS weather_pipeline_config (
+    server_id    INTEGER PRIMARY KEY
+                     REFERENCES server_configs(server_id) ON DELETE CASCADE,
+    phase_1_days INTEGER NOT NULL DEFAULT 5,
+    phase_2_days INTEGER NOT NULL DEFAULT 2,
+    phase_3_hours INTEGER NOT NULL DEFAULT 2
+);
+```
+
+### Step 2 — Model + service
+
+Create `src/models/weather_config.py`:
+
+```python
+from dataclasses import dataclass
+
+@dataclass
+class WeatherPipelineConfig:
+    server_id: int
+    phase_1_days: int = 5
+    phase_2_days: int = 2
+    phase_3_hours: int = 2
+```
+
+Create `src/services/weather_config_service.py` with:
+- `get_weather_pipeline_config(db_path, server_id) -> WeatherPipelineConfig` — returns row or default-valued instance.
+- `set_phase_1_days(db_path, server_id, days)` — upsert + ordering validation.
+- `set_phase_2_days(db_path, server_id, days)` — upsert + ordering validation.
+- `set_phase_3_hours(db_path, server_id, hours)` — upsert + ordering validation.
+- Validation helper: `validate_ordering(p1_days, p2_days, p3_hours) -> str | None` — returns error string or None.
+
+### Step 3 — Scheduler update
+
+In `scheduler_service.py`, change `schedule_round()` signature:
+
+```python
+def schedule_round(
+    self,
+    rnd: Round,
+    *,
+    phase_1_days: int = 5,
+    phase_2_days: int = 2,
+    phase_3_hours: int = 2,
+) -> None:
+```
+
+Replace hardcoded `timedelta(days=5)`, `timedelta(days=2)`, `timedelta(hours=2)` with:
+
+```python
+horizons = {
+    1: scheduled_at - timedelta(days=phase_1_days),
+    2: scheduled_at - timedelta(days=phase_2_days),
+    3: scheduled_at - timedelta(hours=phase_3_hours),
+}
+```
+
+All callers (`_catchup_and_schedule_weather`, restart recovery in `bot.py`) must fetch `WeatherPipelineConfig` and pass the values in. The MYSTERY round notice job hardcodes T−5d independently — this is NOT parameterised by the phase deadline config (it's a separate notice, not a weather phase).
+
+### Step 4 — Weather cog
+
+Create `src/cogs/weather_cog.py` with:
+
+```python
+class WeatherCog(commands.Cog):
+    weather = app_commands.Group(name="weather", ...)
+    config_group = app_commands.Group(name="config", parent=weather, ...)
+```
+
+Add three subcommands: `phase_1_deadline`, `phase_2_deadline`, `phase_3_deadline`.  
+Each follows the validation sequence in `contracts/commands.md` and calls the matching `weather_config_service` setter.
+
+Register `WeatherCog` in `bot.py` alongside other cogs.
+
+### Step 5 — Penalty wizard resubmit button
+
+In `penalty_wizard.py`:
+
+1. Add `_CID_RESUBMIT = "pw_resubmit"` constant.
+2. Add the button to `PenaltyReviewView`:
+
+```python
+@discord.ui.button(
+    label="🔄 Resubmit Initial Results",
+    style=discord.ButtonStyle.danger,
+    custom_id=_CID_RESUBMIT,
+    row=0,
+)
+async def resubmit_btn(self, interaction, button):
+    ...
+```
+
+3. Callback: LM gate → defer → call `enter_resubmit_flow(interaction, self.state)`.
+
+### Step 6 — Resubmit flow
+
+In `result_submission_service.py`, add `enter_resubmit_flow(interaction, state)`:
+
+1. Write `RESULTS_RESUBMISSION_STAGED_DISCARD` audit entry.
+2. Clear `state.staged`.
+3. Supersede existing `DriverSessionResult` rows (`is_superseded = 1`) and reset / delete `session_results` rows for all sessions of the round.
+4. Reset `round_submission_channels`: `in_penalty_review = 0`, `results_posted = 0`.
+5. Post "⚠️ Resubmission started" notice to submission channel.
+6. Post first-session collection prompt (reuse existing first-session posting code, passing `is_resubmission=True` flag through to `enter_penalty_state` after collection completes).
+
+Modify `enter_penalty_state(... is_resubmission: bool = False)`: when `True`, use `"Provisional Results (amended)"` label for `post_round_results` and `post_standings` calls.
+
+---
+
+## Key invariants to preserve
+
+- **Existing non-resubmit penalty path is unchanged**: the resubmit button is purely additive. All existing `PenaltyReviewView` buttons keep their custom_ids and callbacks.
+- **Scheduling defaults are unchanged**: `schedule_round()` defaults to 5/2/2 so existing callers that pass no arguments continue to work correctly.
+- **Audit trail is unbroken**: every resubmission event, staged-penalty discard, and deadline change produces an audit entry readable from the log channel.
+- **Active-season gate on deadline changes**: `get_active_season()` from `season_service` is used; if not None, command is rejected before any DB write.
+
+---
+
+## Running tests
+
+```bash
+# From repo root
+python -m pytest tests/ -v
+```
+
+Target test files for this feature:
+```bash
+python -m pytest tests/unit/test_penalty_wizard.py tests/unit/test_weather_config_service.py tests/unit/test_scheduler_service.py tests/integration/test_penalty_flow.py tests/integration/test_weather_config_flow.py -v
+```

--- a/specs/029-results-weather-improvements/research.md
+++ b/specs/029-results-weather-improvements/research.md
@@ -1,0 +1,68 @@
+# Research: Results Resubmission & Weather Phase Configurability
+
+**Feature**: `029-results-weather-improvements`  
+**Date**: 2026-04-02
+
+---
+
+## Research Tasks & Findings
+
+### R-001: Penalty wizard state and "staged" penalty lifecycle
+
+**Decision**: "Staged penalties" are entries in `PenaltyReviewState.staged` (an in-memory `list[StagedPenalty]`) that have not yet been passed to `finalize_penalty_review`. No `PenaltyRecord` rows exist until `finalize_penalty_review` commits them. Discarding staged penalties = clearing this list.  
+**Rationale**: Confirmed by reading `penalty_wizard.py`. `StagedPenalty` objects live only in the wizard state; the DB is only written in `finalize_penalty_review` via `penalty_service.apply_penalties`.  
+**Alternatives considered**: Checking for uncommitted `PenaltyRecord` rows in the DB — rejected; the wizard never writes partial rows.
+
+---
+
+### R-002: How provisional results are posted and what label is used
+
+**Decision**: `enter_penalty_state()` calls `results_post_service.post_round_results(... label="Provisional Results")` and `results_post_service.post_standings(... label="Provisional Results")`. The `label` parameter is already a free string accepted by both functions. Passing `"Provisional Results (amended)"` is sufficient — no structural change to `results_post_service.py`.  
+**Rationale**: `post_round_results` embeds the `label` string into the message heading. The `_label_from_status` mapping is only used on re-reads from DB (standings sync); the in-wizard path always passes the label directly.  
+**Alternatives considered**: A new `result_status` DB value (`PROVISIONAL_AMENDED`) — rejected: overkill for a display-only distinction; the DB row's `result_status` remains `PROVISIONAL` until `finalize_penalty_review` moves it to `POST_RACE_PENALTY`.
+
+---
+
+### R-003: How to reset state for re-entry after resubmission
+
+**Decision**: To allow the session collection wizard to re-run, the existing `session_results` and `driver_session_results` rows for the round must be superseded (`is_superseded = 1` on `driver_session_results`) and the `session_results` rows deleted (or status reset to `ACTIVE` with no children). The `round_submission_channels` row must have `in_penalty_review = 0` and `results_posted = 0` reset so the recovery logic does not re-post as a penalty-review orphan.  
+**Rationale**: The submission wizard is driven by checking which sessions have been submitted (`SELECT ... FROM session_results WHERE round_id = ?`). Deleting/resetting these rows allows the wizard to restart from session 1.  
+**Alternatives considered**: Keeping session_results rows with a `SUPERSEDED` status and filtering them — rejected: adds complexity to the submission query path; simpler to delete and start clean.
+
+---
+
+### R-004: Where phase horizons are hardcoded and how to parameterise
+
+**Decision**: Phase horizons are hardcoded in `scheduler_service.py:SchedulerService.schedule_round()` as `timedelta(days=5)`, `timedelta(days=2)`, `timedelta(hours=2)`. The method signature is extended with `phase_1_days: int = 5`, `phase_2_days: int = 2`, `phase_3_hours: int = 2` keyword arguments. All callers pass the values fetched from `WeatherPipelineConfig`; callers that can omit them continue to work via the defaults.  
+**Rationale**: This is the sole scheduling site. Keeping the method synchronous avoids the need to make it async just for a DB lookup. The MYSTERY round notice job (`timedelta(days=5)`) is a separate hardcoded horizon — it is not a weather phase and is not parameterised.  
+**Alternatives considered**: Injecting `WeatherPipelineConfig` into `SchedulerService.__init__` — rejected: config is per-server but `schedule_round` is called per-round across multiple servers.
+
+---
+
+### R-005: Where to place the new `/weather config` commands
+
+**Decision**: New `src/cogs/weather_cog.py` with a top-level `/weather` app_commands Group and a nested `config` subgroup. `WeatherCog` is registered in `bot.py`.  
+**Rationale**: No `/weather` group exists anywhere in the codebase. Module enable/disable lives in `module_cog.py` under `/module`; weather-specific configuration belongs under `/weather`, not `/module`. Adding to an existing cog would mix unrelated concerns.  
+**Alternatives considered**: Adding weather config commands to `module_cog.py` — rejected; violates the command grouping principle (same domain, different group).
+
+---
+
+### R-006: Weather pipeline config storage pattern
+
+**Decision**: New table `weather_pipeline_config` (one row per server), separate from `server_configs`. Ownable by the weather module. Row created (upsert) on first deadline command if not already present. Row is NOT deleted when the module is disabled (deadline preferences are settings, not runtime state).  
+**Rationale**: Mirrors the pattern of `signup_module_config` and `signup_module_settings` — module-specific config gets its own table. Avoids polluting `server_configs` with module-specific columns.  
+**Alternatives considered**: Adding columns to `server_configs` — rejected: incorrect ownership (server config owns core bot setup, not module preferences).
+
+---
+
+### R-007: Active-season gate implementation
+
+**Decision**: Use `bot.season_service.get_active_season(server_id)` (already available on `bot`). If the returned value is not `None`, reject the command with a clear error before any DB write.  
+**Rationale**: `get_active_season` is the established API for checking `status = 'ACTIVE'`. All new deadline commands call this gate first, after the module-enabled check.  
+**Alternatives considered**: Querying the DB directly in the cog — rejected: duplicates logic already encapsulated in `SeasonService`.
+
+---
+
+## NEEDS CLARIFICATION — resolved
+
+All unknowns resolved. No open items.

--- a/specs/029-results-weather-improvements/spec.md
+++ b/specs/029-results-weather-improvements/spec.md
@@ -1,0 +1,125 @@
+# Feature Specification: Results Resubmission & Weather Phase Configurability
+
+**Feature Branch**: `029-results-weather-improvements`  
+**Created**: 2026-04-02  
+**Status**: Draft  
+**Input**: User description: "Results: resubmit initial results hotfix button during penalty wizard with staged-penalty discard. Weather: configurable phase deadlines via new commands with ordering validation and active-season gate."
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Results Hotfix Resubmission During Penalty Wizard (Priority: P1)
+
+A tier-2 admin has just submitted a session's results. Provisional results have been posted to the division's results channel and standings have been recomputed. The penalty wizard is now open and the admin has begun staging one or more penalties. They notice a data-entry error in the original result (e.g., a driver's finishing position is wrong). They press the **"Resubmit Initial Results"** button. Any penalties they had staged but not yet committed are discarded. The admin re-enters the complete session results from scratch. Once the new results pass validation, updated provisional results are posted to the results channel with **(amended)** in the title, standings are recomputed and reposted, and the penalty wizard reopens clean against the corrected results.
+
+**Why this priority**: A submission error discovered immediately after posting can cascade into incorrect standings and flawed penalty applications. A zero-interruption in-wizard fix is higher priority than weather configurability and prevents the need for a more disruptive post-finalization amendment.
+
+**Independent Test**: Can be fully tested by deliberately submitting incorrect results, verifying provisional results and standings are posted, staging a penalty in the wizard, pressing "Resubmit Initial Results", entering corrected results, and confirming: (a) amended provisional results appear with "(amended)" marker, (b) standings are recalculated, (c) the previously staged penalty is absent from the record, and (d) audit log entries exist for the discard and resubmission.
+
+**Acceptance Scenarios**:
+
+1. **Given** provisional results have been posted and the penalty wizard is open with no staged penalties, **When** the tier-2 admin presses "Resubmit Initial Results", **Then** the system prompts for full session result re-entry.
+2. **Given** the penalty wizard is open and one or more penalties have been staged (not yet committed), **When** "Resubmit Initial Results" is pressed, **Then** all staged penalties are discarded before re-entry begins and a confirmation of the discard is shown.
+3. **Given** the re-entry prompt is active, **When** the admin submits valid complete results, **Then** updated provisional results are posted to the division's results channel with "(amended)" appended to the session title.
+4. **Given** new provisional results have been posted, **Then** standings for the affected round and all subsequent rounds in that division are recomputed and reposted atomically.
+5. **Given** the resubmission completes, **Then** the penalty wizard reopens, reflecting the new results with no staged penalties.
+6. **Given** any use of the "Resubmit Initial Results" button, **Then** an audit log entry is recorded for the staged-penalty discard and another for the result replacement, including the acting admin's identity and the before/after state.
+7. **Given** the re-entry prompt is active, **When** the admin submits results that fail validation (e.g., duplicate finishing positions), **Then** the submission is rejected with a specific error and the prompt remains open for correction.
+
+---
+
+### User Story 2 — Configure Weather Phase Deadlines (Priority: P2)
+
+A league manager wants to adjust the weather schedule to fit their league's race week rhythm. Their races happen on Friday nights, so a 7-day Phase 1 window makes more sense than the default 5. They run `/weather config phase-1-deadline 7`. The server's Phase 1 horizon is updated and confirmed. Subsequent rounds have their Phase 1 weather job scheduled at T−7 days.
+
+**Why this priority**: Configurable deadlines broaden the weather module's usefulness across leagues with different race cadences without requiring any changes to the core pipeline logic.
+
+**Independent Test**: Can be fully tested independently by setting a deadline value, verifying persistence across a bot restart, and confirming the new value is used when scheduling the next round's weather phases.
+
+**Acceptance Scenarios**:
+
+1. **Given** the weather module is enabled and no season is currently ACTIVE, **When** a league manager runs `/weather config phase-1-deadline 7`, **Then** the server's Phase 1 deadline is updated to 7 days and a confirmation is sent.
+2. **Given** the weather module is enabled and no season is currently ACTIVE, **When** a league manager runs `/weather config phase-2-deadline 3`, **Then** the server's Phase 2 deadline is updated to 3 days and a confirmation is sent.
+3. **Given** the weather module is enabled and no season is currently ACTIVE, **When** a league manager runs `/weather config phase-3-deadline 4`, **Then** the server's Phase 3 deadline is updated to 4 hours and a confirmation is sent.
+4. **Given** a season is currently ACTIVE, **When** any of the three phase deadline commands is run, **Then** the command is rejected with a clear error stating that deadline changes are not permitted during an active season, and no value is changed.
+5. **Given** a valid deadline change is applied, **Then** an audit log entry is recorded per Principle V, including old and new values and the acting user.
+6. **Given** the bot is restarted after deadline values are configured, **Then** the configured values are loaded and used for all subsequent scheduling decisions.
+
+---
+
+### User Story 3 — Phase Deadline Ordering Validation (Priority: P2)
+
+A league manager accidentally attempts to set Phase 2 to 6 days while Phase 1 is still at the default 5 days. This would make Phase 2 fire before Phase 1, violating the pipeline order. The bot rejects the command with a clear explanation referencing the ordering rule and the current conflicting value.
+
+**Why this priority**: Preventing invalid configurations at input time is essential to preserving the integrity of the three-phase weather pipeline. It accompanies User Story 2 directly.
+
+**Independent Test**: Can be fully tested independently by attempting to set each phase's deadline to a value that violates the ordering rule (P1_days × 24 > P2_days × 24 > P3_hours) and verifying rejection with no state change.
+
+**Acceptance Scenarios**:
+
+1. **Given** current settings are P1=5d, P2=2d, P3=2h, **When** `/weather config phase-1-deadline 1` is run (1 × 24 = 24h, which is not greater than P2's 2 × 24 = 48h), **Then** the command is rejected with a message citing the ordering rule and the conflicting P2 value.
+2. **Given** current settings are P1=5d, P2=2d, P3=2h, **When** `/weather config phase-2-deadline 6` is run (6 × 24 = 144h, which exceeds P1's 5 × 24 = 120h), **Then** the command is rejected with a message citing the ordering rule and the conflicting P1 value.
+3. **Given** current settings are P1=5d, P2=2d, P3=2h, **When** `/weather config phase-3-deadline 72` is run (72h, which is not less than P2's 2 × 24 = 48h), **Then** the command is rejected with a message citing the ordering rule and the conflicting P2 value.
+4. **Given** any rejected deadline change, **Then** no state change occurs and the existing deadline values remain exactly as they were.
+
+---
+
+### Edge Cases
+
+- What if "Resubmit Initial Results" is pressed when no penalties have been staged? The resubmission flow begins immediately; no discard notice is required since nothing was staged.
+- What if the re-entered results after resubmission are identical to the original? They are accepted as valid; the "(amended)" marker still appears to make the event auditable.
+- What if Phase 1 and Phase 2 are set to the same number of days (e.g., both 2d)? This produces P1 × 24 = P2 × 24, which violates the strict greater-than rule. Both values must produce a strictly decreasing sequence. Rejected.
+- What if a phase deadline configuration command is run but the weather module is not enabled? The command should be accepted or rejected following the same module-gate rule that applies to all weather commands (Principle X, rule 5).
+- What if a round's weather phases have already been scheduled using the old deadline values when a new deadline is configured (deadline change before season is active)? Deadline changes only affect future round phase scheduling. Already-scheduled phase jobs for a SETUP-phase season are not retroactively rescheduled; they remain on the horizons computed at the time of scheduling.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Results Resubmission
+
+- **FR-001**: During an active penalty wizard session (after provisional results have been posted for a session), the submission interface MUST display a "Resubmit Initial Results" button.
+- **FR-002**: When "Resubmit Initial Results" is pressed, all staged penalties that have not been committed to the record MUST be discarded atomically before re-entry begins.
+- **FR-003**: The system MUST prompt the tier-2 admin to re-enter the complete session results after pressing "Resubmit Initial Results", using the same collection flow as the initial submission.
+- **FR-004**: Re-entered results MUST undergo the same validation rules as the initial submission (e.g., no duplicate finishing positions, valid outcome modifiers, valid tyre and time fields per session type).
+- **FR-005**: Upon successful re-entry and validation, the system MUST post updated provisional results to the division's results channel with "(amended)" appended to the session title.
+- **FR-006**: Upon posting updated provisional results, the system MUST recompute and repost standings for the affected round and all subsequent rounds in that division, atomically.
+- **FR-007**: The discarding of staged penalties MUST produce an audit log entry recording the acting admin, the session, and the number/identity of discarded staged penalties.
+- **FR-008**: The result replacement MUST produce an audit log entry per Principle V, recording the acting admin, the session, and sufficient detail to reconstruct the change.
+- **FR-009**: Re-entered results that fail validation MUST be rejected with a specific, actionable error; the re-entry prompt MUST remain open for correction.
+
+#### Weather Phase Deadline Configuration
+
+- **FR-010**: The system MUST provide a `/weather config phase-1-deadline <days>` command accepting a positive integer representing the number of days before a round that Phase 1 is published.
+- **FR-011**: The system MUST provide a `/weather config phase-2-deadline <days>` command accepting a positive integer representing the number of days before a round that Phase 2 is published.
+- **FR-012**: The system MUST provide a `/weather config phase-3-deadline <hours>` command accepting a positive integer representing the number of hours before a round that Phase 3 is published.
+- **FR-013**: The default value for the Phase 1 deadline MUST be 5 (days), for Phase 2 MUST be 2 (days), and for Phase 3 MUST be 2 (hours), matching the previously hardcoded horizons.
+- **FR-014**: All three deadline commands MUST be rejected with a clear, actionable error if a season is currently in the ACTIVE lifecycle state.
+- **FR-015**: Before accepting any deadline update, the system MUST validate that the resulting configuration satisfies the ordering rule: (P1_days × 24) > (P2_days × 24) > P3_hours, using strict inequality at every step. A command that would violate this rule MUST be rejected before any state change occurs.
+- **FR-016**: The error on an ordering violation MUST identify which current value or values conflict with the proposed change.
+- **FR-017**: Accepted deadline values MUST be persisted per server and survive bot restarts.
+- **FR-018**: Any successful deadline change MUST produce an audit log entry per Principle V, recording old value, new value, and acting user.
+- **FR-019**: The three deadline commands MUST follow the `/domain action subcommand` convention (Principle I Bot Behavior Standards) and MUST be accessible only to league managers (tier-2 admins, Principle I).
+
+### Key Entities *(include if feature involves data)*
+
+- **WeatherPipelineConfig** (new per-server entity, owned by the weather module): stores `phase_1_days` (INTEGER, default 5), `phase_2_days` (INTEGER, default 2), `phase_3_hours` (INTEGER, default 2). Created with default values on first use or module enable. The three values collectively define the server's active phase horizon schedule.
+
+## Assumptions
+
+- Phase 2 input unit is **days**. The ordering rule `P1×24 > P2×24 > P3` — where P1 and P2 are multiplied by 24 to convert to hours and P3 is already in hours — is satisfied when P1 and P2 are in days and P3 is in hours. Confirmed by the project owner.
+- "Staged penalties" are defined as penalties entered into the penalty wizard that have not yet been confirmed/committed as `PenaltyRecord` rows. Discarding staged penalties means resetting the wizard to its initial (empty) state; no `PenaltyRecord` rows exist for them.
+- The "Resubmit Initial Results" button is available throughout the penalty wizard phase, from when the wizard opens until the tier-2 admin finalises the penalty review. It is not available during the appeals wizard (a distinct subsequent phase).
+- Deadline changes made while a season is in `SETUP` (not yet ACTIVE) take effect immediately. Any round phase jobs already scheduled in a SETUP season keep their previously computed horizons; the new deadline applies to rounds whose phase jobs have not yet been scheduled.
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: A tier-2 admin can complete a results resubmission entirely within the active penalty wizard session, with no bot restart or separate amendment command required.
+- **SC-002**: After resubmission, amended provisional results visible in the results channel carry the "(amended)" marker, making them unambiguously distinguishable from the original post.
+- **SC-003**: All staged (uncommitted) penalties are cleared before re-entry begins; zero staged-penalty data survives the resubmission event in the final record.
+- **SC-004**: Standings visible in the standings channel after a resubmission reflect the corrected results, not the original.
+- **SC-005**: A league manager can set any valid phase deadline to a new value and receive confirmation within a single command interaction.
+- **SC-006**: Every invalid phase deadline attempt (ordering violation or active-season gate) is rejected before any state change occurs, with a clear error that identifies the specific constraint breached.
+- **SC-007**: Configured phase deadlines are used for all subsequent round weather scheduling after the change, with no manual restart required.
+- **SC-008**: All actions covered by this feature (resubmission, staged-penalty discard, deadline changes) produce traceable audit log entries viewable by league managers after the fact.

--- a/specs/029-results-weather-improvements/tasks.md
+++ b/specs/029-results-weather-improvements/tasks.md
@@ -1,0 +1,161 @@
+# Tasks: Results Resubmission & Weather Phase Configurability
+
+**Input**: Design documents from `/specs/029-results-weather-improvements/`
+**Prerequisites**: plan.md ✅, spec.md ✅, research.md ✅, data-model.md ✅, contracts/ ✅, quickstart.md ✅
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no incomplete dependencies)
+- **[Story]**: User story this task belongs to (US1–US3)
+- Exact file paths included in every description
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: DB schema foundation required before any weather config code can run.
+
+- [X] T001 Create migration `src/db/migrations/028_weather_pipeline_config.sql` — `CREATE TABLE IF NOT EXISTS weather_pipeline_config (server_id INTEGER PRIMARY KEY REFERENCES server_configs(server_id) ON DELETE CASCADE, phase_1_days INTEGER NOT NULL DEFAULT 5, phase_2_days INTEGER NOT NULL DEFAULT 2, phase_3_hours INTEGER NOT NULL DEFAULT 2)`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites for US2 & US3)
+
+**Purpose**: Model, scheduler signature change, and base service reader shared by both weather stories. Must be complete before Phase 4 begins.
+
+**⚠️ CRITICAL**: US2 and US3 cannot begin until T002–T004 are done.
+
+- [X] T002 [P] Create `WeatherPipelineConfig` dataclass in `src/models/weather_config.py` — fields: `server_id: int`, `phase_1_days: int = 5`, `phase_2_days: int = 2`, `phase_3_hours: int = 2`
+- [X] T003 [P] Update `SchedulerService.schedule_round()` in `src/services/scheduler_service.py` — add `*, phase_1_days: int = 5, phase_2_days: int = 2, phase_3_hours: int = 2` kwargs; replace the hardcoded `timedelta(days=5)`, `timedelta(days=2)`, `timedelta(hours=2)` in the `horizons` dict with `timedelta(days=phase_1_days)`, `timedelta(days=phase_2_days)`, `timedelta(hours=phase_3_hours)`; also update `schedule_all_rounds()` to accept and thread the same three kwargs to each `schedule_round()` call
+- [X] T004 Create `src/services/weather_config_service.py` with a single async function `get_weather_pipeline_config(db_path: str, server_id: int) -> WeatherPipelineConfig` — executes `SELECT phase_1_days, phase_2_days, phase_3_hours FROM weather_pipeline_config WHERE server_id = ?`; returns a `WeatherPipelineConfig` with the stored values, or a default-valued instance (`phase_1_days=5, phase_2_days=2, phase_3_hours=2`) if no row exists
+
+**Checkpoint**: Migration, model, scheduler kwargs, and config reader are all ready. US1 and US2/US3 can now proceed independently.
+
+---
+
+## Phase 3: User Story 1 — Results Hotfix Resubmission (Priority: P1) 🎯 MVP
+
+**Goal**: A tier-2 admin can press "🔄 Resubmit Initial Results" during the penalty wizard to discard any staged penalties and re-enter the session's results from scratch. Amended provisional results are posted with "(amended)" in the title.
+
+**Independent Test**: Submit results deliberately wrong → verify provisional results posted → stage a penalty in the wizard → press "Resubmit Initial Results" → re-enter corrected results → confirm: (a) "Provisional Results (amended)" appears in results channel, (b) standings recomputed, (c) no staged penalty in the record, (d) two audit log entries (`RESULTS_RESUBMISSION_STAGED_DISCARD`, `RESULTS_RESUBMISSION`) exist.
+
+- [X] T005 [P] [US1] In `src/services/penalty_wizard.py`, add the constant `_CID_RESUBMIT = "pw_resubmit"` alongside the existing `_CID_*` constants; add a `🔄 Resubmit Initial Results` `discord.ui.Button` (style=`ButtonStyle.danger`, `custom_id=_CID_RESUBMIT`, row=0) to `PenaltyReviewView` — callback defers as ephemeral; if `state is None` sends the standard restart ephemeral notice (matching existing pattern); otherwise calls `await enter_resubmit_flow(interaction, state)`
+- [X] T006 [P] [US1] In `src/services/result_submission_service.py`, add `is_resubmission: bool = False` keyword parameter to `enter_penalty_state()` — when `True`, pass `label="Provisional Results (amended)"` (instead of `"Provisional Results"`) to both `results_post_service.post_round_results(...)` and `results_post_service.post_standings(...)`
+- [X] T007 [US1] In `src/services/result_submission_service.py`, implement `async def enter_resubmit_flow(interaction: discord.Interaction, state: PenaltyReviewState) -> None` — (1) write audit log entry `RESULTS_RESUBMISSION_STAGED_DISCARD` with actor identity, `state.round_id`, and count/IDs of discarded staged entries; (2) clear `state.staged` in-place; (3) execute `UPDATE driver_session_results SET is_superseded = 1 WHERE round_id = ?` for all sessions of `state.round_id`; (4) execute `DELETE FROM session_results WHERE round_id = ?`; (5) execute `UPDATE round_submission_channels SET in_penalty_review = 0, results_posted = 0 WHERE round_id = ?`; (6) post a `"⚠️ Results resubmission started. Previous provisional results will be replaced."` notice to the submission channel; (7) re-invoke the first-session collection prompt using the same entry path as the original submission start (so the collection wizard restarts from session 1); on re-completion `enter_penalty_state` is called with `is_resubmission=True`; (8) write audit log entry `RESULTS_RESUBMISSION` with actor identity and round context
+
+**Checkpoint**: User Story 1 is fully functional and independently testable. US2/US3 work can proceed in parallel.
+
+---
+
+## Phase 4: User Story 2 — Configure Weather Phase Deadlines (Priority: P2)
+
+**Goal**: League managers can run `/weather config phase-1-deadline`, `phase-2-deadline`, and `phase-3-deadline` to store per-server deadline values that are used when scheduling round weather phases, subject to a module-enabled gate and an active-season gate.
+
+**Independent Test**: Enable the weather module on a test server with no active season. Run `/weather config phase-1-deadline 7` → confirm success response and persistence across restart. Confirm that the next call to `schedule_round()` uses `phase_1_days=7`. Run any deadline command while a season is ACTIVE → confirm rejection with correct error.
+
+- [X] T008 [P] [US2] In `src/services/weather_config_service.py`, add three async upsert functions: `set_phase_1_days(db_path, server_id, days)`, `set_phase_2_days(db_path, server_id, days)`, `set_phase_3_hours(db_path, server_id, hours)` — each executes `INSERT INTO weather_pipeline_config (...) VALUES (...) ON CONFLICT(server_id) DO UPDATE SET <column> = excluded.<column>`; returns the updated `WeatherPipelineConfig`; does **not** validate ordering (ordering validation added in US3)
+- [X] T009 [P] [US2] In `src/cogs/module_cog.py`, update `_catchup_and_schedule_weather()` — after fetching the round list, call `await weather_config_service.get_weather_pipeline_config(self.bot.db_path, server_id)` and pass `phase_1_days`, `phase_2_days`, `phase_3_hours` as kwargs to each `self.bot.scheduler_service.schedule_round(rnd, ...)` call
+- [X] T010 [P] [US2] In `src/cogs/season_cog.py`, update the season-activation path — before calling `self.bot.scheduler_service.schedule_all_rounds(all_rounds)`, fetch `WeatherPipelineConfig` via `weather_config_service.get_weather_pipeline_config` and pass the three phase kwargs to `schedule_all_rounds()`
+- [X] T011 [US2] Create `src/cogs/weather_cog.py` with `WeatherCog(commands.Cog)` — define `weather = app_commands.Group(name="weather", description="Weather module commands")` and a nested `config_group = app_commands.Group(name="config", parent=weather, description="Configure weather pipeline settings")`; implement three `@config_group.command(...)` handlers (`phase_1_deadline(days: int)`, `phase_2_deadline(days: int)`, `phase_3_deadline(hours: int)`); each handler: (a) checks weather module enabled via `bot.module_service` → ephemeral error if not; (b) checks no ACTIVE season via `bot.season_service.get_active_season(server_id)` → ephemeral rejection if active; (c) validates `days >= 1` / `hours >= 1`; (d) calls the corresponding `set_phase_*` function; (e) writes audit log entry with change type from contracts (`WEATHER_CONFIG_PHASE1_DEADLINE` etc.), old value, new value, actor; (f) responds with success message including all three current values (ordering error branch added in US3)
+- [X] T012 [US2] In `src/bot.py`, load `WeatherCog` in `setup_hook` (alongside existing cog additions) with `await self.add_cog(WeatherCog(self))`
+
+**Checkpoint**: All three deadline commands are live, persist across restarts, and the scheduler uses the stored values. US3 ordering validation can now be layered on.
+
+---
+
+## Phase 5: User Story 3 — Phase Deadline Ordering Validation (Priority: P2)
+
+**Goal**: Any deadline command that would produce a configuration violating `(P1_days × 24) > (P2_days × 24) > P3_hours` is rejected before any state change, with an error identifying the conflicting current value.
+
+**Independent Test**: With defaults (P1=5d, P2=2d, P3=2h): run `/weather config phase-1-deadline 1` → rejected citing P2 conflict; run `/weather config phase-2-deadline 6` → rejected citing P1 conflict; run `/weather config phase-3-deadline 72` → rejected citing P2 conflict. After each rejection, confirm config is unchanged (persistence check).
+
+- [X] T013 [US3] In `src/services/weather_config_service.py`, add `validate_ordering(p1_days: int, p2_days: int, p3_hours: int) -> str | None` — returns `None` if `(p1_days * 24) > (p2_days * 24) > p3_hours` (strict), otherwise returns a descriptive error string identifying which constraint is violated (e.g. `"Phase 1 (Xd) must be greater than Phase 2 (Yd)"`)
+- [X] T014 [US3] In `src/services/weather_config_service.py`, integrate `validate_ordering` into each set method — before the upsert, fetch the current config via `get_weather_pipeline_config`, substitute the candidate new value, call `validate_ordering` with the resulting trio; if an error string is returned, do **not** execute the upsert and return the error string to the caller instead of the updated config
+- [X] T015 [US3] In `src/cogs/weather_cog.py`, update each `phase-N-deadline` command handler to handle an ordering-error return from the set method — send an ephemeral error response with the exact message format from `contracts/commands.md` (e.g. `"❌ Phase 2 deadline (6d) must be less than the current Phase 1 deadline (5d). ..."`)
+
+**Checkpoint**: All three user stories are fully functional and independently testable. The full feature is complete.
+
+---
+
+## Phase 6: Polish & Cross-Cutting Concerns
+
+**Purpose**: Final integration checks and housekeeping.
+
+- [X] T016 Verify migration file is named `028_weather_pipeline_config.sql` (no gaps relative to `027_season_signup_flow.sql`) and bot starts cleanly with `python -m pytest tests/ -v`; confirm `WeatherCog` appears in the cog load log on startup
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 (T001) — blocks US2 and US3 only
+- **Phase 3 (US1)**: Depends on **nothing in Phase 2** — can start in parallel with Phase 2 immediately after Phase 1
+- **Phase 4 (US2)**: Depends on Phase 2 completion (T002, T003, T004)
+- **Phase 5 (US3)**: Depends on Phase 4 completion (T008, T011 must exist before ordering validation is wired in)
+- **Phase 6 (Polish)**: Depends on all phases complete
+
+### User Story Dependencies
+
+| Story | Depends on | Independent from |
+|---|---|---|
+| US1 (Results Resubmission) | Phase 1 only | US2, US3, Phase 2 entirely |
+| US2 (Configure Deadlines) | Phase 2 (T001–T004) | US1 |
+| US3 (Ordering Validation) | US2 phase complete (T008 for set methods, T011 for cog) | US1 |
+
+### Within Phase 3 (US1)
+
+- T005 (penalty_wizard.py) and T006 (result_submission_service.py) can be written in parallel — different files
+- T007 (result_submission_service.py) follows T006 — same file, calls `enter_penalty_state(is_resubmission=True)`
+
+### Within Phase 4 (US2)
+
+- T008, T009, T010 can all be written in parallel — all different files, all depend only on T002–T004
+- T011 (weather_cog.py) follows T008 (needs set methods to call)
+- T012 (bot.py) follows T011 (needs the WeatherCog class to exist)
+
+### Within Phase 5 (US3)
+
+- T013 → T014 → T015 are sequential (same file for T013+T014; T015 depends on T014's error return)
+
+---
+
+## Parallel Execution Examples
+
+### Phase 3 (US1) — Two tracks
+
+```
+Track A: T005 (penalty_wizard.py button)
+Track B: T006 → T007 (result_submission_service.py is_resubmission + flow)
+Merge: both complete → US1 is independently testable
+```
+
+### Phase 4 (US2) — Three parallel + sequential tail
+
+```
+Track A: T008 (weather_config_service.py set methods)
+Track B: T009 (module_cog.py caller update)
+Track C: T010 (season_cog.py caller update)
+Sequential tail: T011 (weather_cog.py, needs T008) → T012 (bot.py)
+```
+
+---
+
+## Implementation Strategy
+
+**MVP (User Story 1 only)**: Complete Phase 1 + Phase 3 (T001, T005, T006, T007) for a fully deliverable results hotfix resubmission capability with no weather work required.
+
+**Full feature**: Add Phase 2 + Phase 4 + Phase 5 for complete weather configuration capability. Phase 2 can be worked in parallel with Phase 3.
+
+**Suggested order for a single developer**:
+1. T001 (migration — fast)
+2. T002, T003 in parallel (model + scheduler — fast, different files)
+3. T004 (config reader)
+4. T005, T006 in parallel (US1 prep — different files)
+5. T007 (US1 resubmit flow — core logic)
+6. T008, T009, T010 in parallel (US2 prep)
+7. T011 (weather cog)
+8. T012 (register cog)
+9. T013 → T014 → T015 (US3 validation)
+10. T016 (polish/smoke test)

--- a/src/bot.py
+++ b/src/bot.py
@@ -221,6 +221,7 @@ async def main() -> None:
     from cogs.admin_review_cog import AdminReviewCog
     from cogs.retry_cog import RetryCog
     from cogs.results_cog import ResultsCog
+    from cogs.weather_cog import WeatherCog
 
     await bot.add_cog(InitCog(bot))
     await bot.add_cog(SeasonCog(bot))
@@ -235,6 +236,7 @@ async def main() -> None:
     await bot.add_cog(AdminReviewCog(bot))
     await bot.add_cog(RetryCog(bot))
     await bot.add_cog(ResultsCog(bot))
+    await bot.add_cog(WeatherCog(bot))
 
     # Register ALL persistent views so button interactions survive bot restarts.
     # Views with optional __init__ params resolve driver context from channel at

--- a/src/cogs/module_cog.py
+++ b/src/cogs/module_cog.py
@@ -264,7 +264,10 @@ class ModuleCog(commands.Cog):
         from services.phase1_service import run_phase1
         from services.phase2_service import run_phase2
         from services.phase3_service import run_phase3
+        from services.weather_config_service import get_weather_pipeline_config
         from models.round import RoundFormat
+
+        cfg = await get_weather_pipeline_config(self.bot.db_path, server_id)
 
         now = datetime.now(timezone.utc)
         divisions = await self.bot.season_service.get_divisions(season.id)  # type: ignore[union-attr]
@@ -281,9 +284,9 @@ class ModuleCog(commands.Cog):
             if scheduled_at.tzinfo is None:
                 scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
 
-            p1_horizon = scheduled_at - timedelta(days=5)
-            p2_horizon = scheduled_at - timedelta(days=2)
-            p3_horizon = scheduled_at - timedelta(hours=2)
+            p1_horizon = scheduled_at - timedelta(days=cfg.phase_1_days)
+            p2_horizon = scheduled_at - timedelta(days=cfg.phase_2_days)
+            p3_horizon = scheduled_at - timedelta(hours=cfg.phase_3_hours)
 
             if not rnd.phase1_done and now >= p1_horizon:
                 log.info("Weather enable catch-up: Phase 1 for round %s", rnd.id)
@@ -295,7 +298,12 @@ class ModuleCog(commands.Cog):
                 log.info("Weather enable catch-up: Phase 3 for round %s", rnd.id)
                 await run_phase3(rnd.id, self.bot)
 
-            self.bot.scheduler_service.schedule_round(rnd)
+            self.bot.scheduler_service.schedule_round(
+                rnd,
+                phase_1_days=cfg.phase_1_days,
+                phase_2_days=cfg.phase_2_days,
+                phase_3_hours=cfg.phase_3_hours,
+            )
 
     # ── Weather disable (T012) ─────────────────────────────────────────
 

--- a/src/cogs/season_cog.py
+++ b/src/cogs/season_cog.py
@@ -2517,7 +2517,14 @@ class SeasonCog(commands.Cog):
         results_enabled = await self.bot.module_service.is_results_enabled(cfg.server_id)
         if weather_enabled:
             # schedule_round creates weather phase jobs AND the results_r job together
-            self.bot.scheduler_service.schedule_all_rounds(all_rounds)
+            from services.weather_config_service import get_weather_pipeline_config
+            _wcfg = await get_weather_pipeline_config(self.bot.db_path, cfg.server_id)
+            self.bot.scheduler_service.schedule_all_rounds(
+                all_rounds,
+                phase_1_days=_wcfg.phase_1_days,
+                phase_2_days=_wcfg.phase_2_days,
+                phase_3_hours=_wcfg.phase_3_hours,
+            )
         elif results_enabled:
             # Weather off but results on: schedule results_r jobs for production
             # (real future race times).  In test mode we skip this because past-dated

--- a/src/cogs/weather_cog.py
+++ b/src/cogs/weather_cog.py
@@ -1,0 +1,189 @@
+"""WeatherCog — /weather command group.
+
+Provides /weather config phase-1-deadline, phase-2-deadline, phase-3-deadline
+for configuring per-server weather pipeline horizons.
+"""
+from __future__ import annotations
+
+import logging
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from utils.channel_guard import admin_only, channel_guard
+
+log = logging.getLogger(__name__)
+
+
+class WeatherCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    # ------------------------------------------------------------------
+    # /weather config group
+    # ------------------------------------------------------------------
+
+    weather = app_commands.Group(name="weather", description="Weather module commands")
+    config_group = app_commands.Group(
+        name="config", description="Configure weather pipeline settings", parent=weather
+    )
+
+    # ------------------------------------------------------------------
+    # Shared pre-condition checks
+    # ------------------------------------------------------------------
+
+    async def _weather_gate(self, interaction: discord.Interaction) -> bool:
+        """Return True (and respond ephemerally) if weather module is not enabled."""
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+        if not await self.bot.module_service.is_weather_enabled(server_id):  # type: ignore[attr-defined]
+            await interaction.response.send_message(
+                "❌ The weather module is not enabled.", ephemeral=True
+            )
+            return False
+        return True
+
+    async def _active_season_gate(self, interaction: discord.Interaction) -> bool:
+        """Return True (and respond ephemerally) if a season is currently ACTIVE."""
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+        season = await self.bot.season_service.get_active_season(server_id)  # type: ignore[attr-defined]
+        if season is not None:
+            await interaction.response.send_message(
+                "❌ Phase deadline configuration cannot be changed while a season is active.",
+                ephemeral=True,
+            )
+            return True
+        return False
+
+    # ------------------------------------------------------------------
+    # /weather config phase-1-deadline
+    # ------------------------------------------------------------------
+
+    @config_group.command(
+        name="phase-1-deadline",
+        description="Set days before round to publish Phase 1 weather (default 5).",
+    )
+    @app_commands.describe(days="Number of days before the round (positive integer)")
+    @channel_guard
+    @admin_only
+    async def phase_1_deadline(self, interaction: discord.Interaction, days: int) -> None:
+        if not await self._weather_gate(interaction):
+            return
+        if await self._active_season_gate(interaction):
+            return
+        if days < 1:
+            await interaction.response.send_message(
+                "❌ Phase 1 deadline must be at least 1 day.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+
+        from services.weather_config_service import set_phase_1_days
+        result = await set_phase_1_days(self.bot.db_path, server_id, days)  # type: ignore[attr-defined]
+
+        if isinstance(result, str):
+            await interaction.followup.send(f"❌ {result}", ephemeral=True)
+            return
+
+        await self.bot.output_router.post_log(  # type: ignore[attr-defined]
+            server_id,
+            f"{interaction.user.display_name} (<@{interaction.user.id}>) | WEATHER_CONFIG_PHASE1_DEADLINE | Success\n"
+            f"  new_value: {days}d  (Phase 2: {result.phase_2_days}d, Phase 3: {result.phase_3_hours}h)",
+        )
+        await interaction.followup.send(
+            f"✅ Phase 1 deadline set to **{days} day(s)** before round. "
+            f"(Phase 2: {result.phase_2_days}d, Phase 3: {result.phase_3_hours}h)",
+            ephemeral=True,
+        )
+
+    # ------------------------------------------------------------------
+    # /weather config phase-2-deadline
+    # ------------------------------------------------------------------
+
+    @config_group.command(
+        name="phase-2-deadline",
+        description="Set days before round to publish Phase 2 weather (default 2).",
+    )
+    @app_commands.describe(days="Number of days before the round (positive integer)")
+    @channel_guard
+    @admin_only
+    async def phase_2_deadline(self, interaction: discord.Interaction, days: int) -> None:
+        if not await self._weather_gate(interaction):
+            return
+        if await self._active_season_gate(interaction):
+            return
+        if days < 1:
+            await interaction.response.send_message(
+                "❌ Phase 2 deadline must be at least 1 day.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+
+        from services.weather_config_service import set_phase_2_days
+        result = await set_phase_2_days(self.bot.db_path, server_id, days)  # type: ignore[attr-defined]
+
+        if isinstance(result, str):
+            await interaction.followup.send(f"❌ {result}", ephemeral=True)
+            return
+
+        await self.bot.output_router.post_log(  # type: ignore[attr-defined]
+            server_id,
+            f"{interaction.user.display_name} (<@{interaction.user.id}>) | WEATHER_CONFIG_PHASE2_DEADLINE | Success\n"
+            f"  new_value: {days}d  (Phase 1: {result.phase_1_days}d, Phase 3: {result.phase_3_hours}h)",
+        )
+        await interaction.followup.send(
+            f"✅ Phase 2 deadline set to **{days} day(s)** before round. "
+            f"(Phase 1: {result.phase_1_days}d, Phase 3: {result.phase_3_hours}h)",
+            ephemeral=True,
+        )
+
+    # ------------------------------------------------------------------
+    # /weather config phase-3-deadline
+    # ------------------------------------------------------------------
+
+    @config_group.command(
+        name="phase-3-deadline",
+        description="Set hours before round to publish Phase 3 weather (default 2).",
+    )
+    @app_commands.describe(hours="Number of hours before the round (positive integer)")
+    @channel_guard
+    @admin_only
+    async def phase_3_deadline(self, interaction: discord.Interaction, hours: int) -> None:
+        if not await self._weather_gate(interaction):
+            return
+        if await self._active_season_gate(interaction):
+            return
+        if hours < 1:
+            await interaction.response.send_message(
+                "❌ Phase 3 deadline must be at least 1 hour.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+
+        from services.weather_config_service import set_phase_3_hours
+        result = await set_phase_3_hours(self.bot.db_path, server_id, hours)  # type: ignore[attr-defined]
+
+        if isinstance(result, str):
+            await interaction.followup.send(f"❌ {result}", ephemeral=True)
+            return
+
+        await self.bot.output_router.post_log(  # type: ignore[attr-defined]
+            server_id,
+            f"{interaction.user.display_name} (<@{interaction.user.id}>) | WEATHER_CONFIG_PHASE3_DEADLINE | Success\n"
+            f"  new_value: {hours}h  (Phase 1: {result.phase_1_days}d, Phase 2: {result.phase_2_days}d)",
+        )
+        await interaction.followup.send(
+            f"✅ Phase 3 deadline set to **{hours} hour(s)** before round. "
+            f"(Phase 1: {result.phase_1_days}d, Phase 2: {result.phase_2_days}d)",
+            ephemeral=True,
+        )
+
+
+async def setup(bot: commands.Bot) -> None:
+    await bot.add_cog(WeatherCog(bot))

--- a/src/db/migrations/028_weather_pipeline_config.sql
+++ b/src/db/migrations/028_weather_pipeline_config.sql
@@ -1,0 +1,7 @@
+CREATE TABLE IF NOT EXISTS weather_pipeline_config (
+    server_id     INTEGER PRIMARY KEY
+                      REFERENCES server_configs(server_id) ON DELETE CASCADE,
+    phase_1_days  INTEGER NOT NULL DEFAULT 5,
+    phase_2_days  INTEGER NOT NULL DEFAULT 2,
+    phase_3_hours INTEGER NOT NULL DEFAULT 2
+);

--- a/src/models/weather_config.py
+++ b/src/models/weather_config.py
@@ -1,0 +1,17 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class WeatherPipelineConfig:
+    """Per-server configurable phase horizons for the weather pipeline.
+
+    Default values match the previously hardcoded schedule_round horizons:
+    Phase 1 at T−5 days, Phase 2 at T−2 days, Phase 3 at T−2 hours.
+    """
+
+    server_id: int
+    phase_1_days: int = 5
+    phase_2_days: int = 2
+    phase_3_hours: int = 2

--- a/src/services/penalty_wizard.py
+++ b/src/services/penalty_wizard.py
@@ -27,6 +27,7 @@ log = logging.getLogger(__name__)
 _CID_ADD              = "pw_add"
 _CID_CONFIRM          = "pw_confirm"
 _CID_APPROVE          = "pw_approve"
+_CID_RESUBMIT         = "pw_resubmit"
 _CID_AV_MAKE_CHANGES  = "pw_av_make_changes"
 _CID_AV_APPROVE       = "pw_av_approve"
 _CID_AR_APPROVE       = "ar_approve"
@@ -661,6 +662,27 @@ class PenaltyReviewView(discord.ui.View):
             return
         from services.result_submission_service import finalize_penalty_review
         await finalize_penalty_review(interaction, self.state)
+
+    @discord.ui.button(
+        label="🔄 Resubmit Initial Results",
+        style=discord.ButtonStyle.danger,
+        custom_id=_CID_RESUBMIT,
+        row=0,
+    )
+    async def resubmit_btn(
+        self, interaction: discord.Interaction, button: discord.ui.Button
+    ) -> None:
+        if self.state is None:
+            await interaction.response.send_message(
+                "⚠️ The bot was restarted. Please wait for the penalty prompt to refresh.",
+                ephemeral=True,
+            )
+            return
+        if not await _require_lm(interaction, self.state):
+            return
+        await interaction.response.defer(ephemeral=True)
+        from services.result_submission_service import enter_resubmit_flow
+        await enter_resubmit_flow(interaction, self.state)
 
 
 # ---------------------------------------------------------------------------

--- a/src/services/result_submission_service.py
+++ b/src/services/result_submission_service.py
@@ -240,6 +240,7 @@ async def enter_penalty_state(
     *,
     season_id: int | None = None,
     skip_results_post: bool = False,
+    is_resubmission: bool = False,
 ) -> None:
     """Transition the submission channel to post-round penalty-review state.
 
@@ -315,9 +316,10 @@ async def enter_penalty_state(
             if results_ch_id:
                 rc = guild.get_channel(results_ch_id)
                 if rc:
+                    _results_label = "Provisional Results (amended)" if is_resubmission else "Provisional Results"
                     await results_post_service.post_round_results(
                         db_path, round_id, division_id, rc, guild,
-                        label="Provisional Results",
+                        label=_results_label,
                     )
 
             if standings_ch_id:
@@ -329,13 +331,12 @@ async def enter_penalty_state(
                     )
                     driver_snaps = await compute_driver_standings(db_path, division_id, round_id)
                     team_snaps = await compute_team_standings(db_path, division_id, round_id)
+                    _standings_label = "Provisional Results (amended)" if is_resubmission else "Provisional Results"
                     await results_post_service.post_standings(
                         db_path, division_id, round_id, round_number, track_name,
                         sc, driver_snaps, team_snaps, guild, show_reserves,
-                        label="Provisional Results",
+                        label=_standings_label,
                     )
-
-            # Mark results as posted so restart recovery knows not to re-post.
             async with get_connection(db_path) as db:
                 await db.execute(
                     "UPDATE round_submission_channels SET results_posted = 1 WHERE round_id = ?",
@@ -2095,3 +2096,264 @@ async def run_result_submission_job(round_id: int, bot) -> None:
         await close_submission_channel(sub_channel.id, round_id, guild, db_path)
         return
     await enter_penalty_state(bot, guild, round_id, division_id, sub_channel, season_id=season_id)
+
+
+# ---------------------------------------------------------------------------
+# Resubmission flow — triggered by the 🔄 Resubmit Initial Results button
+# ---------------------------------------------------------------------------
+
+async def enter_resubmit_flow(
+    interaction: discord.Interaction,
+    state,
+) -> None:
+    """Discard staged penalties, supersede existing results, and restart collection.
+
+    Called from the pw_resubmit button callback in PenaltyReviewView.
+    """
+    import asyncio
+    import json as _json
+
+    bot = state.bot
+    db_path: str = bot.db_path
+    round_id = state.round_id
+    division_id = state.division_id
+    actor_id: int = interaction.user.id
+
+    discarded_count = len(state.staged)
+    discarded_detail = [
+        {
+            "driver_user_id": sp.driver_user_id,
+            "session_type": sp.session_type.value,
+            "penalty_type": sp.penalty_type,
+            "penalty_seconds": sp.penalty_seconds,
+        }
+        for sp in state.staged
+    ]
+
+    srv_row = None
+    try:
+        async with get_connection(db_path) as db:
+            cursor = await db.execute(
+                "SELECT s.server_id FROM seasons s JOIN divisions d ON d.season_id = s.id WHERE d.id = ?",
+                (division_id,),
+            )
+            srv_row = await cursor.fetchone()
+        if srv_row:
+            await bot.output_router.post_log(
+                int(srv_row["server_id"]),
+                f"<@{actor_id}> | RESULTS_RESUBMISSION_STAGED_DISCARD | Success\n"
+                f"  round_id: {round_id} ({state.division_name})\n"
+                f"  discarded_count: {discarded_count}\n"
+                f"  discarded: {_json.dumps(discarded_detail)}",
+            )
+    except Exception:
+        log.exception("enter_resubmit_flow: error writing staged-discard audit log (round %s)", round_id)
+
+    state.staged.clear()
+
+    async with get_connection(db_path) as db:
+        await db.execute(
+            "UPDATE driver_session_results SET is_superseded = 1 "
+            "WHERE session_result_id IN (SELECT id FROM session_results WHERE round_id = ?)",
+            (round_id,),
+        )
+        await db.execute("DELETE FROM session_results WHERE round_id = ?", (round_id,))
+        await db.execute(
+            "UPDATE round_submission_channels SET in_penalty_review = 0, results_posted = 0 WHERE round_id = ?",
+            (round_id,),
+        )
+        await db.commit()
+
+    sub_channel = bot.get_channel(state.submission_channel_id)
+    if sub_channel is not None:
+        await sub_channel.send(
+            "⚠️ **Results resubmission started.** "
+            "Previous provisional results will be replaced once new results are submitted."
+        )
+
+    asyncio.create_task(
+        _resubmit_collection_task(round_id, division_id, bot, sub_channel),
+        name=f"resubmit_r{round_id}",
+    )
+
+    try:
+        if srv_row:
+            await bot.output_router.post_log(
+                int(srv_row["server_id"]),
+                f"<@{actor_id}> | RESULTS_RESUBMISSION | Started\n"
+                f"  round_id: {round_id} ({state.division_name})\n"
+                f"  Previous staged penalties discarded: {discarded_count}",
+            )
+    except Exception:
+        log.exception("enter_resubmit_flow: error writing resubmission audit log (round %s)", round_id)
+
+    await interaction.followup.send(
+        "🔄 Resubmission started. Please re-enter the session results in the submission channel.",
+        ephemeral=True,
+    )
+
+
+async def _resubmit_collection_task(
+    round_id: int,
+    division_id: int,
+    bot,
+    sub_channel: discord.TextChannel | None,
+) -> None:
+    """Re-run the session collection loop against an existing submission channel.
+
+    Mirrors run_result_submission_job but skips channel creation.
+    On completion calls enter_penalty_state(..., is_resubmission=True).
+    """
+    if sub_channel is None:
+        log.error("_resubmit_collection_task: sub_channel not found for round %s", round_id)
+        return
+
+    db_path: str = bot.db_path
+    ctx = await _get_round_context(db_path, round_id)
+    if ctx is None:
+        log.error("_resubmit_collection_task: round %s not found", round_id)
+        return
+
+    server_id: int = ctx["server_id"]
+    season_id: int = ctx["season_id"]
+    division_name: str = ctx["division_name"]
+    round_number: int = ctx["round_number"]
+    round_format = RoundFormat(ctx["round_format"])
+
+    guild = bot.get_guild(server_id)
+    if guild is None:
+        log.error("_resubmit_collection_task: guild %s not found for round %s", server_id, round_id)
+        return
+
+    try:
+        (
+            division_driver_ids,
+            team_role_ids,
+            reserve_team_role_id,
+            driver_team_map,
+            reserve_driver_ids,
+        ) = await _build_division_validation_data(division_id, server_id, bot)
+    except Exception:
+        log.exception("_resubmit_collection_task: failed to build validation data for round %s", round_id)
+        await sub_channel.send("❌ Resubmission failed: could not load division data.")
+        return
+
+    from services import season_points_service
+    config_names = await season_points_service.get_attached_config_names(db_path, season_id)
+
+    sessions = get_sessions_for_format(round_format)
+    is_sprint = round_format is RoundFormat.SPRINT
+    session_list_str = ", ".join(
+        results_formatter.format_session_label(s, is_sprint=is_sprint) for s in sessions
+    )
+    await sub_channel.send(
+        f"🔄 Resubmitting results for **Round {round_number}** ({division_name})."
+        f" Sessions: {session_list_str}.\n\n"
+        "Submit results one driver per line (comma-separated), or type `CANCELLED` to skip a session."
+    )
+
+    cancelled_sessions: set[SessionType] = set()
+    for session_type in sessions:
+        label = results_formatter.format_session_label(session_type, is_sprint=is_sprint)
+        if session_type.is_qualifying:
+            format_hint = "Format: `Position, @Driver, @TeamRole, Tyre, BestLap, Gap`"
+        else:
+            format_hint = (
+                "Format: `Position, @Driver, @TeamRole, TotalTime, FastestLap, TimePenalties`\n"
+                "Optional first line: `FL: @Driver` to override fastest-lap holder."
+            )
+
+        await sub_channel.send(
+            f"📋 Submit **{label}** results (one driver per line), or type `CANCELLED`.\n{format_hint}"
+        )
+
+        while True:
+            msg = await bot.wait_for(
+                "message",
+                check=lambda m, ch=sub_channel: (m.channel.id == ch.id and not m.author.bot),
+            )
+            content = msg.content.strip()
+
+            if content.upper() == "CANCELLED":
+                await save_session_result(
+                    db_path=db_path, round_id=round_id, division_id=division_id,
+                    session_type=session_type, status="CANCELLED", config_name=None,
+                    submitted_by=msg.author.id, driver_rows=[],
+                )
+                await sub_channel.send(f"✅ **{label}** marked as CANCELLED.")
+                cancelled_sessions.add(session_type)
+                break
+
+            lines = content.splitlines()
+            fl_override: int | None = None
+            if not session_type.is_qualifying:
+                fl_override, lines = extract_fl_override(lines)
+            result = validate_submission_block(
+                lines, session_type, division_driver_ids, team_role_ids,
+                reserve_team_role_id, driver_team_map, reserve_driver_ids,
+            )
+
+            if isinstance(result[0] if result else None, str):
+                error_list = "\n".join(f"• {e}" for e in result)
+                await sub_channel.send(f"❌ Validation failed:\n{error_list}\nPlease correct and resubmit.")
+                continue
+
+            parsed_rows = result
+            if fl_override is not None:
+                submitted_ids = {r.driver_user_id for r in parsed_rows}
+                if fl_override not in submitted_ids:
+                    await sub_channel.send(
+                        f"❌ FL override <@{fl_override}> is not in the submitted results. Please correct and resubmit."
+                    )
+                    continue
+
+            selected_config: str | None = None
+            if len(config_names) == 1:
+                selected_config = config_names[0]
+                await sub_channel.send(f"✅ Auto-selected config **{selected_config}**.")
+            elif len(config_names) > 1:
+                view = _ConfigSelectView(config_names)
+                config_msg = await sub_channel.send("🔧 Select the points configuration for this session:", view=view)
+                await view.wait()
+                selected_config = view.selected
+                try:
+                    await config_msg.edit(content=f"🔧 Config selected: **{selected_config}**", view=None)
+                except discord.HTTPException:
+                    pass
+
+            if session_type.is_qualifying:
+                driver_rows_data = [_row_dict_from_qualifying(r) for r in parsed_rows]  # type: ignore[arg-type]
+            else:
+                driver_rows_data = [_row_dict_from_race(r) for r in parsed_rows]  # type: ignore[arg-type]
+
+            await save_session_result(
+                db_path=db_path, round_id=round_id, division_id=division_id,
+                session_type=session_type, status="ACTIVE", config_name=selected_config,
+                submitted_by=msg.author.id, driver_rows=driver_rows_data,
+                fl_driver_override=fl_override,
+            )
+
+            if selected_config is not None:
+                async with get_connection(db_path) as _db:
+                    _cur = await _db.execute(
+                        "SELECT id FROM session_results WHERE round_id = ? AND session_type = ?",
+                        (round_id, session_type.value),
+                    )
+                    _sr = await _cur.fetchone()
+                if _sr is not None:
+                    await _apply_points_from_config(db_path, _sr["id"], season_id, selected_config, session_type)
+
+            await sub_channel.send(f"✅ **{label}** results saved.")
+            break
+
+    if cancelled_sessions == set(sessions):
+        await sub_channel.send("⏭️ All sessions were cancelled — no penalty review required.")
+        await close_submission_channel(sub_channel.id, round_id, guild, db_path)
+        return
+
+    await enter_penalty_state(
+        bot, guild, round_id, division_id, sub_channel,
+        season_id=season_id,
+        is_resubmission=True,
+    )
+

--- a/src/services/scheduler_service.py
+++ b/src/services/scheduler_service.py
@@ -236,12 +236,24 @@ class SchedulerService:
     # Round scheduling
     # ------------------------------------------------------------------
 
-    def schedule_round(self, rnd: Round) -> None:
+    def schedule_round(
+        self,
+        rnd: Round,
+        *,
+        phase_1_days: int = 5,
+        phase_2_days: int = 2,
+        phase_3_hours: int = 2,
+    ) -> None:
         """Register DateTrigger jobs for *rnd*.
 
         MYSTERY rounds: schedule the notice job (T−5 days) and the result
         submission job (round start time), but no weather phase jobs.
         Jobs use replace_existing=True so re-scheduling an amended round is safe.
+
+        Args:
+            phase_1_days: Days before the round to fire Phase 1 (default 5).
+            phase_2_days: Days before the round to fire Phase 2 (default 2).
+            phase_3_hours: Hours before the round to fire Phase 3 (default 2).
         """
         if rnd.format == RoundFormat.MYSTERY:
             scheduled_at = rnd.scheduled_at
@@ -276,9 +288,9 @@ class SchedulerService:
             scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
 
         horizons = {
-            1: scheduled_at - timedelta(days=5),
-            2: scheduled_at - timedelta(days=2),
-            3: scheduled_at - timedelta(hours=2),
+            1: scheduled_at - timedelta(days=phase_1_days),
+            2: scheduled_at - timedelta(days=phase_2_days),
+            3: scheduled_at - timedelta(hours=phase_3_hours),
         }
 
         for phase_num, fire_at in horizons.items():
@@ -352,10 +364,22 @@ class SchedulerService:
         for row in rows:
             self.cancel_round(row[0])
 
-    def schedule_all_rounds(self, rounds: list[Round]) -> None:
+    def schedule_all_rounds(
+        self,
+        rounds: list[Round],
+        *,
+        phase_1_days: int = 5,
+        phase_2_days: int = 2,
+        phase_3_hours: int = 2,
+    ) -> None:
         """Schedule all rounds in *rounds*."""
         for rnd in rounds:
-            self.schedule_round(rnd)
+            self.schedule_round(
+                rnd,
+                phase_1_days=phase_1_days,
+                phase_2_days=phase_2_days,
+                phase_3_hours=phase_3_hours,
+            )
 
     def schedule_result_submission_jobs(self, rounds: list[Round]) -> None:
         """Schedule only the result-submission job for each round.

--- a/src/services/weather_config_service.py
+++ b/src/services/weather_config_service.py
@@ -1,0 +1,145 @@
+"""weather_config_service.py — CRUD for the weather_pipeline_config table.
+
+Provides per-server configurable phase horizons (Phase 1 in days, Phase 2 in
+days, Phase 3 in hours) with defaults of 5 / 2 / 2 matching the previously
+hardcoded schedule_round values.
+
+Ordering invariant (enforced before every write):
+    (phase_1_days × 24) > (phase_2_days × 24) > phase_3_hours   [strict]
+"""
+from __future__ import annotations
+
+from db.database import get_connection
+from models.weather_config import WeatherPipelineConfig
+
+_DEFAULTS = WeatherPipelineConfig(server_id=0)  # default field values only
+
+
+async def get_weather_pipeline_config(
+    db_path: str,
+    server_id: int,
+) -> WeatherPipelineConfig:
+    """Return the stored config for *server_id*, or default values if absent."""
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            "SELECT phase_1_days, phase_2_days, phase_3_hours "
+            "FROM weather_pipeline_config WHERE server_id = ?",
+            (server_id,),
+        )
+        row = await cursor.fetchone()
+    if row is None:
+        return WeatherPipelineConfig(server_id=server_id)
+    return WeatherPipelineConfig(
+        server_id=server_id,
+        phase_1_days=row["phase_1_days"],
+        phase_2_days=row["phase_2_days"],
+        phase_3_hours=row["phase_3_hours"],
+    )
+
+
+def validate_ordering(
+    p1_days: int,
+    p2_days: int,
+    p3_hours: int,
+) -> str | None:
+    """Return None if the ordering invariant holds, or an error string if not.
+
+    Invariant: (p1_days × 24) > (p2_days × 24) > p3_hours  (strict inequality)
+    """
+    p1_hours = p1_days * 24
+    p2_hours = p2_days * 24
+    if p1_hours <= p2_hours:
+        return (
+            f"Phase 1 deadline ({p1_days}d = {p1_hours}h) must be strictly greater than "
+            f"Phase 2 deadline ({p2_days}d = {p2_hours}h)."
+        )
+    if p2_hours <= p3_hours:
+        return (
+            f"Phase 2 deadline ({p2_days}d = {p2_hours}h) must be strictly greater than "
+            f"Phase 3 deadline ({p3_hours}h)."
+        )
+    return None
+
+
+async def set_phase_1_days(
+    db_path: str,
+    server_id: int,
+    days: int,
+) -> WeatherPipelineConfig | str:
+    """Upsert phase_1_days.  Returns updated config, or an error string on violation."""
+    current = await get_weather_pipeline_config(db_path, server_id)
+    err = validate_ordering(days, current.phase_2_days, current.phase_3_hours)
+    if err:
+        return err
+    async with get_connection(db_path) as db:
+        await db.execute(
+            """
+            INSERT INTO weather_pipeline_config (server_id, phase_1_days, phase_2_days, phase_3_hours)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(server_id) DO UPDATE SET phase_1_days = excluded.phase_1_days
+            """,
+            (server_id, days, current.phase_2_days, current.phase_3_hours),
+        )
+        await db.commit()
+    return WeatherPipelineConfig(
+        server_id=server_id,
+        phase_1_days=days,
+        phase_2_days=current.phase_2_days,
+        phase_3_hours=current.phase_3_hours,
+    )
+
+
+async def set_phase_2_days(
+    db_path: str,
+    server_id: int,
+    days: int,
+) -> WeatherPipelineConfig | str:
+    """Upsert phase_2_days.  Returns updated config, or an error string on violation."""
+    current = await get_weather_pipeline_config(db_path, server_id)
+    err = validate_ordering(current.phase_1_days, days, current.phase_3_hours)
+    if err:
+        return err
+    async with get_connection(db_path) as db:
+        await db.execute(
+            """
+            INSERT INTO weather_pipeline_config (server_id, phase_1_days, phase_2_days, phase_3_hours)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(server_id) DO UPDATE SET phase_2_days = excluded.phase_2_days
+            """,
+            (server_id, current.phase_1_days, days, current.phase_3_hours),
+        )
+        await db.commit()
+    return WeatherPipelineConfig(
+        server_id=server_id,
+        phase_1_days=current.phase_1_days,
+        phase_2_days=days,
+        phase_3_hours=current.phase_3_hours,
+    )
+
+
+async def set_phase_3_hours(
+    db_path: str,
+    server_id: int,
+    hours: int,
+) -> WeatherPipelineConfig | str:
+    """Upsert phase_3_hours.  Returns updated config, or an error string on violation."""
+    current = await get_weather_pipeline_config(db_path, server_id)
+    err = validate_ordering(current.phase_1_days, current.phase_2_days, hours)
+    if err:
+        return err
+    async with get_connection(db_path) as db:
+        await db.execute(
+            """
+            INSERT INTO weather_pipeline_config (server_id, phase_1_days, phase_2_days, phase_3_hours)
+            VALUES (?, ?, ?, ?)
+            ON CONFLICT(server_id) DO UPDATE SET phase_3_hours = excluded.phase_3_hours
+            """,
+            (server_id, current.phase_1_days, current.phase_2_days, hours),
+        )
+        await db.commit()
+    return WeatherPipelineConfig(
+        server_id=server_id,
+        phase_1_days=current.phase_1_days,
+        phase_2_days=current.phase_2_days,
+        phase_3_hours=hours,
+    )


### PR DESCRIPTION
# Results changes
- Once the provisional results are validated and posted and the penalty wizard starts, there will be a new button that reads "resubmit initial results". This will be a hotfix button that will allow the resubmission of the initial results. Once used, there will be a temporary message requesting the new full result input. Once submitted and validated, the new provisional results will be posted in the appropriate channel with a note (amended) in the title. The standings according to these provisional results will likewise be reposted.
- All staged penalties will be discarded once this button is used.


------


# Weather changes
Weather forecast configuration is currently not customizable. The following changes shall be done

- <NEW COMMAND> An "weather config phase-1-deadline" command will be made available to league managers, which shall have as input an integer standing for a number of days. This command configures the number of days before a round at which point Phase 1 of the weather forecast for the round will be published.
    - By default, this value will be set to 5.
- <NEW COMMAND> An "weather config phase-2-deadline" command will be made available to league managers, which shall have as input an integer standing for a number of hours. This command configures the number of days before a round at which point Phase 2 of the weather forecast for the round will be published.
    - By default, this value will be set to 2.
- <NEW COMMAND> An "weather config phase-3-deadline" command will be made available to league managers, which shall have as input an integer standing for a number of hours. This command configures the number of hours before a round at which point Phase 3 of the weather forecast for the round will be published.
    - By default, this value will be set to 2.
- The input from all commands shall be validated against the current settings so that Phase 3 always happens after Phases 1 and 2, and Phase 2 always happens after Phase 1. Ergo, the configuration shall follow the rule P1\*24 > P2\*24 > P3.
- If there is an ongoing season (read: season approved/active), all three commands must be rejected.