### PR TITLE
031 attendance module

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,52 @@
 <!--
 SYNC IMPACT REPORT
 ==================
+[2026-04-03 — v2.9.0 → v2.10.0: Attendance module ratified — Principle XIII added]
+  Version change    : 2.9.0 → 2.10.0
+  Bump rationale    : MINOR — The Attendance module is formally ratified as a new optional
+                      module. Driver check-in management and attendance tracking were
+                      previously unaddressed; this amendment:
+                        1. Adds "Driver attendance management" (check-in RSVP flow,
+                           attendance point accumulation, reserve distribution, and automatic
+                           sanction enforcement) to the formally in-scope domain list in
+                           Principle VI as item 11.
+                        2. Registers the Attendance module in Principle X's optional modules
+                           list, noting its dependency on the Results & Standings module.
+                        3. Introduces Principle XIII (Attendance & Check-in Integrity):
+                           module dependency gate, season-lifecycle constraints, RSVP notice
+                           timing invariants, reserve distribution rules, attendance point
+                           accumulation and pardon mechanics, autosack/autoreserve sanction
+                           automation, and channel discipline.
+                        4. Defines new data entities: AttendanceConfig, AttendanceDivision-
+                           Config, DriverRoundAttendance, AttendancePardon.
+  Feature branch    : 031-attendance-module (created 2026-04-03 from main)
+  Session intent    : Initial configuration of the Attendance module: governance
+                      ratification only. Implementation (commands, scheduler jobs, DB
+                      migrations, tests) to follow in dedicated sub-increments.
+  Modified principles:
+    - Principle VI (Incremental Scope Expansion) — item 11 (attendance management) added
+      to in-scope; corresponding entry removed from planned future scope (was not listed
+      there; no prior reference).
+    - Principle X (Modular Feature Architecture) — Attendance module added to optional
+      modules list with its dependency constraint.
+  Added sections    :
+    - Principle XIII: Attendance & Check-in Integrity (NEW)
+    - Data & State Management: New Entities (v2.10.0) — AttendanceConfig,
+      AttendanceDivisionConfig, DriverRoundAttendance, AttendancePardon.
+  Removed sections  : None
+  Templates confirmed aligned:
+    ✅ .specify/templates/plan-template.md       — dynamic Constitution Check; no changes.
+    ✅ .specify/templates/spec-template.md       — generic structure; no stale references.
+    ✅ .specify/templates/tasks-template.md      — generic; aligns with I–XIII.
+    ✅ .specify/templates/agent-file-template.md — generic placeholders; no stale names.
+    ✅ .specify/templates/checklist-template.md  — no impact.
+  Deferred TODOs (carried from prior sessions):
+    - Exact command naming for appeal submission and review commands to be confirmed
+      against the 026-penalty-posting-appeals implementation.
+    - Whether the existing penalty wizard loose-text fields on DriverSessionResult
+      (post_race_time_penalties, post_stewarding_total_time) have been superseded by
+      PenaltyRecord rows — migration confirmation required.
+
 [2026-04-03 — v2.8.0 → v2.9.0: Track entity formalised + track/tier stats preparation]
   Version change    : 2.8.0 → 2.9.0
   Bump rationale    : MINOR — The Track registry has been a de-facto bot entity since v1.0.0
@@ -959,6 +1005,10 @@ domains are formally in-scope as of this version:
     penalties, disqualifications) via a stewards workflow, posting of penalty decisions
     to a dedicated channel, and a second-level appeals process allowing interaction-role
     members to contest a penalty, resolved by a tier-2 admin.
+11. **Driver attendance management**: round RSVP check-in flow, reserve distribution at
+    the RSVP deadline, attendance tracking once round results are submitted, attendance
+    point accumulation per driver, attendance pardon workflow inside the penalty wizard,
+    and automatic sanction enforcement (autoreserve and autosack thresholds).
 
 The following domains are **planned future scope** — each will be formally ratified as an
 independent feature increment before any implementation begins:
@@ -1130,6 +1180,12 @@ structured subcommand):
 - **Results & standings module**: delivers the named points-configuration store, season
   attachment, session-by-session round result submission, standings computation, and results
   and standings channel posting (Principle XII).
+- **Attendance module**: manages round RSVP notices and check-in embeds, attendance
+  tracking per round, attendance point accumulation per driver, reserve distribution at
+  the RSVP deadline, and automatic sanction enforcement (autoreserve and autosack)
+  (Principle XIII). MUST NOT be enabled while the Results & Standings module is disabled;
+  if the Results & Standings module is disabled while Attendance is active, the Attendance
+  module is disabled automatically.
 - Additional modules as ratified under Principle VI.
 
 The following rules MUST hold for every optional module:
@@ -1395,6 +1451,198 @@ governs the **Results & Standings optional module** (Principle X).
 competitive league. A deterministic, auditable computation pipeline with named configurations
 and snapshot-based standings history ensures results can always be reproduced from raw input
 and legitimately contested.
+
+### XIII. Attendance & Check-in Integrity
+
+The Attendance module governs driver RSVP check-ins before each round and the resulting
+attendance tracking and point accumulation. It operates as an optional module (Principle X)
+and depends entirely on the Results & Standings module (Principle XII). The following rules
+are non-negotiable.
+
+#### Module Dependency & Lifecycle Gate
+
+- The Attendance module MUST NOT be enabled while the Results & Standings module is
+  disabled. Any attempt MUST be rejected with a clear error.
+- If the Results & Standings module is disabled while the Attendance module is active,
+  the Attendance module MUST be disabled automatically (applying the same disable atomicity
+  rules of Principle X, rule 3).
+- The Attendance module MUST NOT be enabled once a season is in the `ACTIVE` lifecycle
+  state. It MAY only be enabled during `SETUP` or while no season exists.
+- The Attendance module activation status MUST be displayed in the season review output
+  alongside other module states.
+- The Attendance module MUST function correctly with fake driver rosters created under
+  test mode.
+
+#### Season Validation Gates
+
+- Before a season may be approved, if the Attendance module is enabled, every configured
+  division MUST have both an RSVP channel and an attendance channel configured. Missing
+  either channel for any division MUST block season approval with a clear diagnostic.
+- Both channel IDs are stored in **AttendanceDivisionConfig** (one row per division per
+  server). They are displayed in the season review alongside other division channels
+  (results, standings, weather, etc.).
+
+#### RSVP Timing Configuration
+
+Three timing parameters govern the RSVP lifecycle and MUST satisfy the invariant
+**notice_days × 24 > last_notice_hours > deadline_hours** at all times:
+
+- `rsvp_notice_days` (default 5) — days before a round at which the RSVP embed is posted.
+- `rsvp_last_notice_hours` (default 1) — hours before a round at which drivers who have
+  not yet RSVP'd are directly notified. A value of 0 disables the last-notice ping.
+- `rsvp_deadline_hours` (default 2) — hours before a round at which the RSVP choices
+  become locked. A value of 0 means locking occurs at the scheduled round start time.
+
+Any configuration command that would violate the invariant MUST be rejected with a clear
+error. All three commands MUST be rejected if a season is currently `ACTIVE`.
+
+#### RSVP Check-in Embed
+
+At `rsvp_notice_days` days before a round, the bot MUST post an RSVP embed in the
+division's configured RSVP channel. The embed MUST contain:
+
+- **Title**: `Season <X> Round <X> — <canonical_name of track>` (or `Mystery` if the
+  round type is Mystery and track identity is withheld).
+- **Fields**: scheduled datetime as a dynamic Discord timestamp; location (canonical circuit
+  name, or "Mystery" for Mystery rounds); event type (Normal / Sprint / Mystery / Endurance).
+- **Driver roster**: a mini-list per team (including the Reserve team) showing each driver's
+  display name alongside their current RSVP status indicator (empty brackets `()` if not
+  yet responded; ✅ if accepted; ❓ if tentative; ❌ if declined).
+- **Three action buttons** (horizontal): Accept (green ✅), Tentative (grey ❓), Decline
+  (red ❌). Pressing any button updates the embed's status indicator for that driver
+  atomically.
+
+RSVP status MUST be persisted in **DriverRoundAttendance** rows and is authoritative for
+all downstream operations.
+
+#### RSVP Locking Rules
+
+- **Full-time drivers**: RSVP choice locks at the `rsvp_deadline_hours` threshold. No
+  changes are permitted after that point.
+- **Reserve drivers**: RSVP choice locks at the scheduled round start time, but ONLY if
+  they have accepted the check-in. A reserve who remains tentative or declined is
+  locked out at round start regardless.
+- After the RSVP deadline, the bot MUST process the reserve distribution (see below) and
+  post a standby/assignment message to the division's RSVP channel.
+
+#### Reserve Distribution
+
+Once the RSVP deadline is reached, reserves who have confirmed `ACCEPTED` are distributed
+to teams in the following priority order:
+
+1. Teams where at least one driver failed to RSVP (no response).
+2. Teams where at least one driver declined.
+3. Teams where at least one driver is tentative.
+
+Within each priority tier, tie-breaking is applied in order:
+1. Number of `ACCEPTED` drivers already assigned to the team (lowest first — prefer teams
+   with zero confirmed drivers).
+2. Constructors' Championship position in that division (lowest-ranked team first).
+
+Reserves are picked in the order they confirmed `ACCEPTED` (earliest timestamp wins).
+Every time a reserve changes their status back to `ACCEPTED`, their timestamp resets.
+
+Reserves confirmed `ACCEPTED` who remain unplaced are classified as **on standby**. After
+distribution is determined, the bot MUST post a message in the division's RSVP channel:
+- Mentioning each assigned reserve by Discord user and stating which team they are
+  racing for.
+- Mentioning each standby reserve and informing them they are on standby and should be
+  ready to substitute.
+
+#### Attendance Recording
+
+Once the initial round results are submitted (first `SessionResult` row accepted for the
+round), the bot MUST populate attendance status in each `DriverRoundAttendance` row:
+- A driver is counted as **attended** if they appear in any submitted session result for
+  that round (any `DriverSessionResult` row for that round in that division), regardless
+  of outcome modifier.
+- Drivers seated in the Reserve team of that division for this round are excluded from
+  attendance tracking.
+
+Attendance points are NOT distributed at this stage; they are deferred to post-penalty
+finalization (see below).
+
+#### Attendance Pardon Workflow
+
+A dedicated **Attendance Pardon** button MUST be available in the penalty wizard,
+exclusively during the penalty review stage (NOT during the appeals stage). When pressed,
+a modal form MUST request:
+
+1. The Discord User ID of the driver being pardoned.
+2. The type of attendance event being waived: NO_RSVP, NO_ATTEND, or NO_SHOW.
+3. A free-text justification (logged to the calculation log channel; never displayed
+   elsewhere for privacy reasons).
+
+Pardon validation rules:
+- A NO_RSVP pardon requires the driver's RSVP status to be NO_RSVP.
+- A NO_ATTEND pardon requires the driver to have not attended (and RSVP status is
+  irrelevant for this pardon type).
+- A NO_SHOW pardon requires the driver to have been RSVP `ACCEPTED` but not attended.
+- Multiple pardons for the same driver are permitted (e.g., both NO_RSVP and NO_ATTEND
+  can be waived to eliminate both penalties for a driver who did not RSVP and did not
+  attend).
+
+Staged attendance pardons MUST be displayed alongside staged penalties in the penalty
+review summary.
+
+After post-race penalties are approved, attendance pardons can no longer be applied for
+that round.
+
+#### Attendance Point Distribution
+
+Attendance points are distributed once the post-race pen­alty results are finalised
+(approved), to prevent erroneous automatic sanctions due to provisional result errors.
+Points are awarded per driver per round as follows:
+
+| RSVP status | Attended | Points gained |
+|-------------|----------|---------------|
+| NO_RSVP | Attended | `no_rsvp_penalty` |
+| NO_RSVP | Did not attend | `no_rsvp_penalty` + `no_attend_penalty` |
+| Any (ACCEPTED/TENTATIVE/DECLINED) | Attended | 0 |
+| ACCEPTED | Did not attend | `no_show_penalty` |
+| TENTATIVE or DECLINED | Did not attend | 0 |
+
+Pardons waive the corresponding point award(s). A driver who receives a pardon for a given
+event type does NOT accumulate points for that event.
+
+#### Attendance Sheet Posting
+
+Once post-race penalties are approved and posted, the bot MUST post an updated attendance
+sheet to the division's configured attendance channel. The post MUST:
+
+- List all drivers in descending order of total accumulated attendance points (most first).
+- Format each entry as `@mention — X attendance points`.
+- Append the following footer at the end:
+  > Drivers who reach `<autoreserve_threshold>` points will be moved to reserve.
+  > Drivers who reach `<autosack_threshold>` points will be removed from all driving roles
+  > in all divisions.
+  If either threshold is disabled (value 0 / null), the corresponding sentence MUST be
+  omitted.
+
+#### Automatic Sanction Enforcement (Autoreserve & Autosack)
+
+After attendance points are distributed, the bot MUST evaluate each driver's total:
+
+- **Autoreserve** (`autoreserve_threshold`, default disabled): if a full-time driver's
+  total attendance points meet or exceed this threshold, the bot MUST unassign them from
+  their current team seat and assign them to the Reserve team of the same division,
+  producing an audit log entry (Principle V). This action MUST NOT be applied to drivers
+  already seated in the Reserve team.
+- **Autosack** (`autosack_threshold`, default disabled): if a driver's total attendance
+  points meet or exceed this threshold, the bot MUST remove them from all team seats
+  across all divisions (equivalent to `/driver sack`), producing an audit log entry per
+  division affected (Principle V). Autosack supersedes autoreserve when both thresholds
+  are met simultaneously.
+
+Both thresholds are evaluated in a single pass after point distribution. A threshold value
+of 0 or null means the corresponding sanction is disabled.
+
+**Rationale**: Reliable attendance management is essential for competitive fairness in a
+multi-division league. A governed RSVP workflow with clear locking semantics, a proper
+reserve distribution protocol, and an auditable point accumulation pipeline give league
+admins a transparent mechanism to enforce attendance requirements without ad-hoc manual
+intervention. Deferring attendance point distribution to post-penalty finalization prevents
+incorrect automatic sanctions from provisional result errors.
 
 ## Bot Behavior Standards
 
@@ -1756,6 +2004,64 @@ for team-level aggregates):
   appeal outcomes for this division are posted to this channel; if null, the bot falls
   back to `results_channel_id`.
 
+### New Entities (v2.10.0)
+
+**AttendanceConfig** (per server, owned by the Attendance module):
+- `server_id` (TEXT, PK)
+- `module_enabled` (BOOLEAN, default false)
+- `rsvp_notice_days` (INTEGER, default 5) — days before a round for RSVP embed posting.
+- `rsvp_last_notice_hours` (INTEGER, default 1) — hours before round for un-RSVP'd ping;
+  0 disables the last-notice ping.
+- `rsvp_deadline_hours` (INTEGER, default 2) — hours before round when RSVP choices lock;
+  0 means choices lock at round start time.
+- `no_rsvp_penalty` (INTEGER, default 1) — attendance points per no-RSVP event.
+- `no_attend_penalty` (INTEGER, default 1) — attendance points per no-attend event
+  (added on top of no_rsvp_penalty when driver also did not RSVP).
+- `no_show_penalty` (INTEGER, default 1) — attendance points per no-show-after-acceptance
+  event.
+- `autoreserve_threshold` (INTEGER, nullable — null means disabled) — total attendance
+  points at which a full-time driver is automatically moved to Reserve.
+- `autosack_threshold` (INTEGER, nullable — null means disabled) — total attendance points
+  at which a driver is automatically removed from all team seats in all divisions.
+
+**AttendanceDivisionConfig** (per server, per division, owned by the Attendance module):
+- `server_id` (TEXT)
+- `division_id` (INTEGER, FK → Division)
+- `rsvp_channel_id` (TEXT, nullable) — channel for RSVP embeds and reserve distribution
+  notices. Required before season approval when module is enabled.
+- `attendance_channel_id` (TEXT, nullable) — channel for post-round attendance sheet posts.
+  Required before season approval when module is enabled.
+- Uniquely keyed on (server_id, division_id).
+
+**DriverRoundAttendance** (per driver, per round, per division — one row per driver per
+round while the Attendance module is enabled):
+- `attendance_id` (INTEGER PK, server-scoped auto-increment)
+- `round_id` (INTEGER, FK → Round)
+- `division_id` (INTEGER, FK → Division)
+- `driver_id` (TEXT, FK → DriverProfile within server scope)
+- `rsvp_status` (ENUM: ACCEPTED / TENTATIVE / DECLINED / NO_RSVP, default NO_RSVP)
+- `rsvp_timestamp` (TEXT, nullable — UTC ISO 8601; last time driver set status to
+  ACCEPTED; reset each time driver returns to ACCEPTED)
+- `rsvp_locked` (BOOLEAN, default false — set true at deadline or round start per locking
+  rules in Principle XIII)
+- `attended` (BOOLEAN, nullable — null until initial round results are submitted; true if
+  driver appears in any DriverSessionResult for this round and division)
+- `points_awarded` (INTEGER, nullable — null until post-race penalties are finalized;
+  net points after pardons applied)
+- `total_points_after` (INTEGER, nullable — cumulative attendance points for this driver
+  in this division after this round's distribution)
+
+**AttendancePardon** (per driver, per round, per attendance event type):
+- `pardon_id` (INTEGER PK, server-scoped auto-increment)
+- `attendance_id` (INTEGER, FK → DriverRoundAttendance)
+- `pardon_type` (ENUM: NO_RSVP / NO_ATTEND / NO_SHOW)
+- `justification` (TEXT, nullable — logged to calculation log channel only; never
+  displayed in public-facing output)
+- `applied_by` (TEXT — Discord User ID of the tier-2 admin who applied the pardon)
+- `applied_at` (TEXT — UTC ISO 8601 timestamp)
+- Uniquely keyed on (attendance_id, pardon_type) — at most one pardon per event type
+  per driver per round.
+
 ### New Entities (v2.9.0)
 
 **Track** (bot-packaged static registry — 27 circuits as of this version):
@@ -1851,4 +2157,4 @@ before merge. Any deliberate violation of a principle MUST be documented in the 
 Complexity Tracking table with a justification for why the simpler compliant path is
 insufficient.
 
-**Version**: 2.9.0 | **Ratified**: 2026-03-03 | **Last Amended**: 2026-04-03
+**Version**: 2.10.0 | **Ratified**: 2026-03-03 | **Last Amended**: 2026-04-03

--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1488,8 +1488,10 @@ Three timing parameters govern the RSVP lifecycle and MUST satisfy the invariant
 **notice_days × 24 > last_notice_hours > deadline_hours** at all times:
 
 - `rsvp_notice_days` (default 5) — days before a round at which the RSVP embed is posted.
-- `rsvp_last_notice_hours` (default 1) — hours before a round at which drivers who have
-  not yet RSVP'd are directly notified. A value of 0 disables the last-notice ping.
+- `rsvp_last_notice_hours` (default 24) — hours before a round at which drivers who have
+  not yet RSVP'd are directly notified. A value of 0 disables the last-notice ping entirely
+  (the `> deadline_hours` comparison is skipped). Any non-zero value MUST be strictly
+  greater than `rsvp_deadline_hours`.
 - `rsvp_deadline_hours` (default 2) — hours before a round at which the RSVP choices
   become locked. A value of 0 means locking occurs at the scheduled round start time.
 

--- a/specs/031-attendance-module/checklists/requirements.md
+++ b/specs/031-attendance-module/checklists/requirements.md
@@ -1,0 +1,36 @@
+# Specification Quality Checklist: Attendance Module — Initial Setup & Configuration
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning
+**Created**: 2026-04-03
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Out of Scope section explicitly defers RSVP embed logic, reserve distribution, attendance recording, point distribution, pardon workflow, sheet posting, and sanction automation to future increments. This keeps the spec tightly bounded on configuration-only work.
+- Timing invariant edge case (last_notice = 0, deadline = 0) is addressed in edge cases and FR-020.
+- Cascading auto-disable (R&S module disables → Attendance auto-disables) is captured in FR-007 and User Story 1, scenario 5.

--- a/specs/031-attendance-module/data-model.md
+++ b/specs/031-attendance-module/data-model.md
@@ -1,0 +1,155 @@
+# Data Model: Attendance Module — Initial Setup & Configuration
+
+**Feature**: 031-attendance-module  
+**Date**: 2026-04-03
+
+## Entities
+
+---
+
+### `AttendanceConfig`
+
+Per-server configuration for the Attendance module. One row per server. Created atomically
+(with defaults) on first enable or re-enable; `module_enabled` set to 0 on disable but row
+is retained so re-enable can `INSERT OR REPLACE` cleanly.
+
+| Column | Type | Constraints | Default | Description |
+|--------|------|-------------|---------|-------------|
+| `server_id` | INTEGER | PRIMARY KEY, FK → `server_configs(server_id)` ON DELETE CASCADE | — | Discord guild ID |
+| `module_enabled` | INTEGER | NOT NULL | 0 | 0 = disabled, 1 = enabled |
+| `rsvp_notice_days` | INTEGER | NOT NULL | 5 | Days before a round at which the RSVP embed is posted |
+| `rsvp_last_notice_hours` | INTEGER | NOT NULL | 1 | Hours before a round for the last-notice ping; 0 = disabled |
+| `rsvp_deadline_hours` | INTEGER | NOT NULL | 2 | Hours before a round when RSVP locks; 0 = lock at round start |
+| `no_rsvp_penalty` | INTEGER | NOT NULL | 1 | Attendance points awarded for a no-RSVP infraction |
+| `no_attend_penalty` | INTEGER | NOT NULL | 1 | Attendance points awarded for a no-attend infraction |
+| `no_show_penalty` | INTEGER | NOT NULL | 1 | Attendance points awarded for a no-show infraction |
+| `autoreserve_threshold` | INTEGER | NULL | NULL | Points threshold for autoreserve sanction; NULL = disabled |
+| `autosack_threshold` | INTEGER | NULL | NULL | Points threshold for autosack sanction; NULL = disabled |
+
+**Validation invariant** (enforced in application layer, not DB):
+
+> `rsvp_notice_days × 24 > rsvp_last_notice_hours ≥ rsvp_deadline_hours`
+
+Edge case: `rsvp_last_notice_hours = 0` AND `rsvp_deadline_hours = 0` is valid (last-notice
+ping disabled; RSVP locks at the scheduled round start time).
+
+---
+
+### `AttendanceDivisionConfig`
+
+Per-division channel assignments for the Attendance module. One row per division. Created
+lazily on first channel-set command for the division. All rows for a server are deleted
+atomically when the module is disabled.
+
+| Column | Type | Constraints | Default | Description |
+|--------|------|-------------|---------|-------------|
+| `division_id` | INTEGER | PRIMARY KEY, FK → `divisions(id)` ON DELETE CASCADE | — | Division ID |
+| `server_id` | INTEGER | NOT NULL | — | Guild ID (denormalised; NOT a FK — avoids cascade conflict) |
+| `rsvp_channel_id` | TEXT | NULL | NULL | Discord channel ID for RSVP embed posting |
+| `attendance_channel_id` | TEXT | NULL | NULL | Discord channel ID for attendance sheet posting |
+
+**Note on `server_id`**: stored as a plain integer (not a FK) to allow efficient
+`DELETE FROM attendance_division_config WHERE server_id = ?` on module disable without
+requiring a join through `divisions`.
+
+---
+
+## Migration SQL
+
+**File**: `src/db/migrations/030_attendance_module.sql`
+
+```sql
+-- Migration 030: Attendance module — server config and per-division channel config
+-- Adds: attendance_config, attendance_division_config
+
+CREATE TABLE IF NOT EXISTS attendance_config (
+    server_id                INTEGER PRIMARY KEY
+                                 REFERENCES server_configs(server_id)
+                                 ON DELETE CASCADE,
+    module_enabled           INTEGER NOT NULL DEFAULT 0,
+    rsvp_notice_days         INTEGER NOT NULL DEFAULT 5,
+    rsvp_last_notice_hours   INTEGER NOT NULL DEFAULT 1,
+    rsvp_deadline_hours      INTEGER NOT NULL DEFAULT 2,
+    no_rsvp_penalty          INTEGER NOT NULL DEFAULT 1,
+    no_attend_penalty        INTEGER NOT NULL DEFAULT 1,
+    no_show_penalty          INTEGER NOT NULL DEFAULT 1,
+    autoreserve_threshold    INTEGER,
+    autosack_threshold       INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS attendance_division_config (
+    division_id               INTEGER PRIMARY KEY
+                                  REFERENCES divisions(id)
+                                  ON DELETE CASCADE,
+    server_id                 INTEGER NOT NULL,
+    rsvp_channel_id           TEXT,
+    attendance_channel_id     TEXT
+);
+```
+
+---
+
+## State Transitions
+
+### Module Enable
+
+```
+Pre-conditions: R&S module enabled, no ACTIVE season.
+
+1. INSERT OR REPLACE INTO attendance_config
+       (server_id, module_enabled, rsvp_notice_days, rsvp_last_notice_hours,
+        rsvp_deadline_hours, no_rsvp_penalty, no_attend_penalty, no_show_penalty,
+        autoreserve_threshold, autosack_threshold)
+   VALUES (?, 1, 5, 1, 2, 1, 1, 1, NULL, NULL)
+2. INSERT INTO audit_entries (change_type = 'ATTENDANCE_MODULE_ENABLED')
+3. post_log confirmation
+```
+
+### Module Disable (manual via `/module disable attendance`)
+
+```
+1. UPDATE attendance_config SET module_enabled = 0 WHERE server_id = ?
+2. DELETE FROM attendance_division_config WHERE server_id = ?
+3. (cancel scheduler jobs — no-op this increment)
+4. INSERT INTO audit_entries (change_type = 'ATTENDANCE_MODULE_DISABLED')
+5. post_log notice
+```
+
+### Cascading Disable (triggered by `/module disable results`)
+
+```
+Same steps as manual disable but:
+- audit change_type = 'ATTENDANCE_MODULE_CASCADE_DISABLED'
+- post_log note indicates cascade reason
+```
+
+### Re-enable after prior disable
+
+```
+INSERT OR REPLACE attendance_config with all defaults, module_enabled = 1
+(fresh start — prior division configs already deleted on disable per Principle X rule 6)
+```
+
+---
+
+## Relationships
+
+```
+server_configs (1)
+    └──(1) attendance_config          (FK server_id)
+
+divisions (1)
+    └──(0..1) attendance_division_config  (FK division_id, CASCADE DELETE)
+```
+
+---
+
+## Deferred Entities (future increments)
+
+The following entities are defined in the constitution (v2.10.0) but are **not** created in
+this increment. Their migrations will appear in later feature branches.
+
+| Entity | Description | Increment |
+|--------|-------------|-----------|
+| `DriverRoundAttendance` | Per-driver per-round RSVP status + attendance status | RSVP automation |
+| `AttendancePardon` | Attendance pardon records from penalty wizard | Pardon workflow |

--- a/specs/031-attendance-module/data-model.md
+++ b/specs/031-attendance-module/data-model.md
@@ -18,7 +18,7 @@ is retained so re-enable can `INSERT OR REPLACE` cleanly.
 | `server_id` | INTEGER | PRIMARY KEY, FK → `server_configs(server_id)` ON DELETE CASCADE | — | Discord guild ID |
 | `module_enabled` | INTEGER | NOT NULL | 0 | 0 = disabled, 1 = enabled |
 | `rsvp_notice_days` | INTEGER | NOT NULL | 5 | Days before a round at which the RSVP embed is posted |
-| `rsvp_last_notice_hours` | INTEGER | NOT NULL | 1 | Hours before a round for the last-notice ping; 0 = disabled |
+| `rsvp_last_notice_hours` | INTEGER | NOT NULL | 24 | Hours before a round for the last-notice ping; 0 = disabled (bypasses `> deadline` check) |
 | `rsvp_deadline_hours` | INTEGER | NOT NULL | 2 | Hours before a round when RSVP locks; 0 = lock at round start |
 | `no_rsvp_penalty` | INTEGER | NOT NULL | 1 | Attendance points awarded for a no-RSVP infraction |
 | `no_attend_penalty` | INTEGER | NOT NULL | 1 | Attendance points awarded for a no-attend infraction |
@@ -28,10 +28,8 @@ is retained so re-enable can `INSERT OR REPLACE` cleanly.
 
 **Validation invariant** (enforced in application layer, not DB):
 
-> `rsvp_notice_days × 24 > rsvp_last_notice_hours ≥ rsvp_deadline_hours`
-
-Edge case: `rsvp_last_notice_hours = 0` AND `rsvp_deadline_hours = 0` is valid (last-notice
-ping disabled; RSVP locks at the scheduled round start time).
+> `rsvp_notice_days × 24 > rsvp_last_notice_hours` (always); and when `rsvp_last_notice_hours > 0`: `rsvp_last_notice_hours > rsvp_deadline_hours`.
+> A value of 0 for `rsvp_last_notice_hours` is a valid sentinel (last-notice ping disabled); the second comparison is skipped.
 
 ---
 
@@ -68,7 +66,7 @@ CREATE TABLE IF NOT EXISTS attendance_config (
                                  ON DELETE CASCADE,
     module_enabled           INTEGER NOT NULL DEFAULT 0,
     rsvp_notice_days         INTEGER NOT NULL DEFAULT 5,
-    rsvp_last_notice_hours   INTEGER NOT NULL DEFAULT 1,
+    rsvp_last_notice_hours   INTEGER NOT NULL DEFAULT 24,
     rsvp_deadline_hours      INTEGER NOT NULL DEFAULT 2,
     no_rsvp_penalty          INTEGER NOT NULL DEFAULT 1,
     no_attend_penalty        INTEGER NOT NULL DEFAULT 1,
@@ -100,7 +98,7 @@ Pre-conditions: R&S module enabled, no ACTIVE season.
        (server_id, module_enabled, rsvp_notice_days, rsvp_last_notice_hours,
         rsvp_deadline_hours, no_rsvp_penalty, no_attend_penalty, no_show_penalty,
         autoreserve_threshold, autosack_threshold)
-   VALUES (?, 1, 5, 1, 2, 1, 1, 1, NULL, NULL)
+   VALUES (?, 1, 5, 24, 2, 1, 1, 1, NULL, NULL)
 2. INSERT INTO audit_entries (change_type = 'ATTENDANCE_MODULE_ENABLED')
 3. post_log confirmation
 ```

--- a/specs/031-attendance-module/plan.md
+++ b/specs/031-attendance-module/plan.md
@@ -1,0 +1,94 @@
+# Implementation Plan: Attendance Module — Initial Setup & Configuration
+
+**Branch**: `031-attendance-module` | **Date**: 2026-04-03 | **Spec**: [spec.md](spec.md)
+**Input**: Feature specification from `specs/031-attendance-module/spec.md`
+
+## Summary
+
+Add an Attendance module to the F1 League Racing Bot covering the full module lifecycle (enable/disable with cascading disable from R&S), per-division RSVP and attendance channel configuration, eight `attendance config` commands (three timing parameters + five penalty/threshold parameters), season review integration, and season approval gating. Two new database tables are introduced: `attendance_config` (per-server config payload) and `attendance_division_config` (per-division channel assignments). No scheduler jobs are created in this increment; RSVP automation (notices, reserve distribution, last-notice pings) is deferred to a future increment.
+
+## Technical Context
+
+**Language/Version**: Python 3.13.2  
+**Primary Dependencies**: discord.py (app_commands), aiosqlite, APScheduler (SQLAlchemyJobStore — not used this increment)  
+**Storage**: SQLite via aiosqlite; migration `030_attendance_module.sql`  
+**Testing**: pytest; run as `python -m pytest tests/ -v` from repo root  
+**Target Platform**: Linux server (Raspberry Pi); development on Windows  
+**Project Type**: Discord bot service  
+**Performance Goals**: <3 s command acknowledgement (Discord requirement); single-row DB lookups  
+**Constraints**: All command responses MUST be ephemeral; APScheduler callables must be module-level picklable (not relevant this increment — no jobs created)  
+**Scale/Scope**: O(dozens) drivers per server; O(tens) rounds per season
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| # | Principle | Check | Status |
+|---|-----------|-------|--------|
+| I | Trusted Configuration Authority | Commands guarded by `@admin_only` + `@channel_guard`; no anonymous access to config | ✅ PASS |
+| II | Multi-Division Isolation | `attendance_division_config` keyed per `(division_id, server_id)`; each division's channels are independent | ✅ PASS |
+| III | Resilient Schedule Management | No scheduler jobs in this increment; re-arm logic deferred to RSVP increment | ✅ PASS |
+| IV | Three-Phase Weather Pipeline | Not affected | ✅ PASS |
+| V | Observability & Change Audit Trail | All enable/disable and config changes produce `audit_entries` rows and `post_log` calls | ✅ PASS |
+| VI | Incremental Scope Expansion | Attendance management is item 11 of the in-scope domain list (v2.10.0); this is the first increment | ✅ PASS |
+| VII | Output Channel Discipline | RSVP and attendance channels are module-introduced; all command responses are ephemeral | ✅ PASS |
+| VIII | Driver Profile Integrity | No driver state changes in this increment | ✅ PASS |
+| IX | Team & Division Structural Integrity | No team/division mutations; `attendance_division_config` is a join table | ✅ PASS |
+| X | Modular Feature Architecture | Follows all 6 rules: default-off; enable atomicity (INSERT OR REPLACE config row + set flag); disable atomicity (clear division config + post log); scheduling guard (no jobs this increment); gate enforcement on all config commands; config isolation (separate tables, cleared on disable) | ✅ PASS |
+| XI | Signup Wizard Integrity | Not affected | ✅ PASS |
+| XII | Race Results & Championship Integrity | R&S module dependency gate enforced per FR-002 and FR-007; no results data modified | ✅ PASS |
+| XIII | Attendance & Check-in Integrity | Module dependency gate (R&S must be enabled); lifecycle gate (no enable during ACTIVE season); cascading disable (auto-disabled if R&S disabled); season validation gates (RSVP + attendance channels required per-division before approval); timing invariant enforced on all config commands | ✅ PASS |
+
+**Post-design re-check (Phase 1)**: ✅ All gates pass. No violations found. No Complexity Tracking rows required.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/031-attendance-module/
+├── plan.md              # This file
+├── research.md          # Phase 0 output
+├── data-model.md        # Phase 1 output
+├── quickstart.md        # Phase 1 output
+└── tasks.md             # Phase 2 output (speckit.tasks command)
+```
+
+### Source Code (repository root)
+
+**Structure Decision**: Single-project layout. All source in `src/`; tests in `tests/unit/`.
+
+**New files:**
+
+```text
+src/
+├── db/
+│   └── migrations/
+│       └── 030_attendance_module.sql       # attendance_config + attendance_division_config tables
+├── models/
+│   └── attendance.py                       # AttendanceConfig + AttendanceDivisionConfig dataclasses
+├── services/
+│   └── attendance_service.py               # AttendanceService (config CRUD + timing validation)
+└── cogs/
+    └── attendance_cog.py                   # /attendance command group (config subcommands)
+
+tests/
+└── unit/
+    └── test_attendance_service.py          # Unit tests for AttendanceService
+```
+
+**Modified files:**
+
+```text
+src/
+├── services/
+│   └── module_service.py                   # Add is_attendance_enabled, set_attendance_enabled
+├── cogs/
+│   ├── module_cog.py                       # Add "attendance" to _MODULE_CHOICES; add _enable_attendance,
+│   │                                       #   _disable_attendance; cascade auto-disable in _disable_results
+│   └── season_cog.py                       # Add attendance status to season_review modules block;
+│                                           #   add per-division rsvp/attendance channel rows in season_review;
+│                                           #   add /division rsvp-channel + /division attendance-channel commands;
+│                                           #   add attendance gate in _do_approve
+└── bot.py                                  # Register attendance_service + attendance_cog
+```

--- a/specs/031-attendance-module/quickstart.md
+++ b/specs/031-attendance-module/quickstart.md
@@ -1,0 +1,268 @@
+# Quickstart: Attendance Module — Initial Setup & Configuration
+
+**Feature**: 031-attendance-module  
+**Date**: 2026-04-03
+
+## Implementation Order
+
+Follow this order to avoid import-time and FK failures:
+
+1. `030_attendance_module.sql` — schema (tables must exist before any service code runs)
+2. `src/models/attendance.py` — dataclasses (no DB imports; pure data)
+3. `src/services/attendance_service.py` — AttendanceService + timing validator
+4. `src/services/module_service.py` — add `is_attendance_enabled`, `set_attendance_enabled`
+5. `src/cogs/attendance_cog.py` — `/attendance config` command group
+6. `src/cogs/module_cog.py` — add "attendance" choice, `_enable_attendance`, `_disable_attendance`, cascade in `_disable_results`
+7. `src/cogs/season_cog.py` — modules block + division rows + approval gate + two `/division` channel commands
+8. `src/bot.py` — register `attendance_service` and `attendance_cog`
+9. `tests/unit/test_attendance_service.py` — unit tests
+
+---
+
+## Command Reference
+
+### New commands
+
+| Command | Group | Guards | FR |
+|---------|-------|--------|----|
+| `/attendance config rsvp-notice <days>` | `/attendance config` | `@channel_guard` `@admin_only` | FR-017 |
+| `/attendance config rsvp-last-notice <hours>` | `/attendance config` | `@channel_guard` `@admin_only` | FR-018 |
+| `/attendance config rsvp-deadline <hours>` | `/attendance config` | `@channel_guard` `@admin_only` | FR-019 |
+| `/attendance config no-rsvp-penalty <points>` | `/attendance config` | `@channel_guard` `@admin_only` | FR-022 |
+| `/attendance config no-attend-penalty <points>` | `/attendance config` | `@channel_guard` `@admin_only` | FR-023 |
+| `/attendance config no-show-penalty <points>` | `/attendance config` | `@channel_guard` `@admin_only` | FR-024 |
+| `/attendance config autosack <points>` | `/attendance config` | `@channel_guard` `@admin_only` | FR-025 |
+| `/attendance config autoreserve <points>` | `/attendance config` | `@channel_guard` `@admin_only` | FR-026 |
+| `/division rsvp-channel <division> <channel>` | `/division` | `@channel_guard` `@admin_only` | FR-012 |
+| `/division attendance-channel <division> <channel>` | `/division` | `@channel_guard` `@admin_only` | FR-013 |
+
+### Modified commands / behaviours
+
+| Command | Change | FR |
+|---------|--------|----|
+| `/module enable <module>` | "attendance" added to `_MODULE_CHOICES`; `_enable_attendance` dispatched | FR-002–FR-004 |
+| `/module disable <module>` | "attendance" added to `_MODULE_CHOICES`; `_disable_attendance` dispatched | FR-005–FR-006 |
+| `/module disable results` | After R&S disable, cascade-disable attendance if enabled | FR-007 |
+| `/season review` | Attendance status in Modules block; RSVP/attendance channel rows per division | FR-010, FR-016 |
+| `/season approve` | Attendance channel gate: RSVP + attendance channels required per-division | FR-015 |
+
+---
+
+## Guard Chains
+
+### `_enable_attendance`
+
+```
+1. Guard: R&S module must be enabled
+   → "❌ The Attendance module requires the Results & Standings module to be enabled first."
+2. Guard: no ACTIVE season
+   → "❌ The Attendance module cannot be enabled while a season is active."
+3. Guard: already enabled (idempotency)
+   → "ℹ️ The Attendance module is already enabled."
+4. await interaction.response.defer(ephemeral=True)
+5. INSERT OR REPLACE INTO attendance_config
+       (server_id, module_enabled=1, rsvp_notice_days=5, rsvp_last_notice_hours=1,
+        rsvp_deadline_hours=2, no_rsvp_penalty=1, no_attend_penalty=1, no_show_penalty=1,
+        autoreserve_threshold=NULL, autosack_threshold=NULL)
+6. INSERT INTO audit_entries (change_type='ATTENDANCE_MODULE_ENABLED')
+7. await self.bot.output_router.post_log(...)
+8. await interaction.followup.send("✅ Attendance module enabled.", ephemeral=True)
+```
+
+### `_disable_attendance`
+
+```
+1. Guard: not enabled (idempotency)
+   → "ℹ️ The Attendance module is already disabled."
+2. await interaction.response.defer(ephemeral=True)  [or skip defer if already deferred]
+3. UPDATE attendance_config SET module_enabled = 0 WHERE server_id = ?
+4. DELETE FROM attendance_division_config WHERE server_id = ?
+5. (cancel scheduler jobs — no-op this increment)
+6. INSERT INTO audit_entries (change_type='ATTENDANCE_MODULE_DISABLED')
+7. await self.bot.output_router.post_log(...)
+8. await interaction.followup.send("✅ Attendance module disabled.", ephemeral=True)
+```
+
+### `_disable_attendance` called from `_disable_results` (cascade)
+
+```
+Same as above except:
+- No interaction-level defer/followup needed (parent _disable_results owns the interaction)
+- Log message indicates cascade: "Attendance module auto-disabled (R&S module was disabled)"
+- audit change_type = 'ATTENDANCE_MODULE_CASCADE_DISABLED'
+```
+
+### Timing config commands (`rsvp-notice`, `rsvp-last-notice`, `rsvp-deadline`)
+
+```
+1. Guard: module enabled → "❌ Attendance module is not enabled."
+2. Guard: no ACTIVE season → "❌ Cannot change timing configuration during an active season."
+3. Validate timing invariant with new value substituted for the relevant field
+   → if violated, return clear error (see invariant helper below)
+4. UPDATE attendance_config SET <field> = ? WHERE server_id = ?
+5. await interaction.followup.send("✅ `<field>` updated to <value>.", ephemeral=True)
+```
+
+### Penalty/threshold config commands (`no-rsvp-penalty`, etc.)
+
+```
+1. Guard: module enabled → "❌ Attendance module is not enabled."
+2. Validate value ≥ 0
+3. For autoreserve/autosack: if value == 0, store NULL (disabled)
+4. UPDATE attendance_config SET <field> = ? WHERE server_id = ?
+5. await interaction.followup.send("✅ `<field>` updated.", ephemeral=True)
+```
+
+### `/division rsvp-channel` and `/division attendance-channel`
+
+```
+1. Guard: module enabled → "❌ The Attendance module is not enabled."
+2. Find active/setup season for server → 404 if none
+3. Find division by name → 404 if not found
+4. INSERT OR REPLACE INTO attendance_division_config
+       (division_id, server_id, <channel_field> = channel.id)
+   — preserve the other channel field if row already exists
+5. INSERT INTO audit_entries (change_type='ATTENDANCE_CHANNEL_SET')
+6. await interaction.response.send_message("✅ <type> channel set.", ephemeral=True)
+7. await self.bot.output_router.post_log(...)
+```
+
+---
+
+## Timing Invariant Helper
+
+Place as a module-level function in `src/services/attendance_service.py`:
+
+```python
+def validate_timing_invariant(
+    notice_days: int,
+    last_notice_hours: int,
+    deadline_hours: int,
+) -> str | None:
+    """Return an error message string if the invariant is violated, else None.
+
+    Invariant: notice_days * 24 > last_notice_hours >= deadline_hours
+    Edge case: last_notice_hours=0 and deadline_hours=0 is valid (last-notice disabled;
+               RSVP locks at round start time).
+    """
+    if notice_days * 24 <= last_notice_hours:
+        return (
+            f"`rsvp_notice_days` ({notice_days}) \u00d7 24 = {notice_days * 24}h "
+            f"must be greater than `rsvp_last_notice_hours` ({last_notice_hours}h)."
+        )
+    if last_notice_hours < deadline_hours:
+        return (
+            f"`rsvp_last_notice_hours` ({last_notice_hours}h) "
+            f"must be \u2265 `rsvp_deadline_hours` ({deadline_hours}h)."
+        )
+    return None
+```
+
+---
+
+## `AttendanceDivisionConfig` Upsert Pattern
+
+The `/division rsvp-channel` and `/division attendance-channel` commands each update ONE
+channel field. Use `INSERT OR REPLACE` but preserve the other field by reading the existing
+row first:
+
+```python
+existing = await self.bot.attendance_service.get_division_config(div.id)
+rsvp_id = channel.id if setting_rsvp else (existing.rsvp_channel_id if existing else None)
+att_id  = channel.id if setting_att  else (existing.attendance_channel_id if existing else None)
+
+async with get_connection(self.bot.db_path) as db:
+    await db.execute(
+        "INSERT OR REPLACE INTO attendance_division_config "
+        "(division_id, server_id, rsvp_channel_id, attendance_channel_id) "
+        "VALUES (?, ?, ?, ?)",
+        (div.id, interaction.guild_id, rsvp_id, att_id),
+    )
+    await db.commit()
+```
+
+Alternatively, `AttendanceService` can expose `set_rsvp_channel()` and
+`set_attendance_channel()` that handle the read-modify-write internally.
+
+---
+
+## Season Review Integration Points
+
+### Modules block (`season_cog.py` — around line 2484)
+
+Add:
+```python
+attendance_on = await self.bot.module_service.is_attendance_enabled(interaction.guild_id)
+```
+
+Add to the `lines` block:
+```python
+f"  Attendance: {on if attendance_on else off}",
+```
+
+### Per-division block (after lineup/calendar lines)
+
+```python
+if attendance_on:
+    adc = await self.bot.attendance_service.get_division_config(div.id)
+    rsvp_ch = f"<#{adc.rsvp_channel_id}>" if adc and adc.rsvp_channel_id else "*(not set)*"
+    att_ch  = f"<#{adc.attendance_channel_id}>" if adc and adc.attendance_channel_id else "*(not set)*"
+    lines.append(f"  RSVP channel: {rsvp_ch}")
+    lines.append(f"  Attendance channel: {att_ch}")
+```
+
+---
+
+## `_do_approve` Gate Placement
+
+Insert after Gate 3 (signup prerequisites check), before the scheduling / transition block:
+
+```python
+# ── Gate 4: attendance module channel prerequisites ──────────────────────────
+if await self.bot.module_service.is_attendance_enabled(cfg.server_id):
+    att_errors: list[str] = []
+    for d in divisions:
+        adc = await self.bot.attendance_service.get_division_config(d.id)
+        if adc is None or not adc.rsvp_channel_id:
+            att_errors.append(f"**{d.name}** is missing an RSVP channel")
+        if adc is None or not adc.attendance_channel_id:
+            att_errors.append(f"**{d.name}** is missing an attendance channel")
+    if att_errors:
+        bullet_list = "\n\u2022 ".join(att_errors)
+        msg = (
+            f"\u274c Season cannot be approved \u2014 attendance module prerequisites "
+            f"not met:\n\u2022 {bullet_list}"
+        )
+        if interaction.response.is_done():
+            await interaction.followup.send(msg, ephemeral=True)
+        else:
+            await interaction.response.send_message(msg, ephemeral=True)
+        return
+```
+
+---
+
+## Tests to Write
+
+**File**: `tests/unit/test_attendance_service.py`
+
+| Test ID | Scenario | FR |
+|---------|-----------|----|
+| `test_get_config_none_before_create` | No row → `get_config()` returns None | — |
+| `test_is_attendance_enabled_false_by_default` | `is_attendance_enabled()` returns False before any write | FR-001 |
+| `test_enable_creates_config_with_defaults` | Enable writes row with all default values | FR-003 |
+| `test_enable_sets_flag_true` | `is_attendance_enabled()` returns True after enable | FR-002 |
+| `test_disable_sets_flag_false` | `is_attendance_enabled()` returns False after disable | FR-005 |
+| `test_disable_deletes_division_configs` | Disable removes `attendance_division_config` rows for server | FR-005 |
+| `test_reenable_resets_to_defaults` | Re-enabling after disable starts fresh with defaults | FR-003 |
+| `test_set_rsvp_channel` | `rsvp_channel_id` stored correctly | FR-012 |
+| `test_set_attendance_channel` | `attendance_channel_id` stored correctly | FR-013 |
+| `test_set_channel_preserves_other_channel` | Setting RSVP channel doesn't clear attendance channel | FR-012/013 |
+| `test_timing_invariant_valid` | Valid `(5, 1, 2)` → no error | FR-020 |
+| `test_timing_invariant_notice_too_small` | `notice_days=0, last=1` → error | FR-020 |
+| `test_timing_invariant_deadline_exceeds_last` | `last=1, deadline=2` → error | FR-020 |
+| `test_timing_invariant_both_zero` | `last=0, deadline=0` → valid | FR-020 |
+| `test_timing_invariant_last_equals_deadline` | `last=2, deadline=2` → valid (≥ not >) | FR-020 |
+| `test_autosack_zero_stores_null` | `autosack=0` → `autosack_threshold=None` | FR-025 |
+| `test_autoreserve_zero_stores_null` | `autoreserve=0` → `autoreserve_threshold=None` | FR-026 |
+| `test_config_penalty_fields_update` | Each of the 3 penalty fields updates independently | FR-022–024 |

--- a/specs/031-attendance-module/quickstart.md
+++ b/specs/031-attendance-module/quickstart.md
@@ -86,8 +86,9 @@ Follow this order to avoid import-time and FK failures:
 ### `_disable_attendance` called from `_disable_results` (cascade)
 
 ```
-Same as above except:
-- No interaction-level defer/followup needed (parent _disable_results owns the interaction)
+Call: await self._disable_attendance(interaction, cascade=True)
+Same DB steps as above except:
+- cascade=True: skip defer() and followup.send() — parent _disable_results owns the interaction
 - Log message indicates cascade: "Attendance module auto-disabled (R&S module was disabled)"
 - audit change_type = 'ATTENDANCE_MODULE_CASCADE_DISABLED'
 ```
@@ -141,19 +142,19 @@ def validate_timing_invariant(
 ) -> str | None:
     """Return an error message string if the invariant is violated, else None.
 
-    Invariant: notice_days * 24 > last_notice_hours >= deadline_hours
-    Edge case: last_notice_hours=0 and deadline_hours=0 is valid (last-notice disabled;
-               RSVP locks at round start time).
+    Invariant: notice_days * 24 > last_notice_hours (always);
+               last_notice_hours > deadline_hours when last_notice_hours > 0.
+    A value of 0 for last_notice_hours disables the ping and skips the second check.
     """
     if notice_days * 24 <= last_notice_hours:
         return (
             f"`rsvp_notice_days` ({notice_days}) \u00d7 24 = {notice_days * 24}h "
             f"must be greater than `rsvp_last_notice_hours` ({last_notice_hours}h)."
         )
-    if last_notice_hours < deadline_hours:
+    if last_notice_hours > 0 and last_notice_hours <= deadline_hours:
         return (
             f"`rsvp_last_notice_hours` ({last_notice_hours}h) "
-            f"must be \u2265 `rsvp_deadline_hours` ({deadline_hours}h)."
+            f"must be > `rsvp_deadline_hours` ({deadline_hours}h)."
         )
     return None
 ```

--- a/specs/031-attendance-module/research.md
+++ b/specs/031-attendance-module/research.md
@@ -1,0 +1,310 @@
+# Research: Attendance Module — Initial Setup & Configuration
+
+**Feature**: 031-attendance-module  
+**Date**: 2026-04-03
+
+## Decision Log
+
+---
+
+### Decision 1: `attendance_config` uses a dedicated table (results pattern, not server_configs columns)
+
+**Decision**: Use a dedicated `attendance_config` table (one row per server) with a `module_enabled`
+column and all config payload columns, mirroring `results_module_config`.
+
+**Rationale**: Weather and signup modules store their `module_enabled` flag as columns on
+`server_configs`. Results & Standings uses a separate table. Per Principle X rule 6, module
+config is isolated from core server config. The Attendance module has 9 config fields on top
+of the enabled flag; adding them all as columns to `server_configs` would violate config
+isolation and bloat the core table. Using `results_module_config` as the pattern is the
+correct precedent for a module with a substantial config payload.
+
+**Alternatives Considered**:
+- Column on `server_configs` (weather/signup pattern) — rejected; Attendance has too many
+  config fields.
+- Separate payload table + column on `server_configs` for enabled flag — rejected; adds
+  unnecessary complexity with two tables for one logical entity.
+
+**Implementation**:
+- `ModuleService.is_attendance_enabled()` → `SELECT module_enabled FROM attendance_config WHERE server_id = ?`
+- `ModuleService.set_attendance_enabled()` → `INSERT OR REPLACE INTO attendance_config (server_id, module_enabled) VALUES (?, ?)`
+
+---
+
+### Decision 2: `attendance_division_config` is a join table keyed on `division_id`
+
+**Decision**: Separate `attendance_division_config` table with `division_id INTEGER PRIMARY KEY
+REFERENCES divisions(id) ON DELETE CASCADE` plus a denormalised `server_id NOT NULL` column,
+mirroring the `division_results_config` pattern.
+
+**Rationale**: The spec states: "the module uses a separate join table, consistent with the
+DivisionResultsConfig pattern." The `division_results_config` table uses `division_id` as PK
+with a cascade delete from `divisions`. The attendance division config follows the same
+structure, adding `server_id` for efficient `DELETE WHERE server_id = ?` on module disable
+without requiring a join.
+
+**Alternatives Considered**:
+- Columns on the `divisions` table — rejected per spec and Principle X rule 6; module config
+  MUST be isolated from core division data.
+- Keyed only on `division_id` (no `server_id` column) — would require a join through
+  `divisions` to get the server_id on disable; adding `server_id` directly is cheaper and
+  consistent with other join tables.
+
+**Implementation**: `attendance_division_config(division_id PK FK→divisions.id CASCADE,
+server_id NOT NULL, rsvp_channel_id TEXT NULL, attendance_channel_id TEXT NULL)`.
+`server_id` is NOT a FK to `server_configs` to avoid FK collision during cascade delete.
+
+---
+
+### Decision 3: Enable creates config row atomically with defaults; disable deletes division configs
+
+**Decision**:
+- **Enable**: `INSERT OR REPLACE INTO attendance_config` with all defaults + `module_enabled = 1`
+  in a single transaction. This satisfies Principle X rule 2 (enable atomicity).
+- **Disable**: In one transaction: `UPDATE attendance_config SET module_enabled = 0`, then
+  `DELETE FROM attendance_division_config WHERE server_id = ?`. This satisfies Principle X rule 3
+  (disable atomicity).
+
+**Rationale**: Per Principle X rules 2 and 3. `INSERT OR REPLACE` handles both first-enable
+(INSERT) and re-enable after disable (REPLACE with fresh defaults). The spec makes clear that
+disabling "clears `AttendanceDivisionConfig` rows for the server" — this is the full division
+config wipe.
+
+**Alternatives Considered**:
+- Two-step enable (create row separately, then set flag) — rejected; non-atomic, violates
+  Principle X rule 2.
+- Keep `attendance_division_config` on disable (only clear the flag) — rejected; Principle X
+  rule 6 says "disabling a module clears module config; re-enabling starts fresh."
+
+---
+
+### Decision 4: `/attendance config` is a new top-level group with a `config` subgroup
+
+**Decision**: New top-level slash command group `/attendance` with a `config` subgroup hosting
+8 subcommands: `rsvp-notice`, `rsvp-last-notice`, `rsvp-deadline`, `no-rsvp-penalty`,
+`no-attend-penalty`, `no-show-penalty`, `autoreserve`, `autosack`.
+
+**Rationale**: Per Bot Behavior Standards, commands follow the `/domain action` subcommand-group
+convention. The `attendance` domain is new; config subcommands belong naturally under
+`/attendance config`. RSVP channel and attendance channel commands extend the existing
+`/division` group (consistent with `/division results-channel`, `/division standings-channel`).
+
+**Alternatives Considered**:
+- Flat `/attendance-config-*` top-level commands — rejected per Bot Behavior Standards
+  (hyphenated top-level restriction).
+- Config commands under `/module` — rejected; `/module` is specifically for enable/disable
+  lifecycle only.
+
+---
+
+### Decision 5: Cascading disable from `_disable_results` in `module_cog.py`
+
+**Decision**: In `module_cog.py::_disable_results()`, after disabling R&S, call a check:
+if attendance is enabled, call `_disable_attendance()` immediately.
+
+**Rationale**: Per FR-007 and Principle XIII: "if the Results & Standings module is disabled
+while the Attendance module is active, the Attendance module MUST be disabled automatically."
+The cleanest hook is a direct call in `_disable_results()` after the R&S disable logic, reusing
+the same `_disable_attendance()` implementation with an appropriate cascade reason for the log.
+
+**Alternatives Considered**:
+- Event-based cascade (custom Discord event) — rejected; over-engineered for a single
+  conditional call.
+- Cascade inside `ModuleService.set_results_enabled()` — rejected; service methods should not
+  contain cross-module orchestration.
+
+---
+
+### Decision 6: No scheduler jobs in this increment
+
+**Decision**: `_enable_attendance()` does NOT call `scheduler_service`. No APScheduler jobs
+are created. Job scheduling for RSVP notices and last-notice pings is deferred to the RSVP
+automation increment.
+
+**Rationale**: Per spec Out-of-Scope section: RSVP embed posting, last-notice ping scheduling,
+and reserve distribution are explicitly deferred. Adding stub scheduler calls would be dead code
+and violates implementation discipline.
+
+---
+
+### Decision 7: `AttendanceService` is a distinct service class
+
+**Decision**: New `src/services/attendance_service.py` with `AttendanceService` class.
+Methods: `get_config()`, `get_or_create_config()`, `set_rsvp_channel()`,
+`set_attendance_channel()`, `delete_division_configs()`, and a standalone helper
+`validate_timing_invariant()`.
+
+**Rationale**: Follows the service-cog split pattern used throughout the project.
+Config CRUD belongs in a service, not in the cog. The cog handles Discord interaction;
+the service handles DB operations.
+
+**Alternatives Considered**:
+- Inline DB queries in the cog — rejected; violates the established service-cog pattern.
+- Adding attendance config methods to `ModuleService` — rejected; ModuleService is
+  specifically for module-enabled flags. Adding a full config payload API would bloat it.
+
+---
+
+## Pattern Reference
+
+### Module enable pattern (extracted from `module_cog.py::_enable_results`)
+
+```python
+async def _enable_results(self, interaction: discord.Interaction) -> None:
+    server_id = interaction.guild_id
+    # 1. Guard: already enabled
+    if await self.bot.module_service.is_results_enabled(server_id):
+        await interaction.followup.send("Already enabled.", ephemeral=True)
+        return
+    # 2. Guard: ACTIVE season
+    active = await self.bot.season_service.get_active_season(server_id)
+    if active:
+        await interaction.followup.send("Cannot enable during active season.", ephemeral=True)
+        return
+    # 3. defer
+    await interaction.response.defer(ephemeral=True)
+    # 4. DB write
+    await self.bot.module_service.set_results_enabled(server_id, True)
+    # 5. audit entry
+    # INSERT INTO audit_entries ...
+    # 6. post_log
+    await self.bot.output_router.post_log(server_id, "...")
+    # 7. followup
+    await interaction.followup.send("✅ Results & Standings module enabled.", ephemeral=True)
+```
+
+The attendance enable adds one extra guard before step 1:
+- `if not await self.bot.module_service.is_results_enabled(server_id): reject (FR-002a)`
+
+And step 4 uses `INSERT OR REPLACE INTO attendance_config (...all defaults...)` instead of
+just a flag update.
+
+---
+
+### `ModuleService` pattern for separate-table modules (from `is_results_enabled`)
+
+```python
+async def is_attendance_enabled(self, server_id: int) -> bool:
+    async with get_connection(self._db_path) as db:
+        cursor = await db.execute(
+            "SELECT module_enabled FROM attendance_config WHERE server_id = ?",
+            (server_id,),
+        )
+        row = await cursor.fetchone()
+    return bool(row[0]) if row else False
+
+async def set_attendance_enabled(self, server_id: int, value: bool) -> None:
+    async with get_connection(self._db_path) as db:
+        await db.execute(
+            "INSERT OR REPLACE INTO attendance_config (server_id, module_enabled) "
+            "VALUES (?, ?)",
+            (server_id, int(value)),
+        )
+        await db.commit()
+```
+
+---
+
+### Season review modules block (from `season_cog.py`, lines ~2484–2512)
+
+Current pattern:
+```python
+weather_on = await self.bot.module_service.is_weather_enabled(interaction.guild_id)
+signup_on  = await self.bot.module_service.is_signup_enabled(interaction.guild_id)
+results_on = await self.bot.module_service.is_results_enabled(interaction.guild_id)
+# ...
+lines += [
+    "**Modules**",
+    f"  Weather: {on if weather_on else off}",
+    signup_line,
+    f"  Results: {on if results_on else off}",
+    "",
+]
+```
+
+After modification, add:
+```python
+attendance_on = await self.bot.module_service.is_attendance_enabled(interaction.guild_id)
+# ...
+lines += [
+    "**Modules**",
+    f"  Weather: {on if weather_on else off}",
+    signup_line,
+    f"  Results: {on if results_on else off}",
+    f"  Attendance: {on if attendance_on else off}",
+    "",
+]
+```
+
+Per-division block (after the existing `lineup_chan`/`cal_chan` lines):
+```python
+adc = await self.bot.attendance_service.get_division_config(div.id)
+rsvp_chan       = f"<#{adc.rsvp_channel_id}>"       if adc and adc.rsvp_channel_id       else "*(not set)*"
+attendance_chan  = f"<#{adc.attendance_channel_id}>"  if adc and adc.attendance_channel_id  else "*(not set)*"
+lines.append(f"  RSVP channel: {rsvp_chan}")
+lines.append(f"  Attendance channel: {attendance_chan}")
+```
+
+---
+
+### Season approval gate pattern (from `_do_approve`, following Gate 1 / Gate 2)
+
+```python
+# ── Gate N: attendance module channel prerequisites ─────────────────────────
+if await self.bot.module_service.is_attendance_enabled(cfg.server_id):
+    gate_errors: list[str] = []
+    for d in divisions:
+        adc = await self.bot.attendance_service.get_division_config(d.id)
+        if adc is None or not adc.rsvp_channel_id:
+            gate_errors.append(f"**{d.name}** is missing an RSVP channel")
+        if adc is None or not adc.attendance_channel_id:
+            gate_errors.append(f"**{d.name}** is missing an attendance channel")
+    if gate_errors:
+        bullet_list = "\n\u2022 ".join(gate_errors)
+        msg = (
+            f"\u274c Season cannot be approved \u2014 attendance module prerequisites "
+            f"not met:\n\u2022 {bullet_list}"
+        )
+        if interaction.response.is_done():
+            await interaction.followup.send(msg, ephemeral=True)
+        else:
+            await interaction.response.send_message(msg, ephemeral=True)
+        return
+```
+
+---
+
+### Timing invariant validation
+
+Per spec FR-020 and Principle XIII:
+- Invariant: `rsvp_notice_days × 24 > rsvp_last_notice_hours` AND `rsvp_last_notice_hours ≥ rsvp_deadline_hours`
+- Edge case: `last_notice_hours = 0` and `deadline_hours = 0` is **valid** (last-notice ping
+  disabled; RSVP locks at round start). The invariant resolves to `notice_days × 24 > 0 ≥ 0`.
+
+Validation helper:
+```python
+def validate_timing_invariant(
+    notice_days: int,
+    last_notice_hours: int,
+    deadline_hours: int,
+) -> str | None:
+    """Return error message string if invariant violated, else None."""
+    if notice_days * 24 <= last_notice_hours:
+        return (
+            f"`rsvp_notice_days` ({notice_days}) \u00d7 24 = {notice_days * 24}h "
+            f"must be greater than `rsvp_last_notice_hours` ({last_notice_hours}h)."
+        )
+    if last_notice_hours < deadline_hours:
+        return (
+            f"`rsvp_last_notice_hours` ({last_notice_hours}h) "
+            f"must be \u2265 `rsvp_deadline_hours` ({deadline_hours}h)."
+        )
+    return None
+```
+
+---
+
+## Migration Number Confirmation
+
+Latest existing migration: `029_track_data_expansion.sql`  
+Next migration: **`030_attendance_module.sql`**

--- a/specs/031-attendance-module/research.md
+++ b/specs/031-attendance-module/research.md
@@ -100,12 +100,17 @@ convention. The `attendance` domain is new; config subcommands belong naturally 
 ### Decision 5: Cascading disable from `_disable_results` in `module_cog.py`
 
 **Decision**: In `module_cog.py::_disable_results()`, after disabling R&S, call a check:
-if attendance is enabled, call `_disable_attendance()` immediately.
+if attendance is enabled, call `_disable_attendance(interaction, cascade=True)` immediately.
+
+**Signature**: `async def _disable_attendance(self, interaction, *, cascade: bool = False)`
+- `cascade=False` (direct `/module disable attendance`): runs `defer()` + `followup.send()`.
+- `cascade=True` (called from `_disable_results`): skips `defer()`/`followup.send()` entirely
+  — the parent `_disable_results` owns the interaction. Audit entry and `post_log` still fire.
 
 **Rationale**: Per FR-007 and Principle XIII: "if the Results & Standings module is disabled
 while the Attendance module is active, the Attendance module MUST be disabled automatically."
 The cleanest hook is a direct call in `_disable_results()` after the R&S disable logic, reusing
-the same `_disable_attendance()` implementation with an appropriate cascade reason for the log.
+the same `_disable_attendance()` implementation via the `cascade` parameter.
 
 **Alternatives Considered**:
 - Event-based cascade (custom Discord event) — rejected; over-engineered for a single
@@ -277,7 +282,7 @@ if await self.bot.module_service.is_attendance_enabled(cfg.server_id):
 ### Timing invariant validation
 
 Per spec FR-020 and Principle XIII:
-- Invariant: `rsvp_notice_days × 24 > rsvp_last_notice_hours` AND `rsvp_last_notice_hours ≥ rsvp_deadline_hours`
+- Invariant: `rsvp_notice_days × 24 > rsvp_last_notice_hours` always; and `rsvp_last_notice_hours > rsvp_deadline_hours` when `last_notice_hours > 0`. Zero is a sentinel (ping disabled; second check skipped).
 - Edge case: `last_notice_hours = 0` and `deadline_hours = 0` is **valid** (last-notice ping
   disabled; RSVP locks at round start). The invariant resolves to `notice_days × 24 > 0 ≥ 0`.
 

--- a/specs/031-attendance-module/spec.md
+++ b/specs/031-attendance-module/spec.md
@@ -1,0 +1,179 @@
+# Feature Specification: Attendance Module — Initial Setup & Configuration
+
+**Feature Branch**: `031-attendance-module`  
+**Created**: 2026-04-03  
+**Status**: Draft  
+**Input**: User description: attendance module initial configuration (module lifecycle, channel setup, RSVP timing, attendance point settings)
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Enable and Disable the Attendance Module (Priority: P1)
+
+A server administrator wants to activate attendance tracking for the server. They enable the Attendance module using the standard module command. They later disable it when attendance tracking is no longer needed. The module's enabled/disabled status is reflected in the season review.
+
+**Why this priority**: The enable/disable lifecycle is the foundational gate for the entire module. Without it, no other attendance configuration or behaviour is accessible. It also enforces the dependency on the Results & Standings module, protecting data integrity.
+
+**Independent Test**: Can be fully tested by enabling and disabling the module and confirming the gate logic (season state, R&S dependency) without any RSVP or attendance data existing.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Results & Standings module is enabled and no active season exists, **When** a server admin runs `/module enable attendance`, **Then** the module is enabled, the server's attendance config row is initialised with defaults, and the log channel receives a confirmation notice.
+2. **Given** the Results & Standings module is disabled, **When** a server admin attempts `/module enable attendance`, **Then** the command is rejected with a clear error stating that Results & Standings must be enabled first.
+3. **Given** a season is in the `ACTIVE` state, **When** a server admin attempts `/module enable attendance`, **Then** the command is rejected with a clear error stating the module cannot be enabled during an active season.
+4. **Given** the Attendance module is enabled, **When** a server admin runs `/module disable attendance`, **Then** the module is disabled atomically: the enabled flag is cleared, all associated scheduled jobs (rsvp/last-notice timers) are cancelled, division config is cleared, and the log channel receives a notice.
+5. **Given** the Attendance module is enabled and the Results & Standings module is subsequently disabled, **When** the R&S module disable completes, **Then** the Attendance module is automatically disabled (same atomicity rules as manual disable).
+6. **Given** no active season, **When** a server admin runs `/season review`, **Then** the review output includes the Attendance module's enabled/disabled status.
+
+---
+
+### User Story 2 — Configure RSVP and Attendance Channels per Division (Priority: P2)
+
+A league manager wants to point the bot to the correct Discord channels for RSVP polls and attendance sheets for each division. They use the `division rsvp-channel` and `division attendance-channel` commands. Both channels appear in the season review alongside the other per-division channels. If either is missing when the season is approved, the approval is blocked.
+
+**Why this priority**: Channel configuration is a prerequisite for season approval with the module enabled, and it needs to be in place before any RSVP or attendance automation can fire.
+
+**Independent Test**: Can be fully tested by setting channels for a division and attempting a season approval in `SETUP` with and without the channels configured, confirming approval gating behaviour.
+
+**Acceptance Scenarios**:
+
+1. **Given** the Attendance module is enabled and a division exists, **When** a league manager runs `/division rsvp-channel <division> <channel>`, **Then** the RSVP channel is stored in `AttendanceDivisionConfig` for that division, and the season review reflects the new channel.
+2. **Given** the Attendance module is enabled and a division exists, **When** a league manager runs `/division attendance-channel <division> <channel>`, **Then** the attendance channel is stored in `AttendanceDivisionConfig` for that division, and the season review reflects the new channel.
+3. **Given** the Attendance module is enabled and a division is missing its RSVP channel, **When** a league manager attempts to approve the season, **Then** approval is blocked with a diagnostic naming the division and the missing channel.
+4. **Given** the Attendance module is enabled and a division is missing its attendance channel, **When** a league manager attempts to approve the season, **Then** approval is blocked with a diagnostic naming the division and the missing channel.
+5. **Given** both channels are set for all configured divisions, **When** a league manager approves the season, **Then** the attendance channel gate passes (other gates may still block approval independently).
+6. **Given** the Attendance module is disabled, **When** a league manager runs either channel command, **Then** the command is rejected with a clear module-not-enabled error.
+
+---
+
+### User Story 3 — Configure RSVP Timing Parameters (Priority: P3)
+
+A league manager wants to control how far in advance the RSVP notice is sent, whether a last-notice ping fires for un-RSVP'd drivers, and when the RSVP window closes. They use the three `attendance config` timing commands. All three values must satisfy the ordering invariant at all times and cannot be changed mid-season.
+
+**Why this priority**: Timing configuration must be locked down before a season starts and validated for correctness before being persisted.
+
+**Independent Test**: Can be fully tested by setting each timing parameter in isolation and in combination, verifying invariant enforcement and mid-season rejection, without any RSVP data existing.
+
+**Acceptance Scenarios**:
+
+1. **Given** the module is enabled and there is no active season, **When** a league manager runs `/attendance config rsvp-notice 7`, **Then** `rsvp_notice_days` is updated to 7 and validated against the current `rsvp_last_notice_hours` and `rsvp_deadline_hours` (7 × 24 = 168 > current last-notice hours > current deadline hours).
+2. **Given** the module is enabled and there is no active season, **When** a league manager runs `/attendance config rsvp-last-notice 0`, **Then** `rsvp_last_notice_hours` is set to 0 (last-notice ping disabled), provided the invariant is not violated (notice × 24 > 0 is trivially true; 0 must still be > deadline only if deadline = 0 as well — see edge cases).
+3. **Given** the module is enabled and there is no active season, **When** a league manager runs `/attendance config rsvp-deadline 3`, **Then** `rsvp_deadline_hours` is updated to 3, validated that the invariant notice × 24 > last-notice > deadline holds with the current saved values.
+4. **Given** the module is enabled, **When** a league manager submits a timing value that would violate the invariant `notice_days × 24 > last_notice_hours > deadline_hours`, **Then** the command is rejected with a clear error describing which constraint is violated and what the current conflicting values are.
+5. **Given** a season is in the `ACTIVE` state, **When** a league manager attempts any of the three timing commands, **Then** the command is rejected with a clear error stating configuration cannot be changed during an active season.
+
+---
+
+### User Story 4 — Configure Attendance Point Penalties and Sanction Thresholds (Priority: P4)
+
+A league manager wants to define how many attendance points are awarded for each type of infraction and at what point a driver is automatically moved to reserve or sacked. They use the five `attendance config` penalty commands. Autoreserve and autosack are disabled by default (value 0).
+
+**Why this priority**: Penalty configuration is independent of timing and channel configuration and can be set up in isolation, but is required for the attendance points logic to produce meaningful results.
+
+**Independent Test**: Can be fully tested by configuring each penalty value and threshold and reading them back via a config view or the season review, without any attendance data existing.
+
+**Acceptance Scenarios**:
+
+1. **Given** the module is enabled, **When** a league manager runs `/attendance config no-rsvp-penalty 2`, **Then** `no_rsvp_penalty` is updated to 2.
+2. **Given** the module is enabled, **When** a league manager runs `/attendance config no-attend-penalty 2`, **Then** `no_attend_penalty` is updated to 2.
+3. **Given** the module is enabled, **When** a league manager runs `/attendance config no-show-penalty 3`, **Then** `no_show_penalty` is updated to 3.
+4. **Given** the module is enabled, **When** a league manager runs `/attendance config autosack 5`, **Then** `autosack_threshold` is set to 5 (enabled).
+5. **Given** the module is enabled, **When** a league manager runs `/attendance config autosack 0`, **Then** `autosack_threshold` is set to null (disabled).
+6. **Given** the module is enabled, **When** a league manager runs `/attendance config autoreserve 3`, **Then** `autoreserve_threshold` is set to 3 (enabled).
+7. **Given** the module is enabled, **When** a league manager runs `/attendance config autoreserve 0`, **Then** `autoreserve_threshold` is set to null (disabled).
+8. **Given** the Attendance module is disabled, **When** a league manager runs any penalty configuration command, **Then** the command is rejected with a clear module-not-enabled error.
+
+---
+
+### Edge Cases
+
+- What happens when `/module enable attendance` is run and no `AttendanceConfig` row exists yet for the server? The row must be created atomically with defaults during the enable operation.
+- What happens when the Attendance module is disabled and re-enabled? Config is cleared on disable (per Principle X rule 6); re-enabling starts fresh with defaults.
+- What is the timing invariant behaviour when `rsvp_last_notice_hours = 0` (last-notice disabled) and `rsvp_deadline_hours = 0`? Both zero means no last-notice ping and RSVP locks at round start time. The invariant `notice × 24 > last_notice > deadline` resolves to `notice × 24 > 0 > 0` which is `> 0 > 0` — a tie between last-notice and deadline at zero. The rule **must therefore be interpreted as**: `rsvp_deadline_hours ≤ rsvp_last_notice_hours < rsvp_notice_days × 24`, with 0 being valid for both `last_notice` and `deadline` simultaneously, but only valid for `last_notice` if `deadline = 0` as well.
+- What happens if the channel passed to `division rsvp-channel` or `division attendance-channel` is the same as an already-registered module channel (e.g., the results channel)? This is not blocked at the configuration stage; cross-channel registration is the server admin's responsibility. Validation only enforces that a channel is set.
+- What happens when the Attendance module is enabled via test mode? The module must respect test-mode fake driver rosters; enabling and configuring it while test mode is active must be permitted.
+- What happens when `/module disable attendance` is issued while RSVP timer jobs are armed? All scheduled jobs for RSVP notices and last-notice pings must be cancelled atomically.
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+#### Module Lifecycle
+
+- **FR-001**: The Attendance module MUST be disabled by default for all servers.
+- **FR-002**: A server administrator MUST be able to enable the Attendance module via `/module enable attendance`, subject to: (a) the Results & Standings module being enabled; (b) no season being in the `ACTIVE` lifecycle state.
+- **FR-003**: Enabling the module MUST atomically create an `AttendanceConfig` row for the server with default values if one does not exist, set `module_enabled = true`, and post a confirmation to the server's log channel.
+- **FR-004**: If any step of the enable operation fails, it MUST be rolled back and no partial state left.
+- **FR-005**: A server administrator MUST be able to disable the Attendance module via `/module disable attendance`. Disabling MUST atomically: set `module_enabled = false`, cancel all RSVP-related scheduled jobs for the server, clear `AttendanceDivisionConfig` rows for the server, and post a notice to the log channel.
+- **FR-006**: Historical data generated by the module (attendance records, pardon logs) MUST be retained on disable; only live/scheduled artifacts are removed.
+- **FR-007**: If the Results & Standings module is disabled while the Attendance module is enabled, the Attendance module MUST be automatically disabled using the same atomicity rules as a manual disable.
+- **FR-008**: The Attendance module MUST NOT be enabled when a season is in the `ACTIVE` state. The command MUST be rejected with a clear, actionable error.
+- **FR-009**: On bot restart, if the Attendance module is enabled, the bot MUST re-arm any RSVP notice and last-notice scheduled jobs that have not yet fired for rounds in the current `ACTIVE` season.
+- **FR-010**: The Attendance module's enabled/disabled status MUST appear in the `/season review` output alongside other module statuses.
+- **FR-011**: The Attendance module MUST function correctly when test-mode fake driver rosters are in use.
+
+#### Channel Configuration
+
+- **FR-012**: League managers MUST be able to set a per-division RSVP channel via `/division rsvp-channel <division> <channel>`. The channel ID MUST be stored in `AttendanceDivisionConfig` for that division.
+- **FR-013**: League managers MUST be able to set a per-division attendance channel via `/division attendance-channel <division> <channel>`. The channel ID MUST be stored in `AttendanceDivisionConfig` for that division.
+- **FR-014**: Both channel commands MUST be rejected if the Attendance module is not enabled, with a clear error.
+- **FR-015**: Both channels for every configured division MUST be present before a season may be approved when the Attendance module is enabled. Missing either channel for any division MUST block approval and identify the affected division(s) and missing channel(s) in the error message.
+- **FR-016**: Both per-division channels MUST appear in the `/season review` output alongside other division channels (results, standings, weather forecast, etc.).
+
+#### RSVP Timing Configuration
+
+- **FR-017**: League managers MUST be able to configure the number of days before a round at which RSVP notices are sent via `/attendance config rsvp-notice <days>`. Default value: 5.
+- **FR-018**: League managers MUST be able to configure the number of hours before a round at which un-RSVP'd drivers are pinged via `/attendance config rsvp-last-notice <hours>`. Default value: 1. A value of 0 disables the last-notice ping.
+- **FR-019**: League managers MUST be able to configure the RSVP deadline in hours before a round via `/attendance config rsvp-deadline <hours>`. Default value: 2. A value of 0 means RSVP locks at the scheduled round start time.
+- **FR-020**: All three timing parameters MUST satisfy the invariant `rsvp_notice_days × 24 > rsvp_last_notice_hours` and `rsvp_last_notice_hours ≥ rsvp_deadline_hours` at all times. Any command that would violate these constraints MUST be rejected with a clear error identifying the conflicting values.
+- **FR-021**: All three timing commands MUST be rejected if a season is currently in the `ACTIVE` state, with a clear error.
+
+#### Attendance Point Configuration
+
+- **FR-022**: League managers MUST be able to configure the no-RSVP attendance point penalty via `/attendance config no-rsvp-penalty <points>`. Default value: 1. Must be a non-negative integer.
+- **FR-023**: League managers MUST be able to configure the no-attend attendance point penalty via `/attendance config no-attend-penalty <points>`. Default value: 1. Must be a non-negative integer.
+- **FR-024**: League managers MUST be able to configure the no-show attendance point penalty via `/attendance config no-show-penalty <points>`. Default value: 1. Must be a non-negative integer.
+- **FR-025**: League managers MUST be able to configure the autosack threshold via `/attendance config autosack <points>`. Default: disabled. A value of 0 disables the feature (stored as null). Must be a non-negative integer.
+- **FR-026**: League managers MUST be able to configure the autoreserve threshold via `/attendance config autoreserve <points>`. Default: disabled. A value of 0 disables the feature (stored as null). Must be a non-negative integer. This threshold only applies to drivers not already in the Reserve team.
+- **FR-027**: All five penalty configuration commands MUST be rejected if the Attendance module is not enabled, with a clear error.
+
+### Key Entities
+
+- **AttendanceConfig** (per server): `module_enabled`, `rsvp_notice_days` (default 5), `rsvp_last_notice_hours` (default 1), `rsvp_deadline_hours` (default 2), `no_rsvp_penalty` (default 1), `no_attend_penalty` (default 1), `no_show_penalty` (default 1), `autoreserve_threshold` (nullable, default null), `autosack_threshold` (nullable, default null). Owned by the Attendance module. Created on first enable; cleared on disable.
+
+- **AttendanceDivisionConfig** (per server, per division): `rsvp_channel_id` (nullable), `attendance_channel_id` (nullable). Keyed on `(server_id, division_id)`. Created lazily on first channel command for a division; cleared when the module is disabled.
+
+## Assumptions
+
+- The "league manager" role referenced in command access is the tier-2 admin (season/config authority) as defined in Principle I. Server administrators hold tier-2 authority by default on Discord.
+- The `division rsvp-channel` and `division attendance-channel` commands are added to the existing `/division` command group, consistent with the pattern already established for `/division results-channel`, `/division standings-channel`, etc.
+- The `attendance config` commands are grouped under a new `/attendance` top-level command group as subcommands of an `attendance config` subgroup, consistent with the Bot Behavior Standards subcommand-group convention.
+- The invariant edge case where both `rsvp_last_notice_hours` and `rsvp_deadline_hours` are 0 is permitted (last-notice ping is disabled; RSVP locks at round start). The ordering constraint is satisfied as long as `rsvp_notice_days × 24 > 0`.
+- "Ongoing season" in the context of timing command rejection means a season in the `ACTIVE` lifecycle state specifically. A season in `SETUP` or `COMPLETED` does NOT block these commands.
+- All configuration commands produce ephemeral responses visible only to the invoking user (per Bot Behavior Standards).
+- The module does not add a DB migration for `AttendanceDivisionConfig` rows to the `divisions` table itself — it uses a separate join table (per constitution v2.10.0 design), consistent with the `DivisionResultsConfig` pattern in the Results & Standings module.
+
+## Out of Scope for This Increment
+
+The following attendance module behaviours are **explicitly deferred** to future feature increments:
+
+- RSVP embed posting and button interaction handling.
+- Reserve distribution logic at the RSVP deadline.
+- Last-notice ping scheduling and sending.
+- Attendance recording from submitted round results.
+- Attendance point distribution (post-penalty finalization hook).
+- Attendance pardon workflow inside the penalty wizard.
+- Attendance sheet posting to the attendance channel.
+- Autoreserve and autosack sanction enforcement execution.
+- DriverRoundAttendance and AttendancePardon data entities (deferred to the RSVP/attendance implementation increment).
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: League managers can enable and disable the Attendance module in a single command interaction; the enable gate (R&S dependency, season state) is enforced 100% of the time.
+- **SC-002**: Automatic disable fires reliably whenever the Results & Standings module is disabled while Attendance is active, with no manual intervention required and no partial state left.
+- **SC-003**: All seven `attendance config` commands and both `division` channel commands are completable in a single interaction without wizard flows.
+- **SC-004**: The RSVP timing invariant is enforced on every configuration command; no combination of values that violates the constraint can be persisted.
+- **SC-005**: Season approval is reliably blocked when the Attendance module is enabled and any division is missing a required channel; the error message identifies the specific division and missing channel.
+- **SC-006**: The season review accurately reflects the Attendance module's status and all configured per-division channel assignments at all times.
+- **SC-007**: The full test suite covers module enable/disable lifecycle (including cascading disable), all configuration commands (happy path and rejection gates), and season approval channel validation.

--- a/specs/031-attendance-module/spec.md
+++ b/specs/031-attendance-module/spec.md
@@ -88,7 +88,8 @@ A league manager wants to define how many attendance points are awarded for each
 
 - What happens when `/module enable attendance` is run and no `AttendanceConfig` row exists yet for the server? The row must be created atomically with defaults during the enable operation.
 - What happens when the Attendance module is disabled and re-enabled? Config is cleared on disable (per Principle X rule 6); re-enabling starts fresh with defaults.
-- What is the timing invariant behaviour when `rsvp_last_notice_hours = 0` (last-notice disabled) and `rsvp_deadline_hours = 0`? Both zero means no last-notice ping and RSVP locks at round start time. The invariant `notice × 24 > last_notice > deadline` resolves to `notice × 24 > 0 > 0` which is `> 0 > 0` — a tie between last-notice and deadline at zero. The rule **must therefore be interpreted as**: `rsvp_deadline_hours ≤ rsvp_last_notice_hours < rsvp_notice_days × 24`, with 0 being valid for both `last_notice` and `deadline` simultaneously, but only valid for `last_notice` if `deadline = 0` as well.
+- What is the timing invariant behaviour when `rsvp_last_notice_hours` equals `rsvp_deadline_hours`? This is **rejected** — both values would fire at the same time. The invariant requires strict `>` for any non-zero `last_notice_hours`.
+- What is the timing invariant behaviour when `rsvp_last_notice_hours = 0`? Zero is a valid sentinel meaning the last-notice ping is **disabled** entirely. When `last_notice_hours = 0`, the `> deadline_hours` check is skipped; only `notice_days × 24 > 0` (always true for any positive `notice_days`) is enforced. `rsvp_deadline_hours` may be any non-negative value independently.
 - What happens if the channel passed to `division rsvp-channel` or `division attendance-channel` is the same as an already-registered module channel (e.g., the results channel)? This is not blocked at the configuration stage; cross-channel registration is the server admin's responsibility. Validation only enforces that a channel is set.
 - What happens when the Attendance module is enabled via test mode? The module must respect test-mode fake driver rosters; enabling and configuring it while test mode is active must be permitted.
 - What happens when `/module disable attendance` is issued while RSVP timer jobs are armed? All scheduled jobs for RSVP notices and last-notice pings must be cancelled atomically.
@@ -122,9 +123,9 @@ A league manager wants to define how many attendance points are awarded for each
 #### RSVP Timing Configuration
 
 - **FR-017**: League managers MUST be able to configure the number of days before a round at which RSVP notices are sent via `/attendance config rsvp-notice <days>`. Default value: 5.
-- **FR-018**: League managers MUST be able to configure the number of hours before a round at which un-RSVP'd drivers are pinged via `/attendance config rsvp-last-notice <hours>`. Default value: 1. A value of 0 disables the last-notice ping.
+- **FR-018**: League managers MUST be able to configure the number of hours before a round at which un-RSVP'd drivers are pinged via `/attendance config rsvp-last-notice <hours>`. Default value: 24. A value of 0 disables the last-notice ping entirely (the `> deadline_hours` comparison is skipped). Any non-zero value MUST be strictly greater than `rsvp_deadline_hours`.
 - **FR-019**: League managers MUST be able to configure the RSVP deadline in hours before a round via `/attendance config rsvp-deadline <hours>`. Default value: 2. A value of 0 means RSVP locks at the scheduled round start time.
-- **FR-020**: All three timing parameters MUST satisfy the invariant `rsvp_notice_days × 24 > rsvp_last_notice_hours` and `rsvp_last_notice_hours ≥ rsvp_deadline_hours` at all times. Any command that would violate these constraints MUST be rejected with a clear error identifying the conflicting values.
+- **FR-020**: The timing parameters MUST satisfy: `rsvp_notice_days × 24 > rsvp_last_notice_hours` at all times; and when `rsvp_last_notice_hours > 0`, additionally `rsvp_last_notice_hours > rsvp_deadline_hours`. A value of 0 for `rsvp_last_notice_hours` is a valid sentinel that disables the last-notice ping and bypasses the second comparison. Any command that would violate these constraints MUST be rejected with a clear error identifying the conflicting values.
 - **FR-021**: All three timing commands MUST be rejected if a season is currently in the `ACTIVE` state, with a clear error.
 
 #### Attendance Point Configuration
@@ -138,7 +139,7 @@ A league manager wants to define how many attendance points are awarded for each
 
 ### Key Entities
 
-- **AttendanceConfig** (per server): `module_enabled`, `rsvp_notice_days` (default 5), `rsvp_last_notice_hours` (default 1), `rsvp_deadline_hours` (default 2), `no_rsvp_penalty` (default 1), `no_attend_penalty` (default 1), `no_show_penalty` (default 1), `autoreserve_threshold` (nullable, default null), `autosack_threshold` (nullable, default null). Owned by the Attendance module. Created on first enable; cleared on disable.
+- **AttendanceConfig** (per server): `module_enabled`, `rsvp_notice_days` (default 5), `rsvp_last_notice_hours` (default 24), `rsvp_deadline_hours` (default 2), `no_rsvp_penalty` (default 1), `no_attend_penalty` (default 1), `no_show_penalty` (default 1), `autoreserve_threshold` (nullable, default null), `autosack_threshold` (nullable, default null). Owned by the Attendance module. Created on first enable; cleared on disable.
 
 - **AttendanceDivisionConfig** (per server, per division): `rsvp_channel_id` (nullable), `attendance_channel_id` (nullable). Keyed on `(server_id, division_id)`. Created lazily on first channel command for a division; cleared when the module is disabled.
 

--- a/specs/031-attendance-module/tasks.md
+++ b/specs/031-attendance-module/tasks.md
@@ -1,0 +1,175 @@
+# Tasks: Attendance Module — Initial Setup & Configuration
+
+**Branch**: `031-attendance-module`  
+**Input**: `specs/031-attendance-module/` (plan.md, spec.md, research.md, data-model.md, quickstart.md)  
+**Run tests**: `python -m pytest tests/ -v` from repo root
+
+---
+
+## Phase 1: Setup (Shared Infrastructure)
+
+**Purpose**: Create the two new source files that all user stories depend on — the DB migration and model dataclasses. No existing code is touched. Both tasks are fully independent.
+
+- [ ] T001 [P] Create migration `030_attendance_module.sql` with `attendance_config` and `attendance_division_config` tables in `src/db/migrations/030_attendance_module.sql`
+- [ ] T002 [P] Create `AttendanceConfig` and `AttendanceDivisionConfig` dataclasses in `src/models/attendance.py`
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: Core service layer that all user stories call into. MUST be complete before any cog work begins.
+
+**⚠️ CRITICAL**: No user story implementation can begin until this phase is complete.
+
+- [ ] T003 Implement `AttendanceService` with `get_config`, `get_or_create_config`, `delete_division_configs`, and module-level `validate_timing_invariant` helper in `src/services/attendance_service.py`
+- [ ] T004 [P] Add `is_attendance_enabled` and `set_attendance_enabled` methods to `src/services/module_service.py`
+- [ ] T005 Register `attendance_service = AttendanceService(db_path)` on the bot instance in `src/bot.py`
+
+**Checkpoint**: Foundation ready — all service methods exist; user story cog work can begin.
+
+---
+
+## Phase 3: User Story 1 — Enable and Disable the Attendance Module (Priority: P1) 🎯 MVP
+
+**Goal**: Full module lifecycle — enable (with R&S dependency + season-state gate), manual disable, cascading auto-disable when R&S is disabled, and attendance status in `/season review`.
+
+**Independent Test**: Enable the module, confirm the `attendance_config` row exists with defaults, confirm `/season review` shows "Enabled". Disable, confirm flag cleared and division configs removed. Disable R&S while attendance is on; confirm both are off.
+
+### Tests for User Story 1
+
+- [ ] T006 [P] [US1] Write lifecycle unit tests (`test_is_attendance_enabled_false_by_default`, `test_enable_creates_config_with_defaults`, `test_enable_sets_flag_true`, `test_disable_sets_flag_false`, `test_disable_deletes_division_configs`, `test_reenable_resets_to_defaults`) in `tests/unit/test_attendance_service.py`
+
+### Implementation for User Story 1
+
+- [ ] T007 [US1] Add `"attendance"` to `_MODULE_CHOICES` and add dispatch branches in `enable`/`disable` commands in `src/cogs/module_cog.py`
+- [ ] T008 [US1] Implement `_enable_attendance` (R&S gate, ACTIVE-season gate, already-enabled guard, `INSERT OR REPLACE attendance_config` with defaults, audit entry, `post_log`, followup) in `src/cogs/module_cog.py`
+- [ ] T009 [US1] Implement `_disable_attendance` (not-enabled guard, `UPDATE attendance_config SET module_enabled = 0`, `DELETE FROM attendance_division_config WHERE server_id = ?`, audit entry, `post_log`, followup) in `src/cogs/module_cog.py`
+- [ ] T010 [US1] Add cascade call to `_disable_attendance` inside `_disable_results` (fires when R&S disabled while attendance active; uses `ATTENDANCE_MODULE_CASCADE_DISABLED` audit change type) in `src/cogs/module_cog.py`
+- [ ] T011 [US1] Add `attendance_on` lookup and `"  Attendance: {on/off}"` line to the modules block in `season_review` in `src/cogs/season_cog.py`
+
+**Checkpoint**: `/module enable attendance`, `/module disable attendance`, cascading disable, and `/season review` module status all work independently.
+
+---
+
+## Phase 4: User Story 2 — Configure RSVP and Attendance Channels per Division (Priority: P2)
+
+**Goal**: `/division rsvp-channel` and `/division attendance-channel` store channel IDs per division; both appear in `/season review`; both are required before a season can be approved.
+
+**Independent Test**: Set RSVP and attendance channels for a division, confirm they appear in `/season review`. Attempt `/season approve` without channels set — confirm a clear error names the division and the missing channel type(s). Confirm both channels appear after setting.
+
+### Tests for User Story 2
+
+- [ ] T012 [P] [US2] Write division config unit tests (`test_get_config_none_before_create`, `test_set_rsvp_channel`, `test_set_attendance_channel`, `test_set_channel_preserves_other_channel`) in `tests/unit/test_attendance_service.py`
+
+### Implementation for User Story 2
+
+- [ ] T013 [US2] Add `get_division_config`, `set_rsvp_channel`, and `set_attendance_channel` methods (upsert preserving the other channel field) to `src/services/attendance_service.py`
+- [ ] T014 [P] [US2] Implement `/division rsvp-channel <division> <channel>` command (module-enabled guard, season lookup, division lookup, INSERT OR REPLACE via `attendance_service.set_rsvp_channel`, audit entry, `post_log`) in `src/cogs/season_cog.py`
+- [ ] T015 [P] [US2] Implement `/division attendance-channel <division> <channel>` command (same pattern as T014 but for `set_attendance_channel`) in `src/cogs/season_cog.py`
+- [ ] T016 [US2] Add per-division RSVP and attendance channel rows to the division loop in `season_review` (gated on `attendance_on`; show `*(not set)*` if unset) in `src/cogs/season_cog.py`
+- [ ] T017 [US2] Add attendance approval gate (Gate 4) to `_do_approve` — checks all divisions have both `rsvp_channel_id` and `attendance_channel_id`; blocks with named-division error if any missing — in `src/cogs/season_cog.py`
+
+**Checkpoint**: Channel commands work; `/season review` shows channel assignments; approval is correctly gated.
+
+---
+
+## Phase 5: User Story 3 — Configure RSVP Timing Parameters (Priority: P3)
+
+**Goal**: Three `/attendance config` commands (`rsvp-notice`, `rsvp-last-notice`, `rsvp-deadline`) update the timing fields on `attendance_config` with invariant enforcement and ACTIVE-season rejection.
+
+**Independent Test**: Set `rsvp-notice 7` → accepted. Set `rsvp-deadline 100` (violates `7×24=168 > last_notice=1`, deadline=100 > last_notice=1) → rejected with clear message. Attempt any timing command during an ACTIVE season → rejected.
+
+### Tests for User Story 3
+
+- [ ] T018 [P] [US3] Write timing invariant unit tests (`test_timing_invariant_valid`, `test_timing_invariant_notice_too_small`, `test_timing_invariant_deadline_exceeds_last`, `test_timing_invariant_both_zero`, `test_timing_invariant_last_equals_deadline`) in `tests/unit/test_attendance_service.py`
+
+### Implementation for User Story 3
+
+- [ ] T019 [US3] Create `/attendance` command group with `config` subgroup scaffold in `src/cogs/attendance_cog.py`
+- [ ] T020 [US3] Implement `/attendance config rsvp-notice <days>` (module-enabled guard, ACTIVE-season guard, `validate_timing_invariant` with new `notice_days`, UPDATE attendance_config, ephemeral confirm) in `src/cogs/attendance_cog.py`
+- [ ] T021 [US3] Implement `/attendance config rsvp-last-notice <hours>` (same guards + invariant with new `last_notice_hours`) in `src/cogs/attendance_cog.py`
+- [ ] T022 [US3] Implement `/attendance config rsvp-deadline <hours>` (same guards + invariant with new `deadline_hours`) in `src/cogs/attendance_cog.py`
+- [ ] T023 [US3] Register `attendance_cog` in `src/bot.py`
+
+**Checkpoint**: All three timing commands accept valid values, reject invariant violations, and reject ACTIVE-season attempts.
+
+---
+
+## Phase 6: User Story 4 — Configure Attendance Point Penalties and Sanction Thresholds (Priority: P4)
+
+**Goal**: Five `/attendance config` commands update the five penalty/threshold fields. `autosack 0` and `autoreserve 0` store `NULL` (disabled).
+
+**Independent Test**: Run `no-rsvp-penalty 2` → field updated. Run `autosack 0` → threshold stored as `NULL`. Run `autosack 5` → threshold stored as `5`. All commands rejected if module is not enabled.
+
+### Tests for User Story 4
+
+- [ ] T024 [P] [US4] Write penalty/threshold config unit tests (`test_config_penalty_fields_update`, `test_autosack_zero_stores_null`, `test_autoreserve_zero_stores_null`) in `tests/unit/test_attendance_service.py`
+
+### Implementation for User Story 4
+
+- [ ] T025 [P] [US4] Implement `/attendance config no-rsvp-penalty <points>` (module-enabled guard, non-negative int validation, UPDATE no_rsvp_penalty) in `src/cogs/attendance_cog.py`
+- [ ] T026 [P] [US4] Implement `/attendance config no-attend-penalty <points>` (same pattern) in `src/cogs/attendance_cog.py`
+- [ ] T027 [P] [US4] Implement `/attendance config no-show-penalty <points>` (same pattern) in `src/cogs/attendance_cog.py`
+- [ ] T028 [P] [US4] Implement `/attendance config autosack <points>` (0 → store `NULL`, else store value) in `src/cogs/attendance_cog.py`
+- [ ] T029 [P] [US4] Implement `/attendance config autoreserve <points>` (0 → store `NULL`, else store value) in `src/cogs/attendance_cog.py`
+
+**Checkpoint**: All five penalty/threshold commands work with correct zero-to-null handling and module-guard rejection.
+
+---
+
+## Phase 7: Polish & Cross-Cutting Concerns
+
+- [ ] T030 Run full test suite and confirm all tests pass: `python -m pytest tests/ -v` from repo root
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately. T001 and T002 are parallel.
+- **Phase 2 (Foundational)**: Depends on Phase 1 complete. T004 and T005 can overlap with T003 after T001 is done; T005 depends on T003 + T004.
+- **Phase 3 (US1)**: Depends on Phase 2 complete. T006 (tests) can be written in parallel with T007–T011.
+- **Phase 4 (US2)**: Depends on Phase 2 complete. T013 must precede T014/T015 (both need service methods). T016 and T017 depend on T013.
+- **Phase 5 (US3)**: Depends on Phase 2 complete. T019 (scaffold) must precede T020–T022.
+- **Phase 6 (US4)**: Depends on T019 complete (relies on the cog scaffold).
+- **Phase 7 (Polish)**: Depends on all phases complete.
+
+### User Story Dependencies
+
+- **US1 (P1)**: Depends on Phase 2 only — no dependencies on US2/US3/US4.
+- **US2 (P2)**: Depends on Phase 2 and US1 complete (uses `is_attendance_enabled` guard). T013 service methods must precede T014/T015/T016/T017.
+- **US3 (P3)**: Depends on Phase 2 only (uses `validate_timing_invariant` from T003). US1 is a prerequisite at runtime (module-enabled guard) but not a build-time dependency.
+- **US4 (P4)**: Depends on T019 (attendance_cog scaffold from US3). All five commands T025–T029 are parallel with each other.
+
+### Parallel Opportunities
+
+Within Phase 1: T001 ∥ T002  
+Within Phase 2: T003 → (T004 ∥ T005)  
+Within US1 (after Phase 2): T006 ∥ T007 → (T008 ∥ T009 ∥ T010) → T011  
+Within US2 (after T013): T014 ∥ T015; then T016 → T017  
+Within US2 tests: T012 ∥ T013  
+Within US3 (after T019): T020 ∥ T021 ∥ T022  
+Within US4 (after T019): T025 ∥ T026 ∥ T027 ∥ T028 ∥ T029  
+US3 and US4 can overlap (T019 is their shared prerequisite)
+
+---
+
+## Summary
+
+| Metric | Count |
+|--------|-------|
+| Total tasks | 30 |
+| Phase 1 (Setup) | 2 |
+| Phase 2 (Foundational) | 3 |
+| US1 (Enable/Disable) | 6 |
+| US2 (Channel Config) | 6 |
+| US3 (Timing Config) | 5 |
+| US4 (Penalty Config) | 6 |
+| Polish | 1 |
+| Test tasks | 4 (T006, T012, T018, T024) |
+| Parallelisable [P] tasks | 17 |
+
+**MVP scope**: Phase 1 + Phase 2 + Phase 3 (US1) — 11 tasks. Delivers working enable/disable lifecycle with cascading disable and season review integration.
+
+**Suggested delivery order**: US1 → US2 → US3 + US4 in parallel → Polish.

--- a/specs/031-attendance-module/tasks.md
+++ b/specs/031-attendance-module/tasks.md
@@ -27,6 +27,8 @@
 
 **Checkpoint**: Foundation ready — all service methods exist; user story cog work can begin.
 
+> **FR-009 deferred**: FR-009 ("on bot restart, re-arm any RSVP notice and last-notice scheduled jobs") is deferred to the RSVP automation increment. No APScheduler jobs are created in this increment, so FR-009 is vacuously satisfied here.
+
 ---
 
 ## Phase 3: User Story 1 — Enable and Disable the Attendance Module (Priority: P1) 🎯 MVP
@@ -37,14 +39,14 @@
 
 ### Tests for User Story 1
 
-- [ ] T006 [P] [US1] Write lifecycle unit tests (`test_is_attendance_enabled_false_by_default`, `test_enable_creates_config_with_defaults`, `test_enable_sets_flag_true`, `test_disable_sets_flag_false`, `test_disable_deletes_division_configs`, `test_reenable_resets_to_defaults`) in `tests/unit/test_attendance_service.py`
+- [ ] T006 [P] [US1] Write lifecycle unit tests (`test_is_attendance_enabled_false_by_default`, `test_enable_creates_config_with_defaults`, `test_enable_sets_flag_true`, `test_disable_sets_flag_false`, `test_disable_deletes_division_configs`, `test_reenable_resets_to_defaults`, `test_enable_rollback_on_db_failure`) in `tests/unit/test_attendance_service.py` — `test_enable_rollback_on_db_failure` simulates a DB error after `INSERT attendance_config` but before `set_attendance_enabled`; asserts no partial row is left and the enabled flag remains unset (FR-004)
 
 ### Implementation for User Story 1
 
 - [ ] T007 [US1] Add `"attendance"` to `_MODULE_CHOICES` and add dispatch branches in `enable`/`disable` commands in `src/cogs/module_cog.py`
 - [ ] T008 [US1] Implement `_enable_attendance` (R&S gate, ACTIVE-season gate, already-enabled guard, `INSERT OR REPLACE attendance_config` with defaults, audit entry, `post_log`, followup) in `src/cogs/module_cog.py`
-- [ ] T009 [US1] Implement `_disable_attendance` (not-enabled guard, `UPDATE attendance_config SET module_enabled = 0`, `DELETE FROM attendance_division_config WHERE server_id = ?`, audit entry, `post_log`, followup) in `src/cogs/module_cog.py`
-- [ ] T010 [US1] Add cascade call to `_disable_attendance` inside `_disable_results` (fires when R&S disabled while attendance active; uses `ATTENDANCE_MODULE_CASCADE_DISABLED` audit change type) in `src/cogs/module_cog.py`
+- [ ] T009 [US1] Implement `_disable_attendance(self, interaction, *, cascade: bool = False)` (not-enabled guard, `UPDATE attendance_config SET module_enabled = 0`, `DELETE FROM attendance_division_config WHERE server_id = ?`, audit entry, `post_log`; when `cascade=False` also `defer()` and `followup.send("✅ Attendance module disabled.")`; when `cascade=True` skip defer/followup — parent owns the interaction) in `src/cogs/module_cog.py` — Note: FR-006 is vacuously satisfied here; `DriverRoundAttendance` is not introduced in this increment. Future disable logic MUST NOT add `DELETE` statements for that table.
+- [ ] T010 [US1] Add cascade call `await self._disable_attendance(interaction, cascade=True)` inside `_disable_results` after R&S is disabled, guarded by `if attendance_enabled` check; uses `ATTENDANCE_MODULE_CASCADE_DISABLED` audit change type in `src/cogs/module_cog.py`
 - [ ] T011 [US1] Add `attendance_on` lookup and `"  Attendance: {on/off}"` line to the modules block in `season_review` in `src/cogs/season_cog.py`
 
 **Checkpoint**: `/module enable attendance`, `/module disable attendance`, cascading disable, and `/season review` module status all work independently.
@@ -81,7 +83,7 @@
 
 ### Tests for User Story 3
 
-- [ ] T018 [P] [US3] Write timing invariant unit tests (`test_timing_invariant_valid`, `test_timing_invariant_notice_too_small`, `test_timing_invariant_deadline_exceeds_last`, `test_timing_invariant_both_zero`, `test_timing_invariant_last_equals_deadline`) in `tests/unit/test_attendance_service.py`
+- [ ] T018 [P] [US3] Write timing invariant unit tests (`test_timing_invariant_valid`, `test_timing_invariant_notice_too_small`, `test_timing_invariant_deadline_exceeds_last`, `test_timing_invariant_last_zero_sentinel_valid`, `test_timing_invariant_last_equals_deadline_rejected`) in `tests/unit/test_attendance_service.py`
 
 ### Implementation for User Story 3
 
@@ -119,7 +121,7 @@
 
 ## Phase 7: Polish & Cross-Cutting Concerns
 
-- [ ] T030 Run full test suite and confirm all tests pass: `python -m pytest tests/ -v` from repo root
+- [ ] T030 Run full test suite and confirm all tests pass: `python -m pytest tests/ -v` from repo root — FR-011 (test-mode compatibility) is passively satisfied in this increment; no driver roster queries are performed. An explicit test will be required in the RSVP automation increment.
 
 ---
 
@@ -128,9 +130,9 @@
 ### Phase Dependencies
 
 - **Phase 1 (Setup)**: No dependencies — start immediately. T001 and T002 are parallel.
-- **Phase 2 (Foundational)**: Depends on Phase 1 complete. T004 and T005 can overlap with T003 after T001 is done; T005 depends on T003 + T004.
+- **Phase 2 (Foundational)**: Depends on Phase 1 complete. T004 can run in parallel with T003. T005 depends on both T003 and T004 completing first.
 - **Phase 3 (US1)**: Depends on Phase 2 complete. T006 (tests) can be written in parallel with T007–T011.
-- **Phase 4 (US2)**: Depends on Phase 2 complete. T013 must precede T014/T015 (both need service methods). T016 and T017 depend on T013.
+- **Phase 4 (US2)**: Depends on Phase 2 complete. T013 must precede T014/T015 (both need service methods). T016 and T017 depend on T013. T016 also depends on T011 (reads the `attendance_on` variable added to `season_review` by T011).
 - **Phase 5 (US3)**: Depends on Phase 2 complete. T019 (scaffold) must precede T020–T022.
 - **Phase 6 (US4)**: Depends on T019 complete (relies on the cog scaffold).
 - **Phase 7 (Polish)**: Depends on all phases complete.
@@ -138,7 +140,7 @@
 ### User Story Dependencies
 
 - **US1 (P1)**: Depends on Phase 2 only — no dependencies on US2/US3/US4.
-- **US2 (P2)**: Depends on Phase 2 and US1 complete (uses `is_attendance_enabled` guard). T013 service methods must precede T014/T015/T016/T017.
+- **US2 (P2)**: Depends on Phase 2 and US1 complete (uses `is_attendance_enabled` guard). T013 service methods must precede T014/T015/T016/T017. T016 additionally depends on T011 (requires `attendance_on` in `season_review` scope).
 - **US3 (P3)**: Depends on Phase 2 only (uses `validate_timing_invariant` from T003). US1 is a prerequisite at runtime (module-enabled guard) but not a build-time dependency.
 - **US4 (P4)**: Depends on T019 (attendance_cog scaffold from US3). All five commands T025–T029 are parallel with each other.
 

--- a/specs/031-attendance-module/tasks.md
+++ b/specs/031-attendance-module/tasks.md
@@ -10,8 +10,8 @@
 
 **Purpose**: Create the two new source files that all user stories depend on — the DB migration and model dataclasses. No existing code is touched. Both tasks are fully independent.
 
-- [ ] T001 [P] Create migration `030_attendance_module.sql` with `attendance_config` and `attendance_division_config` tables in `src/db/migrations/030_attendance_module.sql`
-- [ ] T002 [P] Create `AttendanceConfig` and `AttendanceDivisionConfig` dataclasses in `src/models/attendance.py`
+- [x] T001 [P] Create migration `030_attendance_module.sql` with `attendance_config` and `attendance_division_config` tables in `src/db/migrations/030_attendance_module.sql`
+- [x] T002 [P] Create `AttendanceConfig` and `AttendanceDivisionConfig` dataclasses in `src/models/attendance.py`
 
 ---
 
@@ -21,9 +21,9 @@
 
 **⚠️ CRITICAL**: No user story implementation can begin until this phase is complete.
 
-- [ ] T003 Implement `AttendanceService` with `get_config`, `get_or_create_config`, `delete_division_configs`, and module-level `validate_timing_invariant` helper in `src/services/attendance_service.py`
-- [ ] T004 [P] Add `is_attendance_enabled` and `set_attendance_enabled` methods to `src/services/module_service.py`
-- [ ] T005 Register `attendance_service = AttendanceService(db_path)` on the bot instance in `src/bot.py`
+- [x] T003 Implement `AttendanceService` with `get_config`, `get_or_create_config`, `delete_division_configs`, and module-level `validate_timing_invariant` helper in `src/services/attendance_service.py`
+- [x] T004 [P] Add `is_attendance_enabled` and `set_attendance_enabled` methods to `src/services/module_service.py`
+- [x] T005 Register `attendance_service = AttendanceService(db_path)` on the bot instance in `src/bot.py`
 
 **Checkpoint**: Foundation ready — all service methods exist; user story cog work can begin.
 
@@ -39,15 +39,15 @@
 
 ### Tests for User Story 1
 
-- [ ] T006 [P] [US1] Write lifecycle unit tests (`test_is_attendance_enabled_false_by_default`, `test_enable_creates_config_with_defaults`, `test_enable_sets_flag_true`, `test_disable_sets_flag_false`, `test_disable_deletes_division_configs`, `test_reenable_resets_to_defaults`, `test_enable_rollback_on_db_failure`) in `tests/unit/test_attendance_service.py` — `test_enable_rollback_on_db_failure` simulates a DB error after `INSERT attendance_config` but before `set_attendance_enabled`; asserts no partial row is left and the enabled flag remains unset (FR-004)
+- [x] T006 [P] [US1] Write lifecycle unit tests (`test_is_attendance_enabled_false_by_default`, `test_enable_creates_config_with_defaults`, `test_enable_sets_flag_true`, `test_disable_sets_flag_false`, `test_disable_deletes_division_configs`, `test_reenable_resets_to_defaults`, `test_enable_rollback_on_db_failure`) in `tests/unit/test_attendance_service.py` — `test_enable_rollback_on_db_failure` simulates a DB error after `INSERT attendance_config` but before `set_attendance_enabled`; asserts no partial row is left and the enabled flag remains unset (FR-004)
 
 ### Implementation for User Story 1
 
-- [ ] T007 [US1] Add `"attendance"` to `_MODULE_CHOICES` and add dispatch branches in `enable`/`disable` commands in `src/cogs/module_cog.py`
-- [ ] T008 [US1] Implement `_enable_attendance` (R&S gate, ACTIVE-season gate, already-enabled guard, `INSERT OR REPLACE attendance_config` with defaults, audit entry, `post_log`, followup) in `src/cogs/module_cog.py`
-- [ ] T009 [US1] Implement `_disable_attendance(self, interaction, *, cascade: bool = False)` (not-enabled guard, `UPDATE attendance_config SET module_enabled = 0`, `DELETE FROM attendance_division_config WHERE server_id = ?`, audit entry, `post_log`; when `cascade=False` also `defer()` and `followup.send("✅ Attendance module disabled.")`; when `cascade=True` skip defer/followup — parent owns the interaction) in `src/cogs/module_cog.py` — Note: FR-006 is vacuously satisfied here; `DriverRoundAttendance` is not introduced in this increment. Future disable logic MUST NOT add `DELETE` statements for that table.
-- [ ] T010 [US1] Add cascade call `await self._disable_attendance(interaction, cascade=True)` inside `_disable_results` after R&S is disabled, guarded by `if attendance_enabled` check; uses `ATTENDANCE_MODULE_CASCADE_DISABLED` audit change type in `src/cogs/module_cog.py`
-- [ ] T011 [US1] Add `attendance_on` lookup and `"  Attendance: {on/off}"` line to the modules block in `season_review` in `src/cogs/season_cog.py`
+- [x] T007 [US1] Add `"attendance"` to `_MODULE_CHOICES` and add dispatch branches in `enable`/`disable` commands in `src/cogs/module_cog.py`
+- [x] T008 [US1] Implement `_enable_attendance` (R&S gate, ACTIVE-season gate, already-enabled guard, `INSERT OR REPLACE attendance_config` with defaults, audit entry, `post_log`, followup) in `src/cogs/module_cog.py`
+- [x] T009 [US1] Implement `_disable_attendance(self, interaction, *, cascade: bool = False)` (not-enabled guard, `UPDATE attendance_config SET module_enabled = 0`, `DELETE FROM attendance_division_config WHERE server_id = ?`, audit entry, `post_log`; when `cascade=False` also `defer()` and `followup.send("✅ Attendance module disabled.")`; when `cascade=True` skip defer/followup — parent owns the interaction) in `src/cogs/module_cog.py` — Note: FR-006 is vacuously satisfied here; `DriverRoundAttendance` is not introduced in this increment. Future disable logic MUST NOT add `DELETE` statements for that table.
+- [x] T010 [US1] Add cascade call `await self._disable_attendance(interaction, cascade=True)` inside `_disable_results` after R&S is disabled, guarded by `if attendance_enabled` check; uses `ATTENDANCE_MODULE_CASCADE_DISABLED` audit change type in `src/cogs/module_cog.py`
+- [x] T011 [US1] Add `attendance_on` lookup and `"  Attendance: {on/off}"` line to the modules block in `season_review` in `src/cogs/season_cog.py`
 
 **Checkpoint**: `/module enable attendance`, `/module disable attendance`, cascading disable, and `/season review` module status all work independently.
 
@@ -61,15 +61,15 @@
 
 ### Tests for User Story 2
 
-- [ ] T012 [P] [US2] Write division config unit tests (`test_get_config_none_before_create`, `test_set_rsvp_channel`, `test_set_attendance_channel`, `test_set_channel_preserves_other_channel`) in `tests/unit/test_attendance_service.py`
+- [x] T012 [P] [US2] Write division config unit tests (`test_get_config_none_before_create`, `test_set_rsvp_channel`, `test_set_attendance_channel`, `test_set_channel_preserves_other_channel`) in `tests/unit/test_attendance_service.py`
 
 ### Implementation for User Story 2
 
-- [ ] T013 [US2] Add `get_division_config`, `set_rsvp_channel`, and `set_attendance_channel` methods (upsert preserving the other channel field) to `src/services/attendance_service.py`
-- [ ] T014 [P] [US2] Implement `/division rsvp-channel <division> <channel>` command (module-enabled guard, season lookup, division lookup, INSERT OR REPLACE via `attendance_service.set_rsvp_channel`, audit entry, `post_log`) in `src/cogs/season_cog.py`
-- [ ] T015 [P] [US2] Implement `/division attendance-channel <division> <channel>` command (same pattern as T014 but for `set_attendance_channel`) in `src/cogs/season_cog.py`
-- [ ] T016 [US2] Add per-division RSVP and attendance channel rows to the division loop in `season_review` (gated on `attendance_on`; show `*(not set)*` if unset) in `src/cogs/season_cog.py`
-- [ ] T017 [US2] Add attendance approval gate (Gate 4) to `_do_approve` — checks all divisions have both `rsvp_channel_id` and `attendance_channel_id`; blocks with named-division error if any missing — in `src/cogs/season_cog.py`
+- [x] T013 [US2] Add `get_division_config`, `set_rsvp_channel`, and `set_attendance_channel` methods (upsert preserving the other channel field) to `src/services/attendance_service.py`
+- [x] T014 [P] [US2] Implement `/division rsvp-channel <division> <channel>` command (module-enabled guard, season lookup, division lookup, INSERT OR REPLACE via `attendance_service.set_rsvp_channel`, audit entry, `post_log`) in `src/cogs/season_cog.py`
+- [x] T015 [P] [US2] Implement `/division attendance-channel <division> <channel>` command (same pattern as T014 but for `set_attendance_channel`) in `src/cogs/season_cog.py`
+- [x] T016 [US2] Add per-division RSVP and attendance channel rows to the division loop in `season_review` (gated on `attendance_on`; show `*(not set)*` if unset) in `src/cogs/season_cog.py`
+- [x] T017 [US2] Add attendance approval gate (Gate 4) to `_do_approve` — checks all divisions have both `rsvp_channel_id` and `attendance_channel_id`; blocks with named-division error if any missing — in `src/cogs/season_cog.py`
 
 **Checkpoint**: Channel commands work; `/season review` shows channel assignments; approval is correctly gated.
 
@@ -83,15 +83,15 @@
 
 ### Tests for User Story 3
 
-- [ ] T018 [P] [US3] Write timing invariant unit tests (`test_timing_invariant_valid`, `test_timing_invariant_notice_too_small`, `test_timing_invariant_deadline_exceeds_last`, `test_timing_invariant_last_zero_sentinel_valid`, `test_timing_invariant_last_equals_deadline_rejected`) in `tests/unit/test_attendance_service.py`
+- [x] T018 [P] [US3] Write timing invariant unit tests (`test_timing_invariant_valid`, `test_timing_invariant_notice_too_small`, `test_timing_invariant_deadline_exceeds_last`, `test_timing_invariant_last_zero_sentinel_valid`, `test_timing_invariant_last_equals_deadline_rejected`) in `tests/unit/test_attendance_service.py`
 
 ### Implementation for User Story 3
 
-- [ ] T019 [US3] Create `/attendance` command group with `config` subgroup scaffold in `src/cogs/attendance_cog.py`
-- [ ] T020 [US3] Implement `/attendance config rsvp-notice <days>` (module-enabled guard, ACTIVE-season guard, `validate_timing_invariant` with new `notice_days`, UPDATE attendance_config, ephemeral confirm) in `src/cogs/attendance_cog.py`
-- [ ] T021 [US3] Implement `/attendance config rsvp-last-notice <hours>` (same guards + invariant with new `last_notice_hours`) in `src/cogs/attendance_cog.py`
-- [ ] T022 [US3] Implement `/attendance config rsvp-deadline <hours>` (same guards + invariant with new `deadline_hours`) in `src/cogs/attendance_cog.py`
-- [ ] T023 [US3] Register `attendance_cog` in `src/bot.py`
+- [x] T019 [US3] Create `/attendance` command group with `config` subgroup scaffold in `src/cogs/attendance_cog.py`
+- [x] T020 [US3] Implement `/attendance config rsvp-notice <days>` (module-enabled guard, ACTIVE-season guard, `validate_timing_invariant` with new `notice_days`, UPDATE attendance_config, ephemeral confirm) in `src/cogs/attendance_cog.py`
+- [x] T021 [US3] Implement `/attendance config rsvp-last-notice <hours>` (same guards + invariant with new `last_notice_hours`) in `src/cogs/attendance_cog.py`
+- [x] T022 [US3] Implement `/attendance config rsvp-deadline <hours>` (same guards + invariant with new `deadline_hours`) in `src/cogs/attendance_cog.py`
+- [x] T023 [US3] Register `attendance_cog` in `src/bot.py`
 
 **Checkpoint**: All three timing commands accept valid values, reject invariant violations, and reject ACTIVE-season attempts.
 
@@ -105,15 +105,15 @@
 
 ### Tests for User Story 4
 
-- [ ] T024 [P] [US4] Write penalty/threshold config unit tests (`test_config_penalty_fields_update`, `test_autosack_zero_stores_null`, `test_autoreserve_zero_stores_null`) in `tests/unit/test_attendance_service.py`
+- [x] T024 [P] [US4] Write penalty/threshold config unit tests (`test_config_penalty_fields_update`, `test_autosack_zero_stores_null`, `test_autoreserve_zero_stores_null`) in `tests/unit/test_attendance_service.py`
 
 ### Implementation for User Story 4
 
-- [ ] T025 [P] [US4] Implement `/attendance config no-rsvp-penalty <points>` (module-enabled guard, non-negative int validation, UPDATE no_rsvp_penalty) in `src/cogs/attendance_cog.py`
-- [ ] T026 [P] [US4] Implement `/attendance config no-attend-penalty <points>` (same pattern) in `src/cogs/attendance_cog.py`
-- [ ] T027 [P] [US4] Implement `/attendance config no-show-penalty <points>` (same pattern) in `src/cogs/attendance_cog.py`
-- [ ] T028 [P] [US4] Implement `/attendance config autosack <points>` (0 → store `NULL`, else store value) in `src/cogs/attendance_cog.py`
-- [ ] T029 [P] [US4] Implement `/attendance config autoreserve <points>` (0 → store `NULL`, else store value) in `src/cogs/attendance_cog.py`
+- [x] T025 [P] [US4] Implement `/attendance config no-rsvp-penalty <points>` (module-enabled guard, non-negative int validation, UPDATE no_rsvp_penalty) in `src/cogs/attendance_cog.py`
+- [x] T026 [P] [US4] Implement `/attendance config no-attend-penalty <points>` (same pattern) in `src/cogs/attendance_cog.py`
+- [x] T027 [P] [US4] Implement `/attendance config no-show-penalty <points>` (same pattern) in `src/cogs/attendance_cog.py`
+- [x] T028 [P] [US4] Implement `/attendance config autosack <points>` (0 → store `NULL`, else store value) in `src/cogs/attendance_cog.py`
+- [x] T029 [P] [US4] Implement `/attendance config autoreserve <points>` (0 → store `NULL`, else store value) in `src/cogs/attendance_cog.py`
 
 **Checkpoint**: All five penalty/threshold commands work with correct zero-to-null handling and module-guard rejection.
 
@@ -121,7 +121,7 @@
 
 ## Phase 7: Polish & Cross-Cutting Concerns
 
-- [ ] T030 Run full test suite and confirm all tests pass: `python -m pytest tests/ -v` from repo root — FR-011 (test-mode compatibility) is passively satisfied in this increment; no driver roster queries are performed. An explicit test will be required in the RSVP automation increment.
+- [x] T030 Run full test suite and confirm all tests pass: `python -m pytest tests/ -v` from repo root — FR-011 (test-mode compatibility) is passively satisfied in this increment; no driver roster queries are performed. An explicit test will be required in the RSVP automation increment.
 
 ---
 

--- a/src/bot.py
+++ b/src/bot.py
@@ -60,6 +60,7 @@ async def main() -> None:
     from services.module_service import ModuleService
     from services.signup_module_service import SignupModuleService
     from services.wizard_service import WizardService
+    from services.attendance_service import AttendanceService
     from utils.output_router import OutputRouter as _OutputRouter  # already imported above
 
     bot.module_service = ModuleService(DB_PATH)          # type: ignore[attr-defined]
@@ -69,6 +70,7 @@ async def main() -> None:
         bot.scheduler_service,  # type: ignore[attr-defined]
         bot.output_router,  # type: ignore[attr-defined]
     )
+    bot.attendance_service = AttendanceService(DB_PATH)  # type: ignore[attr-defined]
 
     @bot.event
     async def on_ready() -> None:
@@ -222,6 +224,7 @@ async def main() -> None:
     from cogs.retry_cog import RetryCog
     from cogs.results_cog import ResultsCog
     from cogs.weather_cog import WeatherCog
+    from cogs.attendance_cog import AttendanceCog
 
     await bot.add_cog(InitCog(bot))
     await bot.add_cog(SeasonCog(bot))
@@ -237,6 +240,7 @@ async def main() -> None:
     await bot.add_cog(RetryCog(bot))
     await bot.add_cog(ResultsCog(bot))
     await bot.add_cog(WeatherCog(bot))
+    await bot.add_cog(AttendanceCog(bot))
 
     # Register ALL persistent views so button interactions survive bot restarts.
     # Views with optional __init__ params resolve driver context from channel at

--- a/src/cogs/attendance_cog.py
+++ b/src/cogs/attendance_cog.py
@@ -1,0 +1,325 @@
+"""AttendanceCog — /attendance config commands."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import discord
+from discord import app_commands
+from discord.ext import commands
+
+from db.database import get_connection
+from services.attendance_service import validate_timing_invariant
+from utils.channel_guard import admin_only, channel_guard
+
+log = logging.getLogger(__name__)
+
+
+class AttendanceCog(commands.Cog):
+    def __init__(self, bot: commands.Bot) -> None:
+        self.bot = bot
+
+    attendance = app_commands.Group(
+        name="attendance",
+        description="Attendance module commands.",
+        default_permissions=None,
+    )
+
+    config = app_commands.Group(
+        name="config",
+        description="Configure attendance module settings.",
+        parent=attendance,
+    )
+
+    # ── Helpers ────────────────────────────────────────────────────────────
+
+    async def _guard_module_enabled(self, interaction: discord.Interaction) -> bool:
+        """Return True (and send error) if module is NOT enabled."""
+        if not await self.bot.module_service.is_attendance_enabled(interaction.guild_id):  # type: ignore[attr-defined]
+            await interaction.response.send_message(
+                "\u274c The Attendance module is not enabled. "
+                "Use `/module enable attendance` first.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    async def _guard_no_active_season(self, interaction: discord.Interaction) -> bool:
+        """Return True (and send error) if there IS an active season."""
+        season = await self.bot.season_service.get_active_season(interaction.guild_id)  # type: ignore[attr-defined]
+        if season is not None:
+            await interaction.response.send_message(
+                "\u274c Attendance configuration cannot be changed while a season is active.",
+                ephemeral=True,
+            )
+            return False
+        return True
+
+    # ── /attendance config rsvp-notice ────────────────────────────────────
+
+    @config.command(
+        name="rsvp-notice",
+        description="Set how many days before the race to send the first RSVP notice.",
+    )
+    @app_commands.describe(days="Number of days before the race for the RSVP notice (≥ 1)")
+    @channel_guard
+    @admin_only
+    async def config_rsvp_notice(
+        self, interaction: discord.Interaction, days: int
+    ) -> None:
+        if not await self._guard_module_enabled(interaction):
+            return
+        if not await self._guard_no_active_season(interaction):
+            return
+        if days < 1:
+            await interaction.response.send_message(
+                "\u274c `rsvp_notice_days` must be at least 1.", ephemeral=True
+            )
+            return
+
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+        cfg = await self.bot.attendance_service.get_config(server_id)  # type: ignore[attr-defined]
+        if cfg is None:
+            await interaction.response.send_message(
+                "\u274c No attendance configuration found. Enable the module first.",
+                ephemeral=True,
+            )
+            return
+
+        error = validate_timing_invariant(days, cfg.rsvp_last_notice_hours, cfg.rsvp_deadline_hours)
+        if error:
+            await interaction.response.send_message(f"\u274c {error}", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        await self.bot.attendance_service.update_rsvp_notice_days(server_id, days)  # type: ignore[attr-defined]
+        await interaction.followup.send(
+            f"\u2705 RSVP notice set to **{days}** day(s) before the race.", ephemeral=True
+        )
+
+    # ── /attendance config rsvp-last-notice ───────────────────────────────
+
+    @config.command(
+        name="rsvp-last-notice",
+        description="Set hours before the race for the last RSVP reminder (0 = disabled).",
+    )
+    @app_commands.describe(hours="Hours before the race for the last notice (0 to disable)")
+    @channel_guard
+    @admin_only
+    async def config_rsvp_last_notice(
+        self, interaction: discord.Interaction, hours: int
+    ) -> None:
+        if not await self._guard_module_enabled(interaction):
+            return
+        if not await self._guard_no_active_season(interaction):
+            return
+        if hours < 0:
+            await interaction.response.send_message(
+                "\u274c `rsvp_last_notice_hours` cannot be negative.", ephemeral=True
+            )
+            return
+
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+        cfg = await self.bot.attendance_service.get_config(server_id)  # type: ignore[attr-defined]
+        if cfg is None:
+            await interaction.response.send_message(
+                "\u274c No attendance configuration found. Enable the module first.",
+                ephemeral=True,
+            )
+            return
+
+        error = validate_timing_invariant(cfg.rsvp_notice_days, hours, cfg.rsvp_deadline_hours)
+        if error:
+            await interaction.response.send_message(f"\u274c {error}", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        await self.bot.attendance_service.update_rsvp_last_notice_hours(server_id, hours)  # type: ignore[attr-defined]
+        if hours == 0:
+            msg = "\u2705 Last RSVP reminder **disabled** (set to 0)."
+        else:
+            msg = f"\u2705 Last RSVP reminder set to **{hours}** hour(s) before the race."
+        await interaction.followup.send(msg, ephemeral=True)
+
+    # ── /attendance config rsvp-deadline ──────────────────────────────────
+
+    @config.command(
+        name="rsvp-deadline",
+        description="Set the RSVP deadline in hours before the race.",
+    )
+    @app_commands.describe(hours="Hours before the race when RSVPs close")
+    @channel_guard
+    @admin_only
+    async def config_rsvp_deadline(
+        self, interaction: discord.Interaction, hours: int
+    ) -> None:
+        if not await self._guard_module_enabled(interaction):
+            return
+        if not await self._guard_no_active_season(interaction):
+            return
+        if hours < 0:
+            await interaction.response.send_message(
+                "\u274c `rsvp_deadline_hours` cannot be negative.", ephemeral=True
+            )
+            return
+
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+        cfg = await self.bot.attendance_service.get_config(server_id)  # type: ignore[attr-defined]
+        if cfg is None:
+            await interaction.response.send_message(
+                "\u274c No attendance configuration found. Enable the module first.",
+                ephemeral=True,
+            )
+            return
+
+        error = validate_timing_invariant(cfg.rsvp_notice_days, cfg.rsvp_last_notice_hours, hours)
+        if error:
+            await interaction.response.send_message(f"\u274c {error}", ephemeral=True)
+            return
+
+        await interaction.response.defer(ephemeral=True)
+        await self.bot.attendance_service.update_rsvp_deadline_hours(server_id, hours)  # type: ignore[attr-defined]
+        await interaction.followup.send(
+            f"\u2705 RSVP deadline set to **{hours}** hour(s) before the race.", ephemeral=True
+        )
+
+    # ── /attendance config no-rsvp-penalty ────────────────────────────────
+
+    @config.command(
+        name="no-rsvp-penalty",
+        description="Set the point penalty for failing to RSVP.",
+    )
+    @app_commands.describe(points="Penalty points (≥ 0)")
+    @channel_guard
+    @admin_only
+    async def config_no_rsvp_penalty(
+        self, interaction: discord.Interaction, points: int
+    ) -> None:
+        if not await self._guard_module_enabled(interaction):
+            return
+        if points < 0:
+            await interaction.response.send_message(
+                "\u274c Penalty points cannot be negative.", ephemeral=True
+            )
+            return
+
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+        await interaction.response.defer(ephemeral=True)
+        await self.bot.attendance_service.update_no_rsvp_penalty(server_id, points)  # type: ignore[attr-defined]
+        await interaction.followup.send(
+            f"\u2705 No-RSVP penalty set to **{points}** point(s).", ephemeral=True
+        )
+
+    # ── /attendance config no-attend-penalty ──────────────────────────────
+
+    @config.command(
+        name="no-attend-penalty",
+        description="Set the point penalty for missing attendance without notice.",
+    )
+    @app_commands.describe(points="Penalty points (≥ 0)")
+    @channel_guard
+    @admin_only
+    async def config_no_attend_penalty(
+        self, interaction: discord.Interaction, points: int
+    ) -> None:
+        if not await self._guard_module_enabled(interaction):
+            return
+        if points < 0:
+            await interaction.response.send_message(
+                "\u274c Penalty points cannot be negative.", ephemeral=True
+            )
+            return
+
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+        await interaction.response.defer(ephemeral=True)
+        await self.bot.attendance_service.update_no_attend_penalty(server_id, points)  # type: ignore[attr-defined]
+        await interaction.followup.send(
+            f"\u2705 No-attend penalty set to **{points}** point(s).", ephemeral=True
+        )
+
+    # ── /attendance config no-show-penalty ────────────────────────────────
+
+    @config.command(
+        name="no-show-penalty",
+        description="Set the point penalty for a no-show (RSVP'd but did not attend).",
+    )
+    @app_commands.describe(points="Penalty points (≥ 0)")
+    @channel_guard
+    @admin_only
+    async def config_no_show_penalty(
+        self, interaction: discord.Interaction, points: int
+    ) -> None:
+        if not await self._guard_module_enabled(interaction):
+            return
+        if points < 0:
+            await interaction.response.send_message(
+                "\u274c Penalty points cannot be negative.", ephemeral=True
+            )
+            return
+
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+        await interaction.response.defer(ephemeral=True)
+        await self.bot.attendance_service.update_no_show_penalty(server_id, points)  # type: ignore[attr-defined]
+        await interaction.followup.send(
+            f"\u2705 No-show penalty set to **{points}** point(s).", ephemeral=True
+        )
+
+    # ── /attendance config autosack ────────────────────────────────────────
+
+    @config.command(
+        name="autosack",
+        description="Set the cumulative no-show threshold that triggers auto-sack (0 = disabled).",
+    )
+    @app_commands.describe(points="Cumulative threshold for auto-sack (0 to disable)")
+    @channel_guard
+    @admin_only
+    async def config_autosack(
+        self, interaction: discord.Interaction, points: int
+    ) -> None:
+        if not await self._guard_module_enabled(interaction):
+            return
+        if points < 0:
+            await interaction.response.send_message(
+                "\u274c Threshold cannot be negative.", ephemeral=True
+            )
+            return
+
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+        value = None if points == 0 else points
+        await interaction.response.defer(ephemeral=True)
+        await self.bot.attendance_service.update_autosack_threshold(server_id, value)  # type: ignore[attr-defined]
+        if value is None:
+            msg = "\u2705 Auto-sack **disabled**."
+        else:
+            msg = f"\u2705 Auto-sack threshold set to **{value}** point(s)."
+        await interaction.followup.send(msg, ephemeral=True)
+
+    # ── /attendance config autoreserve ────────────────────────────────────
+
+    @config.command(
+        name="autoreserve",
+        description="Set the cumulative threshold that triggers auto-reserve (0 = disabled).",
+    )
+    @app_commands.describe(points="Cumulative threshold for auto-reserve (0 to disable)")
+    @channel_guard
+    @admin_only
+    async def config_autoreserve(
+        self, interaction: discord.Interaction, points: int
+    ) -> None:
+        if not await self._guard_module_enabled(interaction):
+            return
+        if points < 0:
+            await interaction.response.send_message(
+                "\u274c Threshold cannot be negative.", ephemeral=True
+            )
+            return
+
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+        value = None if points == 0 else points
+        await interaction.response.defer(ephemeral=True)
+        await self.bot.attendance_service.update_autoreserve_threshold(server_id, value)  # type: ignore[attr-defined]
+        if value is None:
+            msg = "\u2705 Auto-reserve **disabled**."
+        else:
+            msg = f"\u2705 Auto-reserve threshold set to **{value}** point(s)."
+        await interaction.followup.send(msg, ephemeral=True)

--- a/src/cogs/module_cog.py
+++ b/src/cogs/module_cog.py
@@ -22,6 +22,7 @@ _MODULE_CHOICES = [
     app_commands.Choice(name="weather", value="weather"),
     app_commands.Choice(name="signup", value="signup"),
     app_commands.Choice(name="results", value="results"),
+    app_commands.Choice(name="attendance", value="attendance"),
 ]
 
 # ---------------------------------------------------------------------------
@@ -153,6 +154,8 @@ class ModuleCog(commands.Cog):
             await self._enable_weather(interaction, server_id)
         elif module_name.value == "results":
             await self._enable_results(interaction, server_id)
+        elif module_name.value == "attendance":
+            await self._enable_attendance(interaction, server_id)
         else:
             await self._enable_signup(interaction, server_id)
 
@@ -177,6 +180,8 @@ class ModuleCog(commands.Cog):
             await self._disable_weather(interaction, server_id)
         elif module_name.value == "results":
             await self._disable_results(interaction, server_id)
+        elif module_name.value == "attendance":
+            await self._disable_attendance(interaction)
         else:
             await self._disable_signup(interaction, server_id)
 
@@ -421,6 +426,118 @@ class ModuleCog(commands.Cog):
         await interaction.followup.send(
             "✅ Results & Standings module disabled.", ephemeral=True
         )
+
+        # Cascade: disable attendance if it is currently enabled
+        if await self.bot.module_service.is_attendance_enabled(server_id):
+            await self._disable_attendance(interaction, cascade=True)
+
+    # ── Attendance enable ──────────────────────────────────────────────
+
+    async def _enable_attendance(
+        self, interaction: discord.Interaction, server_id: int
+    ) -> None:
+        # 1. Guard: R&S must be enabled first
+        if not await self.bot.module_service.is_results_enabled(server_id):
+            await interaction.response.send_message(
+                "❌ The Attendance module requires the Results & Standings module to be enabled first.",
+                ephemeral=True,
+            )
+            return
+
+        # 2. Guard: no ACTIVE season
+        active_season = await self.bot.season_service.get_active_season(server_id)
+        if active_season is not None:
+            await interaction.response.send_message(
+                "❌ Attendance module cannot be enabled while a season is active.",
+                ephemeral=True,
+            )
+            return
+
+        # 3. Guard: already enabled
+        if await self.bot.module_service.is_attendance_enabled(server_id):
+            await interaction.response.send_message(
+                "⚠️ Attendance module is already enabled.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+
+        # 4. Atomically insert config row with defaults + audit entry
+        now = datetime.now(timezone.utc).isoformat()
+        try:
+            async with get_connection(self.bot.db_path) as db:
+                await db.execute(
+                    "INSERT OR REPLACE INTO attendance_config "
+                    "(server_id, module_enabled, rsvp_notice_days, rsvp_last_notice_hours, "
+                    "rsvp_deadline_hours, no_rsvp_penalty, no_attend_penalty, no_show_penalty, "
+                    "autoreserve_threshold, autosack_threshold) "
+                    "VALUES (?, 1, 5, 24, 2, 1, 1, 1, NULL, NULL)",
+                    (server_id,),
+                )
+                await db.execute(
+                    "INSERT INTO audit_entries "
+                    "(server_id, actor_id, actor_name, division_id, change_type, old_value, new_value, timestamp) "
+                    "VALUES (?, ?, ?, NULL, 'ATTENDANCE_MODULE_ENABLED', '', '', ?)",
+                    (server_id, interaction.user.id, str(interaction.user), now),
+                )
+                await db.commit()
+        except Exception as exc:
+            await interaction.followup.send(
+                f"❌ Attendance module enable failed: {exc}. Module remains disabled.",
+                ephemeral=True,
+            )
+            return
+
+        await self.bot.output_router.post_log(
+            server_id,
+            f"{interaction.user.display_name} (<@{interaction.user.id}>) | /module enable attendance | Success",
+        )
+        await interaction.followup.send("✅ Attendance module enabled.", ephemeral=True)
+
+    # ── Attendance disable ─────────────────────────────────────────────
+
+    async def _disable_attendance(
+        self, interaction: discord.Interaction, *, cascade: bool = False
+    ) -> None:
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+
+        if not cascade:
+            if not await self.bot.module_service.is_attendance_enabled(server_id):
+                await interaction.response.send_message(
+                    "⚠️ Attendance module is already disabled.", ephemeral=True
+                )
+                return
+            await interaction.response.defer(ephemeral=True)
+
+        change_type = (
+            "ATTENDANCE_MODULE_CASCADE_DISABLED" if cascade else "ATTENDANCE_MODULE_DISABLED"
+        )
+        now = datetime.now(timezone.utc).isoformat()
+        async with get_connection(self.bot.db_path) as db:
+            await db.execute(
+                "UPDATE attendance_config SET module_enabled = 0 WHERE server_id = ?",
+                (server_id,),
+            )
+            await db.execute(
+                "DELETE FROM attendance_division_config WHERE server_id = ?",
+                (server_id,),
+            )
+            await db.execute(
+                "INSERT INTO audit_entries "
+                "(server_id, actor_id, actor_name, division_id, change_type, old_value, new_value, timestamp) "
+                "VALUES (?, ?, ?, NULL, ?, '', '', ?)",
+                (server_id, interaction.user.id, str(interaction.user), change_type, now),
+            )
+            await db.commit()
+
+        await self.bot.output_router.post_log(
+            server_id,
+            f"{interaction.user.display_name} (<@{interaction.user.id}>) | /module disable attendance | Success",
+        )
+        if not cascade:
+            await interaction.followup.send(
+                "✅ Attendance module disabled.", ephemeral=True
+            )
 
     # ── Signup enable (T010) ───────────────────────────────────────────
 

--- a/src/cogs/season_cog.py
+++ b/src/cogs/season_cog.py
@@ -203,6 +203,7 @@ class SeasonCog(commands.Cog):
             weather_on = await self.bot.module_service.is_weather_enabled(interaction.guild_id)  # type: ignore[attr-defined]
             signup_on = await self.bot.module_service.is_signup_enabled(interaction.guild_id)  # type: ignore[attr-defined]
             results_on = await self.bot.module_service.is_results_enabled(interaction.guild_id)  # type: ignore[attr-defined]
+            attendance_on = await self.bot.module_service.is_attendance_enabled(interaction.guild_id)  # type: ignore[attr-defined]
             on = "✅ Enabled"
             off = "❌ Disabled"
             if signup_on:
@@ -224,6 +225,7 @@ class SeasonCog(commands.Cog):
                 f"  Weather: {on if weather_on else off}",
                 signup_line,
                 f"  Results: {on if results_on else off}",
+                f"  Attendance: {on if attendance_on else off}",
                 "",
             ]
 
@@ -293,6 +295,21 @@ class SeasonCog(commands.Cog):
                 cal_chan = f"<#{div.calendar_channel_id}>" if div.calendar_channel_id else "*(not set)*"
                 lines.append(f"  Lineup channel: {lineup_chan}")
                 lines.append(f"  Calendar channel: {cal_chan}")
+                # Attendance channels (gated on attendance module being enabled)
+                if attendance_on:
+                    att_div_cfg = await self.bot.attendance_service.get_division_config(div.id)  # type: ignore[attr-defined]
+                    rsvp_chan = (
+                        f"<#{att_div_cfg.rsvp_channel_id}>"
+                        if att_div_cfg and att_div_cfg.rsvp_channel_id
+                        else "*(not set)*"
+                    )
+                    att_chan = (
+                        f"<#{att_div_cfg.attendance_channel_id}>"
+                        if att_div_cfg and att_div_cfg.attendance_channel_id
+                        else "*(not set)*"
+                    )
+                    lines.append(f"  RSVP channel: {rsvp_chan}")
+                    lines.append(f"  Attendance channel: {att_chan}")
                 # ASSIGNED drivers grouped by team
                 async with get_connection(self.bot.db_path) as _db:  # type: ignore[attr-defined]
                     _cur = await _db.execute(
@@ -1253,6 +1270,172 @@ class SeasonCog(commands.Cog):
         await self.bot.output_router.post_log(
             server_id,
             f"{interaction.user.display_name} (<@{interaction.user.id}>) | /division verdicts-channel | Success\n"
+            f"  division: {name}\n"
+            f"  channel: #{channel.name}",
+        )
+
+    @division.command(
+        name="rsvp-channel",
+        description="Set the RSVP notice channel for a division (attendance module).",
+    )
+    @app_commands.describe(name="Division name", channel="RSVP notice channel")
+    @channel_guard
+    @admin_only
+    async def division_rsvp_channel(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+        channel: discord.TextChannel,
+    ) -> None:
+        import json as _json
+        if not await self.bot.module_service.is_attendance_enabled(interaction.guild_id):
+            await interaction.response.send_message(
+                "\u274c The Attendance module is not enabled.", ephemeral=True
+            )
+            return
+        await interaction.response.defer(ephemeral=True)
+
+        guild = interaction.guild
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+
+        if guild is None or not channel.permissions_for(guild.me).send_messages:
+            await interaction.followup.send(
+                "\u274c Cannot access that channel. Ensure the bot has permission to post there.",
+                ephemeral=True,
+            )
+            return
+
+        season = await self.bot.season_service.get_season_for_server(server_id)
+        if season is None:
+            await interaction.followup.send(
+                "\u274c No season found. Set up a season before assigning channels.",
+                ephemeral=True,
+            )
+            return
+
+        divisions = await self.bot.season_service.get_divisions(season.id)
+        div = next((d for d in divisions if d.name.lower() == name.lower()), None)
+        if div is None:
+            await interaction.followup.send(
+                f"\u274c Division \"{name}\" not found.",
+                ephemeral=True,
+            )
+            return
+
+        old_cfg = await self.bot.attendance_service.get_division_config(div.id)
+        old_id = old_cfg.rsvp_channel_id if old_cfg else None
+
+        await self.bot.attendance_service.set_rsvp_channel(div.id, server_id, channel.id)
+
+        now = datetime.now(timezone.utc).isoformat()
+        async with get_connection(self.bot.db_path) as db:
+            await db.execute(
+                "INSERT INTO audit_entries "
+                "(server_id, actor_id, actor_name, division_id, change_type, old_value, new_value, timestamp) "
+                "VALUES (?, ?, ?, ?, 'RSVP_CHANNEL_SET', ?, ?, ?)",
+                (
+                    server_id,
+                    interaction.user.id,
+                    str(interaction.user),
+                    div.id,
+                    _json.dumps({"channel_id": old_id}),
+                    _json.dumps({"channel_id": str(channel.id)}),
+                    now,
+                ),
+            )
+            await db.commit()
+
+        if old_id is None:
+            msg = f"\u2705 RSVP channel for {name} set to #{channel.name}."
+        else:
+            msg = f"\u2705 RSVP channel for {name} updated to #{channel.name}."
+        await interaction.followup.send(msg, ephemeral=True)
+        await self.bot.output_router.post_log(
+            server_id,
+            f"{interaction.user.display_name} (<@{interaction.user.id}>) | /division rsvp-channel | Success\n"
+            f"  division: {name}\n"
+            f"  channel: #{channel.name}",
+        )
+
+    @division.command(
+        name="attendance-channel",
+        description="Set the attendance logging channel for a division (attendance module).",
+    )
+    @app_commands.describe(name="Division name", channel="Attendance logging channel")
+    @channel_guard
+    @admin_only
+    async def division_attendance_channel(
+        self,
+        interaction: discord.Interaction,
+        name: str,
+        channel: discord.TextChannel,
+    ) -> None:
+        import json as _json
+        if not await self.bot.module_service.is_attendance_enabled(interaction.guild_id):
+            await interaction.response.send_message(
+                "\u274c The Attendance module is not enabled.", ephemeral=True
+            )
+            return
+        await interaction.response.defer(ephemeral=True)
+
+        guild = interaction.guild
+        server_id: int = interaction.guild_id  # type: ignore[assignment]
+
+        if guild is None or not channel.permissions_for(guild.me).send_messages:
+            await interaction.followup.send(
+                "\u274c Cannot access that channel. Ensure the bot has permission to post there.",
+                ephemeral=True,
+            )
+            return
+
+        season = await self.bot.season_service.get_season_for_server(server_id)
+        if season is None:
+            await interaction.followup.send(
+                "\u274c No season found. Set up a season before assigning channels.",
+                ephemeral=True,
+            )
+            return
+
+        divisions = await self.bot.season_service.get_divisions(season.id)
+        div = next((d for d in divisions if d.name.lower() == name.lower()), None)
+        if div is None:
+            await interaction.followup.send(
+                f"\u274c Division \"{name}\" not found.",
+                ephemeral=True,
+            )
+            return
+
+        old_cfg = await self.bot.attendance_service.get_division_config(div.id)
+        old_id = old_cfg.attendance_channel_id if old_cfg else None
+
+        await self.bot.attendance_service.set_attendance_channel(div.id, server_id, channel.id)
+
+        now = datetime.now(timezone.utc).isoformat()
+        async with get_connection(self.bot.db_path) as db:
+            await db.execute(
+                "INSERT INTO audit_entries "
+                "(server_id, actor_id, actor_name, division_id, change_type, old_value, new_value, timestamp) "
+                "VALUES (?, ?, ?, ?, 'ATTENDANCE_CHANNEL_SET', ?, ?, ?)",
+                (
+                    server_id,
+                    interaction.user.id,
+                    str(interaction.user),
+                    div.id,
+                    _json.dumps({"channel_id": old_id}),
+                    _json.dumps({"channel_id": str(channel.id)}),
+                    now,
+                ),
+            )
+            await db.commit()
+
+        if old_id is None:
+            msg = f"\u2705 Attendance channel for {name} set to #{channel.name}."
+        else:
+            msg = f"\u2705 Attendance channel for {name} updated to #{channel.name}."
+        await interaction.followup.send(msg, ephemeral=True)
+        await self.bot.output_router.post_log(
+            server_id,
+            f"{interaction.user.display_name} (<@{interaction.user.id}>) | /division attendance-channel | Success\n"
             f"  division: {name}\n"
             f"  channel: #{channel.name}",
         )
@@ -2648,6 +2831,33 @@ class SeasonCog(commands.Cog):
                     else:
                         await interaction.response.send_message(msg, ephemeral=True)
                     return
+
+        # ── Gate 4: attendance module channel prerequisites ───────────────────
+        if await self.bot.module_service.is_attendance_enabled(cfg.server_id):
+            att_errors: list[str] = []
+            for _div in divisions:
+                att_div_cfg = await self.bot.attendance_service.get_division_config(_div.id)  # type: ignore[attr-defined]
+                if att_div_cfg is None or not att_div_cfg.rsvp_channel_id:
+                    att_errors.append(
+                        f"**{_div.name}** is missing an RSVP channel "
+                        f"(use `/division rsvp-channel {_div.name} <channel>`)"
+                    )
+                if att_div_cfg is None or not att_div_cfg.attendance_channel_id:
+                    att_errors.append(
+                        f"**{_div.name}** is missing an attendance channel "
+                        f"(use `/division attendance-channel {_div.name} <channel>`)"
+                    )
+            if att_errors:
+                bullet_list = "\n\u2022 ".join(att_errors)
+                msg = (
+                    f"\u274c Season cannot be approved \u2014 attendance module is enabled but "
+                    f"missing required channel configuration:\n\u2022 {bullet_list}"
+                )
+                if interaction.response.is_done():
+                    await interaction.followup.send(msg, ephemeral=True)
+                else:
+                    await interaction.response.send_message(msg, ephemeral=True)
+                return
 
         # Snapshot attached points configs before transitioning (FR-007)
         if await self.bot.module_service.is_results_enabled(cfg.server_id):

--- a/src/db/migrations/030_attendance_module.sql
+++ b/src/db/migrations/030_attendance_module.sql
@@ -1,0 +1,26 @@
+-- Migration 030: Attendance Module
+-- Creates attendance_config (server-level) and attendance_division_config (per-division) tables.
+
+CREATE TABLE IF NOT EXISTS attendance_config (
+    server_id                INTEGER PRIMARY KEY
+                                 REFERENCES server_configs(server_id)
+                                 ON DELETE CASCADE,
+    module_enabled           INTEGER NOT NULL DEFAULT 0,
+    rsvp_notice_days         INTEGER NOT NULL DEFAULT 5,
+    rsvp_last_notice_hours   INTEGER NOT NULL DEFAULT 24,
+    rsvp_deadline_hours      INTEGER NOT NULL DEFAULT 2,
+    no_rsvp_penalty          INTEGER NOT NULL DEFAULT 1,
+    no_attend_penalty        INTEGER NOT NULL DEFAULT 1,
+    no_show_penalty          INTEGER NOT NULL DEFAULT 1,
+    autoreserve_threshold    INTEGER,
+    autosack_threshold       INTEGER
+);
+
+CREATE TABLE IF NOT EXISTS attendance_division_config (
+    division_id               INTEGER PRIMARY KEY
+                                  REFERENCES divisions(id)
+                                  ON DELETE CASCADE,
+    server_id                 INTEGER NOT NULL,
+    rsvp_channel_id           TEXT,
+    attendance_channel_id     TEXT
+);

--- a/src/models/attendance.py
+++ b/src/models/attendance.py
@@ -1,0 +1,26 @@
+"""Dataclasses for the Attendance Module."""
+from __future__ import annotations
+
+from dataclasses import dataclass
+
+
+@dataclass
+class AttendanceConfig:
+    server_id: int
+    module_enabled: bool
+    rsvp_notice_days: int
+    rsvp_last_notice_hours: int
+    rsvp_deadline_hours: int
+    no_rsvp_penalty: int
+    no_attend_penalty: int
+    no_show_penalty: int
+    autoreserve_threshold: int | None
+    autosack_threshold: int | None
+
+
+@dataclass
+class AttendanceDivisionConfig:
+    division_id: int
+    server_id: int
+    rsvp_channel_id: str | None
+    attendance_channel_id: str | None

--- a/src/services/attendance_service.py
+++ b/src/services/attendance_service.py
@@ -1,0 +1,195 @@
+"""AttendanceService — read/write attendance module configuration."""
+from __future__ import annotations
+
+from db.database import get_connection
+from models.attendance import AttendanceConfig, AttendanceDivisionConfig
+
+
+def validate_timing_invariant(
+    notice_days: int,
+    last_notice_hours: int,
+    deadline_hours: int,
+) -> str | None:
+    """Return an error string if the timing invariant is violated, else None.
+
+    Invariants:
+    - notice_days * 24 > last_notice_hours  (always)
+    - last_notice_hours > deadline_hours    (only when last_notice_hours > 0;
+                                             0 is the sentinel meaning "no last notice")
+    """
+    if notice_days * 24 <= last_notice_hours:
+        return (
+            f"`rsvp_notice_days` ({notice_days}) \u00d7 24 = {notice_days * 24}h "
+            f"must be greater than `rsvp_last_notice_hours` ({last_notice_hours}h)."
+        )
+    if last_notice_hours > 0 and last_notice_hours <= deadline_hours:
+        return (
+            f"`rsvp_last_notice_hours` ({last_notice_hours}h) "
+            f"must be greater than `rsvp_deadline_hours` ({deadline_hours}h)."
+        )
+    return None
+
+
+class AttendanceService:
+    def __init__(self, db_path: str) -> None:
+        self._db_path = db_path
+
+    # ── Server-level config ────────────────────────────────────────────────
+
+    async def get_config(self, server_id: int) -> AttendanceConfig | None:
+        async with get_connection(self._db_path) as db:
+            cursor = await db.execute(
+                "SELECT * FROM attendance_config WHERE server_id = ?",
+                (server_id,),
+            )
+            row = await cursor.fetchone()
+        if row is None:
+            return None
+        return AttendanceConfig(
+            server_id=row["server_id"],
+            module_enabled=bool(row["module_enabled"]),
+            rsvp_notice_days=row["rsvp_notice_days"],
+            rsvp_last_notice_hours=row["rsvp_last_notice_hours"],
+            rsvp_deadline_hours=row["rsvp_deadline_hours"],
+            no_rsvp_penalty=row["no_rsvp_penalty"],
+            no_attend_penalty=row["no_attend_penalty"],
+            no_show_penalty=row["no_show_penalty"],
+            autoreserve_threshold=row["autoreserve_threshold"],
+            autosack_threshold=row["autosack_threshold"],
+        )
+
+    async def get_or_create_config(self, server_id: int) -> AttendanceConfig:
+        existing = await self.get_config(server_id)
+        if existing is not None:
+            return existing
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                "INSERT OR IGNORE INTO attendance_config (server_id) VALUES (?)",
+                (server_id,),
+            )
+            await db.commit()
+        result = await self.get_config(server_id)
+        assert result is not None
+        return result
+
+    async def delete_division_configs(self, server_id: int) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                "DELETE FROM attendance_division_config WHERE server_id = ?",
+                (server_id,),
+            )
+            await db.commit()
+
+    # ── Division-level config ──────────────────────────────────────────────
+
+    async def get_division_config(self, division_id: int) -> AttendanceDivisionConfig | None:
+        async with get_connection(self._db_path) as db:
+            cursor = await db.execute(
+                "SELECT * FROM attendance_division_config WHERE division_id = ?",
+                (division_id,),
+            )
+            row = await cursor.fetchone()
+        if row is None:
+            return None
+        return AttendanceDivisionConfig(
+            division_id=row["division_id"],
+            server_id=row["server_id"],
+            rsvp_channel_id=row["rsvp_channel_id"],
+            attendance_channel_id=row["attendance_channel_id"],
+        )
+
+    async def set_rsvp_channel(
+        self, division_id: int, server_id: int, channel_id: int
+    ) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO attendance_division_config (division_id, server_id, rsvp_channel_id)
+                VALUES (?, ?, ?)
+                ON CONFLICT(division_id)
+                DO UPDATE SET rsvp_channel_id = excluded.rsvp_channel_id
+                """,
+                (division_id, server_id, str(channel_id)),
+            )
+            await db.commit()
+
+    async def set_attendance_channel(
+        self, division_id: int, server_id: int, channel_id: int
+    ) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO attendance_division_config (division_id, server_id, attendance_channel_id)
+                VALUES (?, ?, ?)
+                ON CONFLICT(division_id)
+                DO UPDATE SET attendance_channel_id = excluded.attendance_channel_id
+                """,
+                (division_id, server_id, str(channel_id)),
+            )
+            await db.commit()
+
+    # ── Field updates ──────────────────────────────────────────────────────
+
+    async def update_rsvp_notice_days(self, server_id: int, value: int) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                "UPDATE attendance_config SET rsvp_notice_days = ? WHERE server_id = ?",
+                (value, server_id),
+            )
+            await db.commit()
+
+    async def update_rsvp_last_notice_hours(self, server_id: int, value: int) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                "UPDATE attendance_config SET rsvp_last_notice_hours = ? WHERE server_id = ?",
+                (value, server_id),
+            )
+            await db.commit()
+
+    async def update_rsvp_deadline_hours(self, server_id: int, value: int) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                "UPDATE attendance_config SET rsvp_deadline_hours = ? WHERE server_id = ?",
+                (value, server_id),
+            )
+            await db.commit()
+
+    async def update_no_rsvp_penalty(self, server_id: int, value: int) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                "UPDATE attendance_config SET no_rsvp_penalty = ? WHERE server_id = ?",
+                (value, server_id),
+            )
+            await db.commit()
+
+    async def update_no_attend_penalty(self, server_id: int, value: int) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                "UPDATE attendance_config SET no_attend_penalty = ? WHERE server_id = ?",
+                (value, server_id),
+            )
+            await db.commit()
+
+    async def update_no_show_penalty(self, server_id: int, value: int) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                "UPDATE attendance_config SET no_show_penalty = ? WHERE server_id = ?",
+                (value, server_id),
+            )
+            await db.commit()
+
+    async def update_autosack_threshold(self, server_id: int, value: int | None) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                "UPDATE attendance_config SET autosack_threshold = ? WHERE server_id = ?",
+                (value, server_id),
+            )
+            await db.commit()
+
+    async def update_autoreserve_threshold(self, server_id: int, value: int | None) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                "UPDATE attendance_config SET autoreserve_threshold = ? WHERE server_id = ?",
+                (value, server_id),
+            )
+            await db.commit()

--- a/src/services/module_service.py
+++ b/src/services/module_service.py
@@ -69,3 +69,22 @@ class ModuleService:
                 (server_id, int(value)),
             )
             await db.commit()
+
+    async def is_attendance_enabled(self, server_id: int) -> bool:
+        async with get_connection(self._db_path) as db:
+            cursor = await db.execute(
+                "SELECT module_enabled FROM attendance_config WHERE server_id = ?",
+                (server_id,),
+            )
+            row = await cursor.fetchone()
+        if row is None:
+            return False
+        return bool(row[0])
+
+    async def set_attendance_enabled(self, server_id: int, value: bool) -> None:
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                "UPDATE attendance_config SET module_enabled = ? WHERE server_id = ?",
+                (int(value), server_id),
+            )
+            await db.commit()

--- a/tests/unit/test_attendance_service.py
+++ b/tests/unit/test_attendance_service.py
@@ -1,0 +1,415 @@
+"""Unit tests for AttendanceService — T006, T012, T018, T024."""
+from __future__ import annotations
+
+import sys
+import os
+
+import aiosqlite
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+
+# ---------------------------------------------------------------------------
+# Fixtures
+# ---------------------------------------------------------------------------
+
+
+@pytest.fixture
+async def db_path(tmp_path):
+    """Temp SQLite DB with the minimal schema needed by AttendanceService."""
+    path = str(tmp_path / "test.db")
+    async with aiosqlite.connect(path) as db:
+        db.row_factory = aiosqlite.Row
+        await db.execute(
+            """
+            CREATE TABLE server_configs (
+                server_id INTEGER PRIMARY KEY
+            )
+            """
+        )
+        await db.execute(
+            "INSERT INTO server_configs (server_id) VALUES (1)"
+        )
+        await db.execute(
+            """
+            CREATE TABLE divisions (
+                id        INTEGER PRIMARY KEY,
+                server_id INTEGER NOT NULL
+            )
+            """
+        )
+        await db.execute("INSERT INTO divisions (id, server_id) VALUES (10, 1)")
+        await db.execute("INSERT INTO divisions (id, server_id) VALUES (11, 1)")
+        await db.execute(
+            """
+            CREATE TABLE attendance_config (
+                server_id                INTEGER PRIMARY KEY
+                                             REFERENCES server_configs(server_id)
+                                             ON DELETE CASCADE,
+                module_enabled           INTEGER NOT NULL DEFAULT 0,
+                rsvp_notice_days         INTEGER NOT NULL DEFAULT 5,
+                rsvp_last_notice_hours   INTEGER NOT NULL DEFAULT 24,
+                rsvp_deadline_hours      INTEGER NOT NULL DEFAULT 2,
+                no_rsvp_penalty          INTEGER NOT NULL DEFAULT 1,
+                no_attend_penalty        INTEGER NOT NULL DEFAULT 1,
+                no_show_penalty          INTEGER NOT NULL DEFAULT 1,
+                autoreserve_threshold    INTEGER,
+                autosack_threshold       INTEGER
+            )
+            """
+        )
+        await db.execute(
+            """
+            CREATE TABLE attendance_division_config (
+                division_id               INTEGER PRIMARY KEY
+                                              REFERENCES divisions(id)
+                                              ON DELETE CASCADE,
+                server_id                 INTEGER NOT NULL,
+                rsvp_channel_id           TEXT,
+                attendance_channel_id     TEXT
+            )
+            """
+        )
+        await db.commit()
+    return path
+
+
+# ---------------------------------------------------------------------------
+# T006 — Lifecycle tests (enable/disable)
+# ---------------------------------------------------------------------------
+
+
+class TestIsAttendanceEnabledFalseByDefault:
+    async def test_returns_false_when_no_row(self, db_path):
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        result = await svc.get_config(1)
+        assert result is None
+
+    async def test_module_enabled_false_after_get_or_create(self, db_path):
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        cfg = await svc.get_or_create_config(1)
+        assert cfg.module_enabled is False
+
+
+class TestEnableCreatesConfigWithDefaults:
+    async def test_enable_creates_config_with_defaults(self, db_path):
+        """Simulate the INSERT performed by _enable_attendance."""
+        import aiosqlite as _aio
+        async with _aio.connect(db_path) as db:
+            db.row_factory = _aio.Row
+            await db.execute(
+                "INSERT OR REPLACE INTO attendance_config "
+                "(server_id, module_enabled, rsvp_notice_days, rsvp_last_notice_hours, "
+                "rsvp_deadline_hours, no_rsvp_penalty, no_attend_penalty, no_show_penalty, "
+                "autoreserve_threshold, autosack_threshold) "
+                "VALUES (?, 1, 5, 24, 2, 1, 1, 1, NULL, NULL)",
+                (1,),
+            )
+            await db.commit()
+
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        cfg = await svc.get_config(1)
+        assert cfg is not None
+        assert cfg.module_enabled is True
+        assert cfg.rsvp_notice_days == 5
+        assert cfg.rsvp_last_notice_hours == 24
+        assert cfg.rsvp_deadline_hours == 2
+        assert cfg.no_rsvp_penalty == 1
+        assert cfg.no_attend_penalty == 1
+        assert cfg.no_show_penalty == 1
+        assert cfg.autoreserve_threshold is None
+        assert cfg.autosack_threshold is None
+
+
+class TestEnableSetsFlag:
+    async def test_enable_sets_flag_true(self, db_path):
+        import aiosqlite as _aio
+        async with _aio.connect(db_path) as db:
+            db.row_factory = _aio.Row
+            await db.execute(
+                "INSERT OR REPLACE INTO attendance_config (server_id, module_enabled) VALUES (?, 1)",
+                (1,),
+            )
+            await db.commit()
+
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        cfg = await svc.get_config(1)
+        assert cfg is not None
+        assert cfg.module_enabled is True
+
+
+class TestDisableSetsFlag:
+    async def test_disable_sets_flag_false(self, db_path):
+        import aiosqlite as _aio
+        async with _aio.connect(db_path) as db:
+            db.row_factory = _aio.Row
+            await db.execute(
+                "INSERT OR REPLACE INTO attendance_config (server_id, module_enabled) VALUES (?, 1)",
+                (1,),
+            )
+            await db.commit()
+
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        # Simulate disable: UPDATE module_enabled = 0
+        async with _aio.connect(db_path) as db:
+            await db.execute(
+                "UPDATE attendance_config SET module_enabled = 0 WHERE server_id = ?", (1,)
+            )
+            await db.commit()
+
+        cfg = await svc.get_config(1)
+        assert cfg is not None
+        assert cfg.module_enabled is False
+
+
+class TestDisableDeletesDivisionConfigs:
+    async def test_disable_deletes_division_configs(self, db_path):
+        import aiosqlite as _aio
+        async with _aio.connect(db_path) as db:
+            db.row_factory = _aio.Row
+            await db.execute(
+                "INSERT OR REPLACE INTO attendance_config (server_id, module_enabled) VALUES (?, 1)",
+                (1,),
+            )
+            await db.execute(
+                "INSERT INTO attendance_division_config (division_id, server_id) VALUES (10, 1)"
+            )
+            await db.commit()
+
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        await svc.delete_division_configs(1)
+
+        div_cfg = await svc.get_division_config(10)
+        assert div_cfg is None
+
+
+class TestReenableResetsToDefaults:
+    async def test_reenable_resets_to_defaults(self, db_path):
+        """INSERT OR REPLACE overwrites any stale field values with defaults."""
+        import aiosqlite as _aio
+        async with _aio.connect(db_path) as db:
+            db.row_factory = _aio.Row
+            # First enable with custom values
+            await db.execute(
+                "INSERT OR REPLACE INTO attendance_config "
+                "(server_id, module_enabled, rsvp_notice_days) VALUES (?, 1, 10)",
+                (1,),
+            )
+            await db.commit()
+
+        # Re-enable (INSERT OR REPLACE restores defaults)
+        async with _aio.connect(db_path) as db:
+            db.row_factory = _aio.Row
+            await db.execute(
+                "INSERT OR REPLACE INTO attendance_config "
+                "(server_id, module_enabled, rsvp_notice_days, rsvp_last_notice_hours, "
+                "rsvp_deadline_hours, no_rsvp_penalty, no_attend_penalty, no_show_penalty, "
+                "autoreserve_threshold, autosack_threshold) "
+                "VALUES (?, 1, 5, 24, 2, 1, 1, 1, NULL, NULL)",
+                (1,),
+            )
+            await db.commit()
+
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        cfg = await svc.get_config(1)
+        assert cfg is not None
+        assert cfg.rsvp_notice_days == 5
+
+
+class TestEnableRollbackOnDbFailure:
+    async def test_enable_rollback_on_db_failure(self, db_path):
+        """Simulate a DB error mid-transaction; confirms no partial row is left."""
+        import aiosqlite as _aio
+
+        # Simulate a failed transaction: begin but don't commit
+        async with _aio.connect(db_path) as db:
+            db.row_factory = _aio.Row
+            await db.execute(
+                "INSERT OR REPLACE INTO attendance_config "
+                "(server_id, module_enabled, rsvp_notice_days, rsvp_last_notice_hours, "
+                "rsvp_deadline_hours, no_rsvp_penalty, no_attend_penalty, no_show_penalty, "
+                "autoreserve_threshold, autosack_threshold) "
+                "VALUES (?, 1, 5, 24, 2, 1, 1, 1, NULL, NULL)",
+                (1,),
+            )
+            # Intentionally NOT calling db.commit() — simulates rollback
+            await db.rollback()
+
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        cfg = await svc.get_config(1)
+        # No partial row should remain
+        assert cfg is None
+
+
+# ---------------------------------------------------------------------------
+# T012 — Division config tests
+# ---------------------------------------------------------------------------
+
+
+class TestGetDivisionConfigNoneBeforeCreate:
+    async def test_get_config_none_before_create(self, db_path):
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        result = await svc.get_division_config(10)
+        assert result is None
+
+
+class TestSetRsvpChannel:
+    async def test_set_rsvp_channel(self, db_path):
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        await svc.set_rsvp_channel(10, 1, 999)
+        cfg = await svc.get_division_config(10)
+        assert cfg is not None
+        assert cfg.rsvp_channel_id == "999"
+        assert cfg.attendance_channel_id is None
+
+
+class TestSetAttendanceChannel:
+    async def test_set_attendance_channel(self, db_path):
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        await svc.set_attendance_channel(10, 1, 888)
+        cfg = await svc.get_division_config(10)
+        assert cfg is not None
+        assert cfg.attendance_channel_id == "888"
+        assert cfg.rsvp_channel_id is None
+
+
+class TestSetChannelPreservesOtherChannel:
+    async def test_set_channel_preserves_other_channel(self, db_path):
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        await svc.set_rsvp_channel(10, 1, 111)
+        await svc.set_attendance_channel(10, 1, 222)
+        cfg = await svc.get_division_config(10)
+        assert cfg is not None
+        assert cfg.rsvp_channel_id == "111"
+        assert cfg.attendance_channel_id == "222"
+
+
+# ---------------------------------------------------------------------------
+# T018 — Timing invariant tests
+# ---------------------------------------------------------------------------
+
+
+class TestTimingInvariantValid:
+    async def test_timing_invariant_valid(self):
+        from services.attendance_service import validate_timing_invariant
+        # notice_days=5, 5*24=120 > last_notice=24 > deadline=2 → valid
+        result = validate_timing_invariant(5, 24, 2)
+        assert result is None
+
+
+class TestTimingInvariantNoticeTooSmall:
+    async def test_timing_invariant_notice_too_small(self):
+        from services.attendance_service import validate_timing_invariant
+        # 1*24=24, last_notice_hours=24 → 24 <= 24 → violation
+        result = validate_timing_invariant(1, 24, 2)
+        assert result is not None
+        assert "rsvp_notice_days" in result
+
+
+class TestTimingInvariantDeadlineExceedsLast:
+    async def test_timing_invariant_deadline_exceeds_last(self):
+        from services.attendance_service import validate_timing_invariant
+        # notice_days=5, 120>6, but last=6 <= deadline=6 → violation
+        result = validate_timing_invariant(5, 6, 6)
+        assert result is not None
+        assert "rsvp_last_notice_hours" in result
+
+
+class TestTimingInvariantLastZeroSentinelValid:
+    async def test_timing_invariant_last_zero_sentinel_valid(self):
+        from services.attendance_service import validate_timing_invariant
+        # last_notice_hours=0 is sentinel (no last-notice ping); deadline check skipped
+        result = validate_timing_invariant(5, 0, 2)
+        assert result is None
+
+
+class TestTimingInvariantLastEqualsDeadlineRejected:
+    async def test_timing_invariant_last_equals_deadline_rejected(self):
+        from services.attendance_service import validate_timing_invariant
+        # notice_days=5 (120h), last=4, deadline=4 → last <= deadline → rejected
+        result = validate_timing_invariant(5, 4, 4)
+        assert result is not None
+        assert "rsvp_last_notice_hours" in result
+
+
+# ---------------------------------------------------------------------------
+# T024 — Penalty / threshold config tests
+# ---------------------------------------------------------------------------
+
+
+class TestConfigPenaltyFieldsUpdate:
+    async def test_config_penalty_fields_update(self, db_path):
+        import aiosqlite as _aio
+        async with _aio.connect(db_path) as db:
+            db.row_factory = _aio.Row
+            await db.execute(
+                "INSERT OR REPLACE INTO attendance_config "
+                "(server_id, module_enabled, rsvp_notice_days, rsvp_last_notice_hours, "
+                "rsvp_deadline_hours, no_rsvp_penalty, no_attend_penalty, no_show_penalty, "
+                "autoreserve_threshold, autosack_threshold) "
+                "VALUES (?, 1, 5, 24, 2, 1, 1, 1, NULL, NULL)",
+                (1,),
+            )
+            await db.commit()
+
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        await svc.update_no_rsvp_penalty(1, 3)
+        await svc.update_no_attend_penalty(1, 2)
+        await svc.update_no_show_penalty(1, 4)
+        cfg = await svc.get_config(1)
+        assert cfg is not None
+        assert cfg.no_rsvp_penalty == 3
+        assert cfg.no_attend_penalty == 2
+        assert cfg.no_show_penalty == 4
+
+
+class TestAutosackZeroStoresNull:
+    async def test_autosack_zero_stores_null(self, db_path):
+        import aiosqlite as _aio
+        async with _aio.connect(db_path) as db:
+            db.row_factory = _aio.Row
+            await db.execute(
+                "INSERT OR REPLACE INTO attendance_config (server_id, module_enabled) VALUES (?, 1)",
+                (1,),
+            )
+            await db.commit()
+
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        await svc.update_autosack_threshold(1, None)
+        cfg = await svc.get_config(1)
+        assert cfg is not None
+        assert cfg.autosack_threshold is None
+
+
+class TestAutoreserveZeroStoresNull:
+    async def test_autoreserve_zero_stores_null(self, db_path):
+        import aiosqlite as _aio
+        async with _aio.connect(db_path) as db:
+            db.row_factory = _aio.Row
+            await db.execute(
+                "INSERT OR REPLACE INTO attendance_config (server_id, module_enabled) VALUES (?, 1)",
+                (1,),
+            )
+            await db.commit()
+
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        await svc.update_autoreserve_threshold(1, None)
+        cfg = await svc.get_config(1)
+        assert cfg is not None
+        assert cfg.autoreserve_threshold is None


### PR DESCRIPTION
# Attendance module
- <COMMAND CHANGE> The attendance module may be enabled via a "module enable" command akin to other modules. May only be used by server admins.
- <COMMAND CHANGE> The attendance module may be disabled via a "module disable" command akin to other modules. May only be used by server admins.
- The attendance module is disabled by default.
- The attendance module may not be enabled once the season is approved.
- Due to being dependent on the results module, the attendance module cannot be enabled while the results & standings module is disabled.
- If the results & standings module is disabled, then the attendance module shall be disabled as well.
- Attendance module activation status shall be displayed in the season review.
- This module must work with the fake driver rosters used in test mode.

## Concepts
- RSVP or check-in: Confirmation of round attendance to all members of a division in a configured channel to mark their presence or absence.
- Attendance points: Points gained upon failing to RSVP or showing up for a round.

## Configuring the attendance module
### Channels
- <NEW COMMAND> A "division rsvp-channel" command will be made available to league managers, which shall have as input a division name and a channel on which RSVP polls shall be posted by the bot.
    - If a RSVP channel is not configured for a division in the season review, then the season will fail validation.
    - Each division's RSVP channel will be displayed in the season review much alike other division channels like results, standings, weather, etc.
- <NEW COMMAND> A "division attendance-channel" command will be made available to league managers, which shall have as input a division name and a channel on which attendance for each one of the rounds will be posted by the bot.
    - If an attendance channel is not configured for a division in the season review, then the season will fail validation.
    - Each division's attendance channel will be displayed in the season review much alike other division channels like results, standings, weather, etc.

### RSVP notices
- <NEW COMMAND> An "attendance config rsvp-notice" command will be made available to league managers, which shall have as input an integer standing for a number of days. This command configures the number of days before a round at which point RSVP notices will be sent out too all drivers of a division to mark their attendance for that round.
    - By default, this value will be set to 5.
- <NEW COMMAND> An "attendance config rsvp-last-notice" command will be made available to league managers, which shall have as input an integer standing for a number of hours. This command configures the number of hours before a round at which point the bot will notify users who have not RSVP'd until then. A value of 0 means that no "last notice" announcement will be sent out to users who have no RSVP'd.
    - By default, this value will be set to 24.
- <NEW COMMAND> An "attendance config rsvp-deadline" command will be made available to league managers, which shall have as input an integer standing for a number of hours. This command configures the number of hours before a round at which point users can no longer alter their RSVP status. A value of 0 means that the deadline lasts up until the scheduled time of the round, which no alterations permitted beyond that point.
    - By default, this value will be set to 2.
- The input from all commands shall be validated against the current settings so that the RSVP Deadline always happens after the RSVP Notice and the RSVP Last Notice, and the RSVP Last Notice always happens after RSVP Notice. Ergo, the configuration shall follow the rule Notice\*24 > LastNotice\*24 > Deadline.
- If there is an ongoing season (read: season approved/active), all three commands must be rejected.

### Attendance points
- <NEW COMMAND> An "attendance config no-rsvp-penalty" command will be made available to league managers, which shall have as input an integer standing for the number of attendance points gained upon failing to RSVP up for a round.
    - By default, this value will be 1.
- <NEW COMMAND> An "attendance config no-attend-penalty" command will be made available to league managers, which shall have as input an integer standing for the number of attendance points gained upon failing to show up for a round (regardless of check-in status).
    - By default, this value will be 1.
- <NEW COMMAND> An "attendance config no-show-penalty" command will be made available to league managers, which shall have as input an integer standing for the number of attendance points gained upon failing to show up for a round after having accepted the check-in.
    - By default, this value will be 1.
- <NEW COMMAND> An "attendance config autosack" command will be made available to league managers, which shall have as input an integer standing for the number of attendance points upon which a driver will be automatically sacked from all team seats. A value of 0 means that the autosack functionality is disabled.
    - By default, this value will be false (disabled).
- <NEW COMMAND> An "attendance config autoreserve" command will be made available to league managers, which shall have as input an integer standing for the number of attendance points upon which a driver will be unassigned from their current seat and assigned to the reserve team of the same division. A value of 0 means that the autoreserve functionality is disabled.
    - By default, this value will be false (disabled).
    - The autoreserve functionality is only applied to drivers not in the reserve team.