### PR TITLE
032 attendance rsvp checkin

### DIFF
--- a/.specify/memory/constitution.md
+++ b/.specify/memory/constitution.md
@@ -1,6 +1,45 @@
 <!--
 SYNC IMPACT REPORT
 ==================
+[2026-04-03 — Session reuse: Attendance module RSVP & check-in implementation — feature branch created]
+  - Constitution reused as-is; no principle amendments required at session start.
+  - Session intent: implement the RSVP check-in embed and button interactions;
+    reserve distribution at the RSVP deadline; last-notice ping scheduling and sending;
+    attendance recording from submitted round results (first SessionResult row hook);
+    attendance point distribution (post-penalty finalization hook); attendance pardon
+    workflow inside the penalty wizard; attendance sheet posting to the attendance channel;
+    and automatic sanction enforcement (autoreserve and autosack).
+    DriverRoundAttendance and AttendancePardon data entities to be introduced as part of
+    this increment.
+  - Feature branch: 032-attendance-rsvp-checkin (created 2026-04-03 from main).
+  - Implementation status at session start:
+      ✅ 031-attendance-module — fully merged to main (2026-04-03, PR #50); all tasks [x]
+         complete. Covers: Attendance module enable/disable lifecycle (Results & Standings
+         dependency gate, ACTIVE-season gate, cascading auto-disable on R&S disable);
+         /division rsvp-channel and /division attendance-channel commands; season approval
+         Gate 4 (both RSVP and attendance channels required per division); /attendance
+         config timing commands (rsvp-notice, rsvp-last-notice, rsvp-deadline) with
+         invariant enforcement; /attendance config penalty commands (no-rsvp-penalty,
+         no-attend-penalty, no-show-penalty, autosack, autoreserve); season review
+         attendance status and per-division channel display; full unit test suite (20
+         tests passing).
+  - All placeholder tokens remain resolved; constitution is fully resolved at v2.10.0.
+  - No version bump required; Last Amended date remains 2026-04-03 (no content amendments).
+  - All templates confirmed aligned with Principles I–XIII:
+      ✅ .specify/templates/plan-template.md       — dynamic Constitution Check; no changes.
+      ✅ .specify/templates/spec-template.md       — generic structure; no stale references.
+      ✅ .specify/templates/tasks-template.md      — generic; aligns with I–XIII.
+      ✅ .specify/templates/agent-file-template.md — generic placeholders; no stale names.
+      ✅ .specify/templates/checklist-template.md  — no impact.
+  - Deferred TODOs (carried from v2.10.0):
+      - Exact command naming for appeal submission and review commands to be confirmed
+        against the 026-penalty-posting-appeals implementation.
+      - Whether the existing penalty wizard loose-text fields on DriverSessionResult
+        (post_race_time_penalties, post_stewarding_total_time) have been superseded by
+        PenaltyRecord rows — migration confirmation required.
+  - Pending: speckit.specify to define exact scope and task ordering for this sub-increment;
+    constitution will be re-evaluated if any new governance requirements are identified.
+
 [2026-04-03 — v2.9.0 → v2.10.0: Attendance module ratified — Principle XIII added]
   Version change    : 2.9.0 → 2.10.0
   Bump rationale    : MINOR — The Attendance module is formally ratified as a new optional

--- a/specs/032-attendance-rsvp-checkin/checklists/requirements.md
+++ b/specs/032-attendance-rsvp-checkin/checklists/requirements.md
@@ -1,0 +1,43 @@
+# Specification Quality Checklist: Attendance Module RSVP Check-in & Reserve Distribution
+
+**Purpose**: Validate specification completeness and quality before proceeding to planning  
+**Created**: 2026-04-03  
+**Feature**: [spec.md](../spec.md)
+
+## Content Quality
+
+- [x] No implementation details (languages, frameworks, APIs)
+- [x] Focused on user value and business needs
+- [x] Written for non-technical stakeholders
+- [x] All mandatory sections completed
+
+## Requirement Completeness
+
+- [x] No [NEEDS CLARIFICATION] markers remain
+- [x] Requirements are testable and unambiguous
+- [x] Success criteria are measurable
+- [x] Success criteria are technology-agnostic (no implementation details)
+- [x] All acceptance scenarios are defined
+- [x] Edge cases are identified
+- [x] Scope is clearly bounded
+- [x] Dependencies and assumptions identified
+
+## Feature Readiness
+
+- [x] All functional requirements have clear acceptance criteria
+- [x] User scenarios cover primary flows
+- [x] Feature meets measurable outcomes defined in Success Criteria
+- [x] No implementation details leak into specification
+
+## Notes
+
+- Assumption 4 references persisting the Discord message ID — this is a necessary
+  implementation detail that cannot be described in purely user-facing terms without
+  losing precision. It has been kept in the Assumptions section (not in FRs) as a
+  design constraint rather than a specification requirement.
+- SC-001/SC-004 time windows (1 minute, 30 seconds) are scheduling latency expectations
+  consistent with APScheduler behaviour under normal load at the project's target server
+  size. Not framework-specific.
+- Last-notice ping (US5, FR-028–FR-030) added to scope per user request 2026-04-03.
+  Out of Scope section defers attendance recording, point distribution, pardons, sheet
+  posting, and sanction enforcement to future increments.

--- a/specs/032-attendance-rsvp-checkin/data-model.md
+++ b/specs/032-attendance-rsvp-checkin/data-model.md
@@ -1,0 +1,173 @@
+# Data Model: Attendance RSVP Check-in & Reserve Distribution
+
+**Feature Branch**: `032-attendance-rsvp-checkin`  
+**Date**: 2026-04-03
+
+## New Entities
+
+### DriverRoundAttendance
+
+Stores per-driver RSVP state for each round in each division. One row per
+(round, division, driver). Created in bulk when the RSVP embed is posted (FR-009).
+
+| Column | Type | Constraints | Notes |
+|--------|------|-------------|-------|
+| `id` | INTEGER | PK AUTOINCREMENT | |
+| `round_id` | INTEGER | NOT NULL, FK → rounds(id) ON DELETE CASCADE | |
+| `division_id` | INTEGER | NOT NULL, FK → divisions(id) | |
+| `driver_profile_id` | INTEGER | NOT NULL, FK → driver_profiles(id) | |
+| `rsvp_status` | TEXT | NOT NULL DEFAULT 'NO_RSVP' | NO_RSVP / ACCEPTED / TENTATIVE / DECLINED |
+| `accepted_at` | TEXT | NULL | ISO 8601 UTC; set on first Accept; reset on re-Accept after non-Accept |
+| `assigned_team_id` | INTEGER | NULL | FK → team_instances(id); set by distribution |
+| `is_standby` | INTEGER | NOT NULL DEFAULT 0 | 1 = classified as standby at deadline |
+| `attended` | INTEGER | NULL | 0/1; populated in future increment when results submitted |
+| UNIQUE | | (round_id, division_id, driver_profile_id) | one row per driver per round |
+
+**Index**: `(round_id, division_id)` — primary query pattern for embed building and distribution.
+
+---
+
+### rsvp_embed_messages
+
+Stores the Discord message ID of the posted RSVP embed per (round, division).
+Used to edit the embed in-place on button interactions and to re-register persistent views on restart.
+
+| Column | Type | Constraints | Notes |
+|--------|------|-------------|-------|
+| `id` | INTEGER | PK AUTOINCREMENT | |
+| `round_id` | INTEGER | NOT NULL, FK → rounds(id) ON DELETE CASCADE | |
+| `division_id` | INTEGER | NOT NULL, FK → divisions(id) | |
+| `message_id` | TEXT | NOT NULL | Discord message snowflake ID |
+| `channel_id` | TEXT | NOT NULL | Discord channel snowflake ID; stored for fetch without querying attendance config |
+| `posted_at` | TEXT | NOT NULL | ISO 8601 UTC |
+| UNIQUE | | (round_id, division_id) | one embed per round per division |
+
+**Pattern**: Mirrors `forecast_messages` (used for weather phase outputs). Allows
+re-registration of `RsvpView` on bot restart by iterating rows for rounds whose
+`scheduled_at` is in the future (or whose deadline has not yet passed).
+
+---
+
+## Amended Entities
+
+### AttendanceConfig (existing — no schema change)
+
+All fields needed for this increment already exist: `rsvp_notice_days`,
+`rsvp_last_notice_hours`, `rsvp_deadline_hours`. No migration required.
+
+### AttendanceDivisionConfig (existing — no schema change)
+
+`rsvp_channel_id` and `attendance_channel_id` already present. No migration required.
+
+---
+
+## New DB Migration
+
+**File**: `src/db/migrations/031_attendance_rsvp.sql`
+
+```sql
+-- Migration 031: Attendance RSVP check-in tables
+-- Creates driver_round_attendance and rsvp_embed_messages tables.
+
+CREATE TABLE IF NOT EXISTS driver_round_attendance (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    round_id           INTEGER NOT NULL
+                           REFERENCES rounds(id)
+                           ON DELETE CASCADE,
+    division_id        INTEGER NOT NULL
+                           REFERENCES divisions(id),
+    driver_profile_id  INTEGER NOT NULL
+                           REFERENCES driver_profiles(id),
+    rsvp_status        TEXT    NOT NULL DEFAULT 'NO_RSVP',
+    accepted_at        TEXT,
+    assigned_team_id   INTEGER REFERENCES team_instances(id),
+    is_standby         INTEGER NOT NULL DEFAULT 0,
+    attended           INTEGER,
+    UNIQUE (round_id, division_id, driver_profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dra_round_division
+    ON driver_round_attendance (round_id, division_id);
+
+CREATE TABLE IF NOT EXISTS rsvp_embed_messages (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    round_id    INTEGER NOT NULL
+                    REFERENCES rounds(id)
+                    ON DELETE CASCADE,
+    division_id INTEGER NOT NULL
+                    REFERENCES divisions(id),
+    message_id  TEXT    NOT NULL,
+    channel_id  TEXT    NOT NULL,
+    posted_at   TEXT    NOT NULL,
+    UNIQUE (round_id, division_id)
+);
+```
+
+---
+
+## New Dataclasses
+
+### DriverRoundAttendance (src/models/attendance.py — extend existing file)
+
+```python
+@dataclass
+class DriverRoundAttendance:
+    id: int
+    round_id: int
+    division_id: int
+    driver_profile_id: int
+    rsvp_status: str        # NO_RSVP | ACCEPTED | TENTATIVE | DECLINED
+    accepted_at: str | None
+    assigned_team_id: int | None
+    is_standby: bool
+    attended: bool | None   # None until results submitted (future increment)
+```
+
+### RsvpEmbedMessage (src/models/attendance.py — extend existing file)
+
+```python
+@dataclass
+class RsvpEmbedMessage:
+    id: int
+    round_id: int
+    division_id: int
+    message_id: str
+    channel_id: str
+    posted_at: str
+```
+
+---
+
+## Entity Relationships
+
+```
+rounds (1) ──< driver_round_attendance >── (1) driver_profiles
+rounds (1) ──< rsvp_embed_messages >── divisions (1)
+rounds (1) ──> divisions (1) ──> seasons
+driver_round_attendance.assigned_team_id ──> team_instances
+team_instances.is_reserve ──> 0 (full-time) | 1 (Reserve team)
+driver_season_assignments ──> team_seats ──> team_instances (determines is_reserve)
+team_standings_snapshots (most recent round_id for division) ──> standing_position
+```
+
+---
+
+## Data Flow Summary
+
+1. **Season approval** → scheduling jobs created for `rsvp_notice_r{round_id}`,
+   `rsvp_last_notice_r{round_id}` (if `rsvp_last_notice_hours > 0`),
+   `rsvp_deadline_r{round_id}`.
+2. **Notice job fires** → query all full-time + reserve drivers in division via
+   `driver_season_assignments → team_seats → team_instances` join. Insert
+   `driver_round_attendance` rows (status = NO_RSVP). Build embed. Post to RSVP
+   channel. Store `message_id` + `channel_id` in `rsvp_embed_messages`.
+3. **Driver presses button** → validate driver membership + locking rules. Update
+   `rsvp_status` (and `accepted_at` if newly ACCEPTED). Rebuild embed string.
+   Fetch message via `rsvp_embed_messages` channel_id + message_id. Edit message.
+4. **Last-notice job fires** → query `driver_round_attendance` WHERE `rsvp_status =
+   'NO_RSVP'` AND driver is full-time (joined via `driver_season_assignments`). Post
+   mention string to RSVP channel. No DB writes.
+5. **Deadline job fires** → lock embed (disable buttons by editing the message with
+   a new View(disabled=True) or removing buttons). Run distribution algorithm. Write
+   `assigned_team_id` and `is_standby` to `driver_round_attendance`. Post assignment
+   message to RSVP channel.

--- a/specs/032-attendance-rsvp-checkin/plan.md
+++ b/specs/032-attendance-rsvp-checkin/plan.md
@@ -1,0 +1,89 @@
+# Implementation Plan: Attendance RSVP Check-in & Reserve Distribution
+
+**Branch**: `032-attendance-rsvp-checkin` | **Date**: 2026-04-03 | **Spec**: [spec.md](spec.md)  
+**Input**: Feature specification from `specs/032-attendance-rsvp-checkin/spec.md`
+
+## Summary
+
+Automates the RSVP lifecycle for scheduled rounds: the bot posts a per-division embed in the
+configured RSVP channel at the `rsvp_notice_days` notice window, drivers respond via persistent
+Discord buttons (Accept / Tentative / Decline), the embed roster is updated in-place, a
+last-notice ping is sent to non-responding full-time drivers at `rsvp_last_notice_hours`, and at
+`rsvp_deadline_hours` reserve distribution is computed and an assignment announcement is posted.
+
+**Technical approach**: Three APScheduler `DateTrigger` jobs per non-Mystery round (notice,
+last-notice, deadline), module-level async callables (picklable for SQLAlchemyJobStore),
+a `discord.ui.View(timeout=None)` with deterministic `custom_id`s re-armed on restart from
+`rsvp_embed_messages`, and two new SQLite tables (`driver_round_attendance`,
+`rsvp_embed_messages`). All patterns extend existing scheduler, service, and cog conventions.
+
+## Technical Context
+
+**Language/Version**: Python 3.13.2  
+**Primary Dependencies**: discord.py (slash commands, `discord.ui.View`), APScheduler
+(AsyncIOScheduler + SQLAlchemyJobStore + DateTrigger), aiosqlite  
+**Storage**: SQLite — new migration `src/db/migrations/031_attendance_rsvp.sql`  
+**Testing**: pytest — `python -m pytest tests/ -v` from repo root  
+**Target Platform**: Raspberry Pi (Linux)  
+**Project Type**: Discord bot (service)  
+**Performance Goals**: Sub-second embed update on button press; distribution computation at most
+O(reserves × teams) — tens of drivers, not thousands  
+**Constraints**: APScheduler jobs must be picklable (module-level callables only); persistent
+views must be re-armed by message_id on bot restart  
+**Scale/Scope**: Single Discord server; ≤5 divisions; ≤30 drivers per division
+
+## Constitution Check
+
+*GATE: Must pass before Phase 0 research. Re-check after Phase 1 design.*
+
+| Principle | Check | Status |
+|-----------|-------|--------|
+| **XIII** — Attendance & Check-in Integrity: RSVP embed, locking rules, reserve distribution, last-notice ping, DriverRoundAttendance entity | All FR-001–FR-030 align directly with Principle XIII rules. No rule is relaxed or omitted. | ✅ PASS |
+| **X** — Modular Feature Architecture (rule 3): Attendance module gate enforced at every scheduling and posting site; guarded by `is_attendance_enabled()` check in `_do_approve` before scheduling jobs; no jobs scheduled if module disabled | Job scheduling is conditional; RSVP jobs extend `cancel_round` so they are removed when a round is cancelled regardless of module state | ✅ PASS |
+| **X** — Modular Feature Architecture (enable atomicity): No new enable/disable commands this increment; prior 031 implementation handles all lifecycle transitions | Out of scope for this increment | ✅ PASS |
+| **VII** — Output Channel Discipline: RSVP channel is a module-introduced channel (registered in `attendance_division_config.rsvp_channel_id`); embed and announcement posted only to that channel | All output targets are module-registered channels; no unregistered channel posting | ✅ PASS |
+| **V** — Audit trail: Skip events (no RSVP channel configured, Mystery round bypass) MUST produce audit log entries via `output_router.post_log` | Covered by FR-008; `_rsvp_notice_job` logs skip reason | ✅ PASS |
+| **XII** — Results & Standings dependency: `attended` field on `DriverRoundAttendance` populated only when results are submitted; not populated this increment | `attended` column defined NULL by default; populated in a future increment | ✅ PASS |
+
+**Post-Phase-1 re-check**: No violations introduced by data-model or contract design.
+
+## Project Structure
+
+### Documentation (this feature)
+
+```text
+specs/032-attendance-rsvp-checkin/
+├── plan.md              ← this file
+├── research.md          ← Phase 0 output
+├── data-model.md        ← Phase 1 output
+├── quickstart.md        ← Phase 1 output
+└── tasks.md             ← Phase 2 output (speckit.tasks — not yet created)
+```
+
+### Source Code (repository root)
+
+```text
+src/
+├── db/
+│   └── migrations/
+│       └── 031_attendance_rsvp.sql          NEW — driver_round_attendance, rsvp_embed_messages
+├── models/
+│   └── attendance.py                        AMEND — add DriverRoundAttendance, RsvpEmbedMessage
+├── services/
+│   ├── attendance_service.py                AMEND — add CRUD for new tables
+│   ├── rsvp_service.py                      NEW — notice dispatch, last-notice, deadline + distribution
+│   └── scheduler_service.py                 AMEND — 3 module-level callables + schedule_attendance_round
+├── cogs/
+│   ├── attendance_cog.py                    AMEND — RsvpView (persistent buttons)
+│   └── season_cog.py                        AMEND — _do_approve: schedule attendance jobs
+└── bot.py                                   AMEND — register callbacks, add_view, restart re-arm
+
+tests/
+└── unit/
+    ├── test_rsvp_service.py                 NEW — distribution algorithm + service methods
+    └── test_rsvp_embed_builder.py           NEW — embed content and roster formatting
+```
+
+**Structure Decision**: Single project, extending the existing `src/` layout. No new
+directories required. Two new service-side files (`rsvp_service.py`) to keep RSVP
+orchestration separate from the existing config-only `attendance_service.py`.

--- a/specs/032-attendance-rsvp-checkin/quickstart.md
+++ b/specs/032-attendance-rsvp-checkin/quickstart.md
@@ -1,0 +1,129 @@
+# Quickstart: Attendance RSVP Check-in & Reserve Distribution
+
+**Feature Branch**: `032-attendance-rsvp-checkin`  
+**Date**: 2026-04-03
+
+## Prerequisites
+
+- Attendance module enabled (`/module enable attendance`)
+- Season in `SETUP` state with at least one division
+- RSVP channel configured per division (`/division rsvp-channel`)
+- Attendance channel configured per division (`/division attendance-channel`)
+- Full-time drivers assigned to teams in the division
+- (Optional) Reserve drivers assigned to the Reserve team
+
+---
+
+## Triggering the RSVP Flow (Development / Test)
+
+### 1. Run the migration
+
+On bot startup the migration runner applies `031_attendance_rsvp.sql` automatically.
+Verify with:
+
+```sql
+SELECT name FROM sqlite_master WHERE type='table' AND name IN (
+    'driver_round_attendance', 'rsvp_embed_messages'
+);
+```
+
+### 2. Schedule and inspect jobs
+
+Approve a season. If attendance is enabled, three new scheduler jobs are created per
+non-Mystery round:
+
+```
+rsvp_notice_r{round_id}       — fires at round_start − rsvp_notice_days days
+rsvp_last_notice_r{round_id}  — fires at round_start − rsvp_last_notice_hours hours
+                                  (only if rsvp_last_notice_hours > 0)
+rsvp_deadline_r{round_id}     — fires at round_start − rsvp_deadline_hours hours
+```
+
+Confirm in the APScheduler SQLite jobstore:
+
+```python
+for job in bot.scheduler_service._scheduler.get_jobs():
+    if job.id.startswith("rsvp_"):
+        print(job.id, job.next_run_time)
+```
+
+### 3. Manually fire the notice job (development shortcut)
+
+```python
+from services.rsvp_service import run_rsvp_notice
+await run_rsvp_notice(round_id=<ID>, bot=bot)
+```
+
+This posts the RSVP embed to the configured channel, creates `driver_round_attendance`
+rows, and stores the message ID in `rsvp_embed_messages`.
+
+### 4. Verify embed content
+
+The embed in the RSVP channel should show:
+- Title: `Season N Round N — <track name>`
+- Fields: datetime timestamp, location, event type
+- Per-team roster with `()` status indicators
+- Three buttons: ✅ Accept (green), ❓ Tentative (grey), ❌ Decline (red)
+
+### 5. Test button interactions
+
+Have a registered driver press each button. Verify:
+- Embed updates the driver's status indicator in-place
+- `driver_round_attendance.rsvp_status` row updated in DB
+- Non-members receive an ephemeral error
+
+Verify locking by simulating past-deadline by temporarily setting `rsvp_deadline_hours`
+to a high value and checking server time vs round time.
+
+### 6. Manually fire the last-notice job
+
+```python
+from services.rsvp_service import run_rsvp_last_notice
+await run_rsvp_last_notice(round_id=<ID>, bot=bot)
+```
+
+The RSVP channel should receive a message mentioning only full-time drivers whose
+`rsvp_status` is `NO_RSVP`. Reserve drivers must not appear.
+
+### 7. Manually fire the deadline job
+
+```python
+from services.rsvp_service import run_rsvp_deadline
+await run_rsvp_deadline(round_id=<ID>, bot=bot)
+```
+
+Verify:
+- Embed buttons disabled (or message edited without buttons)
+- `driver_round_attendance` rows updated with `assigned_team_id` / `is_standby`
+- Distribution announcement posted in RSVP channel mentioning assigned and standby
+  reserves
+
+---
+
+## Running Tests
+
+```bash
+python -m pytest tests/ -v -k attendance
+```
+
+New test files for this increment:
+- `tests/unit/test_rsvp_service.py` — notice, last-notice, deadline, distribution logic
+- `tests/unit/test_rsvp_embed_builder.py` — embed content and roster formatting
+
+All 20 existing attendance service tests must continue to pass.
+
+---
+
+## Key Files
+
+| File | Purpose |
+|------|---------|
+| `src/db/migrations/031_attendance_rsvp.sql` | New tables: driver_round_attendance, rsvp_embed_messages |
+| `src/models/attendance.py` | Add DriverRoundAttendance, RsvpEmbedMessage dataclasses |
+| `src/services/rsvp_service.py` | NEW — notice dispatch, last-notice, deadline + distribution |
+| `src/services/scheduler_service.py` | Add 3 module-level job callables + schedule/cancel methods |
+| `src/cogs/attendance_cog.py` | Add RsvpView (persistent buttons) + extend with RSVP cog logic |
+| `src/cogs/season_cog.py` | Extend `_do_approve` to schedule attendance jobs; extend `cancel_round` |
+| `src/bot.py` | Register RsvpView, register 3 attendance callbacks, re-arm embed views on restart |
+| `tests/unit/test_rsvp_service.py` | Unit tests for distribution algorithm + service methods |
+| `tests/unit/test_rsvp_embed_builder.py` | Unit tests for embed content builder |

--- a/specs/032-attendance-rsvp-checkin/research.md
+++ b/specs/032-attendance-rsvp-checkin/research.md
@@ -155,14 +155,32 @@ by a future increment.
 
 ## 9. test_mode_service Integration
 
-**No changes required for this increment.**
+**Decision**: RSVP jobs (`rsvp_notice_r{id}`, `rsvp_last_notice_r{id}`,
+`rsvp_deadline_r{id}`) ARE included in the `/test-mode advance` queue. They are
+assigned phase numbers 5, 6, and 7 respectively and added to `_PHASE_PREFIX_MAP`
+in `get_pending_advance_jobs`. The `advance` dispatcher in `test_mode_cog.py` is
+extended to call the appropriate RSVP service function for each new phase number.
 
-**Rationale**: `get_pending_advance_jobs` in `test_mode_service.py` uses
-`_PHASE_PREFIX_MAP` to recognise advance-queue jobs. The `rsvp_*` jobs should NOT
-appear in the test-mode advance queue — they are attendance booking jobs, not
-race-phase progression events. Test mode for the RSVP timers will be handled in a
-separate future increment (or tested via unit/integration tests injecting mock times
-directly). This keeps the advance command's responsibility narrowly scoped.
+**Rationale**: The `/test-mode advance` command fires events in scheduled order
+(`next_run_time ASC, round_id ASC, phase_number ASC`). RSVP jobs are genuine
+scheduler events with real `next_run_time` values — excluding them would require a
+separate trigger mechanism and create an inconsistent testing experience.
+Including them keeps the advance command as the single entry point for all
+time-driven bot actions in test mode, which is the established convention.
+
+**Phase number mapping** (updated `_PHASE_PREFIX_MAP` in `scheduler_service.py`):
+
+| Prefix | Phase number | Dispatches to |
+|--------|-------------|---------------|
+| `mystery` | 0 | `run_mystery_notice` |
+| `phase1` | 1 | `run_phase1` |
+| `phase2` | 2 | `run_phase2` |
+| `phase3` | 3 | `run_phase3` |
+| `rsvp_notice` | 5 | `run_rsvp_notice` |
+| `rsvp_last_notice` | 6 | `run_rsvp_last_notice` |
+| `rsvp_deadline` | 7 | `run_rsvp_deadline` |
+
+(Phase 4 = result submission; detected via DB fallback, not `_PHASE_PREFIX_MAP`.)
 
 ---
 

--- a/specs/032-attendance-rsvp-checkin/research.md
+++ b/specs/032-attendance-rsvp-checkin/research.md
@@ -1,0 +1,183 @@
+# Research: Attendance RSVP Check-in & Reserve Distribution
+
+**Feature Branch**: `032-attendance-rsvp-checkin`  
+**Date**: 2026-04-03
+
+## 1. Persistent Discord UI Views (RSVP Buttons)
+
+**Decision**: Use `discord.ui.View` with `timeout=None` (persistent view) and
+deterministic `custom_id` strings per round+division. Register via `bot.add_view()`
+in `bot.py` on startup.
+
+**Rationale**: The RSVP embed persists between bot restarts. A persistent `View`
+(timeout=None + static `custom_id`) guarantees that button presses are dispatched
+to the handler even after a restart because discord.py reconnects to the existing
+message. This is already the established pattern in this codebase: `AdminReviewView`,
+`SignupButtonView`, `PenaltyReviewView` all use `timeout=None` and are registered via
+`bot.add_view()` in the `setup_hook`. The RSVP view requires round-scoped `custom_id`
+values (`rsvp_accept_r{round_id}`, `rsvp_tentative_r{round_id}`, `rsvp_decline_r{round_id}`)
+so each button maps unambiguously to its round.
+
+**Alternative considered**: Per-message `View` with dynamic timeout set to match the
+RSVP deadline. Rejected because the view would not survive a bot restart (it is not
+stored in the APScheduler jobstore or any DB table) and the deadline/locking logic
+should be evaluated at interaction time from DB state, not embedded in the view
+timeout.
+
+**Implementation pattern**: The `RsvpView` class lives in `attendance_cog.py`. On
+startup, `bot.py` loops over all active RSVP embed message IDs (from the new
+`rsvp_embed_messages` DB table) and calls `bot.add_view(RsvpView(), message_id=msg_id)`
+for each one — mirroring how `appeals_view` is re-registered in the existing
+`_recover_missed_phases` / startup block.
+
+---
+
+## 2. Job ID Conventions for Attendance Scheduler Jobs
+
+**Decision**: Three new APScheduler job ID prefixes:
+
+| Job | ID pattern | Trigger time |
+|-----|-----------|------|
+| RSVP notice embed post | `rsvp_notice_r{round_id}` | T − `rsvp_notice_days` days |
+| Last-notice ping | `rsvp_last_notice_r{round_id}` | T − `rsvp_last_notice_hours` hours |
+| RSVP deadline / distribution | `rsvp_deadline_r{round_id}` | T − `rsvp_deadline_hours` hours |
+
+**Rationale**: All existing job IDs follow the `{prefix}_r{round_id}` pattern
+(`phase1_r`, `mystery_r`, `results_r`, `cleanup_r`). Adopting the same convention
+keeps `cancel_round` and `get_pending_advance_jobs` extendable with minimal changes.
+Using the round_id (not division_id) is consistent because each round belongs to
+exactly one division — there is no per-division fan-out needed.
+
+**Alternative considered**: Per-division job IDs using `{prefix}_r{round_id}_d{div_id}`.
+Rejected because each round is already division-scoped through the `rounds` table; the
+extra `_d` suffix would complicate cancellation logic without benefit.
+
+---
+
+## 3. Module-Level APScheduler Callables
+
+**Decision**: Add three new module-level async functions in `scheduler_service.py`,
+following the identical pattern used for `_phase_job`, `_mystery_notice_job`, and
+`_result_submission_job_wrapper`:
+
+```python
+async def _rsvp_notice_job(round_id: int) -> None: ...
+async def _rsvp_last_notice_job(round_id: int) -> None: ...
+async def _rsvp_deadline_job(round_id: int) -> None: ...
+```
+
+Each delegates via `_GLOBAL_SERVICE._rsvp_*_callback`.
+
+**Rationale**: SQLAlchemyJobStore requires top-level picklable callables: closures
+and methods are not picklable. The codebase has consistently used this pattern for
+every new job type since Phase 1. Deviating would break job persistence across
+restarts.
+
+---
+
+## 4. Scheduling Attendance Jobs on Season Approval
+
+**Decision**: Extend `_do_approve` in `season_cog.py` (after the existing weather/
+results scheduling block) to call a new `schedule_attendance_round(rnd, cfg)` method
+when the attendance module is enabled. This method is guarded by an attendance-enabled
+check — it is a no-op when attendance is off, matching how result submission jobs are
+guarded by `results_enabled`.
+
+**Rationale**: Season approval is the single synchronisation point for all scheduled
+jobs in this codebase. All three types (weather, results, attendance) follow: check
+if module enabled → compute trigger times → add_job with replace_existing=True. The
+guard is `bot.module_service.is_attendance_enabled(server_id)`, consistent with the
+pattern already used for the Gate 4 approval check.
+
+**cancel_round must be extended**: `cancel_round(round_id)` in `SchedulerService`
+currently removes `phase1_r`, `phase2_r`, `phase3_r`, `mystery_r`, `cleanup_r`,
+`results_r`. It must also remove `rsvp_notice_r`, `rsvp_last_notice_r`, and
+`rsvp_deadline_r`. This is a one-line addition per ID.
+
+---
+
+## 5. Reserve Driver Identification
+
+**Decision**: Full-time vs. reserve classification is determined via
+`team_instances.is_reserve` (INTEGER, 0 = full-time, 1 = Reserve team). Queried
+through the join chain: `driver_season_assignments → team_seats → team_instances`.
+
+**Rationale**: This is already the authoritative discriminator used in
+`standings_service.py` (filter `ti.is_reserve = 0` for driver/team standings) and
+`results_cog.py`. No new field is required.
+
+---
+
+## 6. Constructors' Championship Position for Distribution Tie-Breaking
+
+**Decision**: Query `team_standings_snapshots` for the most recent `round_id` in the
+division before the current round, ordered by `standing_position ASC`. Team identity
+is matched by `team_role_id`. If no snapshot rows exist (first round of the season),
+fall back to alphabetical ordering of the team name.
+
+**Rationale**: `team_standings_snapshots` already has `standing_position` per
+`(round_id, division_id, team_role_id)`. The most recent snapshot is the one with
+the highest `round_id` (rounds complete sequentially within a season). The fallback
+is alphabetical to remain deterministic with no external configuration needed.
+
+---
+
+## 7. RSVP Embed Message ID Persistence
+
+**Decision**: Add a new table `rsvp_embed_messages` to store the Discord message ID
+of the posted RSVP embed, keyed by `(round_id, division_id)`.
+
+**Rationale**: The embed must be edited in-place on every button press and after
+distribution. The message ID is not predictable and cannot be derived from other data.
+The pattern is established: `forecast_messages` table already does exactly this for
+weather phase messages. This table also supports re-registration of the persistent
+view on bot restart.
+
+**Migration number**: `031_attendance_rsvp.sql` (next sequential).
+
+---
+
+## 8. DriverRoundAttendance Table
+
+**Decision**: New table storing per-driver RSVP state for each round. Columns:
+`id`, `round_id`, `division_id`, `driver_profile_id`, `rsvp_status`
+(NO_RSVP/ACCEPTED/TENTATIVE/DECLINED), `accepted_at` (ISO 8601 UTC, null until
+first accepted, reset on re-accept), `assigned_team_id` (null until distribution),
+`is_standby` (INTEGER 0/1), `attended` (null — future increment).
+
+**Rationale**: Required by constitution Principle XIII and spec FR-009. Centralises
+all RSVP state in a single queryable table rather than embedding it in the embed
+message content. `accepted_at` supports the timestamp-based reserve distribution
+ordering (FR-022). `attended` is null-allowed from the start since it is populated
+by a future increment.
+
+---
+
+## 9. test_mode_service Integration
+
+**No changes required for this increment.**
+
+**Rationale**: `get_pending_advance_jobs` in `test_mode_service.py` uses
+`_PHASE_PREFIX_MAP` to recognise advance-queue jobs. The `rsvp_*` jobs should NOT
+appear in the test-mode advance queue — they are attendance booking jobs, not
+race-phase progression events. Test mode for the RSVP timers will be handled in a
+separate future increment (or tested via unit/integration tests injecting mock times
+directly). This keeps the advance command's responsibility narrowly scoped.
+
+---
+
+## 10. Locking Logic Implementation
+
+**Decision**: Locking is evaluated at interaction time (inside the button callback),
+not enforced by View timeout. The button handler queries:
+1. Whether the interacting user is a full-time or reserve driver in this division.
+2. Whether the RSVP deadline has passed (compare UTC now against
+   `round.scheduled_at − rsvp_deadline_hours`).
+3. If reserve and not currently ACCEPTED: compare UTC now against
+   `round.scheduled_at` (round start time as the lock horizon).
+
+**Rationale**: Evaluating locking at interaction time is the only reliable approach
+because View timeout does not survive bot restarts and Discord can deliver button
+events after restart. The DB is always the authoritative source of timing truth.
+This pattern is used throughout the codebase (e.g., the penalty wizard checks
+`season.status` in each interaction rather than relying on view state).

--- a/specs/032-attendance-rsvp-checkin/spec.md
+++ b/specs/032-attendance-rsvp-checkin/spec.md
@@ -336,6 +336,22 @@ already responded and all reserve drivers are not mentioned.
 - **FR-030**: When `rsvp_last_notice_hours` is 0, no last-notice job MUST be created or
   armed for any round.
 
+**Test Mode Integration**
+
+- **FR-031**: A `/test-mode rsvp set-status` command MUST be available to league managers
+  when test mode is active. It MUST accept the following parameters:
+  - `driver_id` (mandatory) — the Discord user ID (snowflake) of the driver whose status
+    is being set.
+  - `status` (mandatory) — one of `accepted`, `tentative`, or `declined`.
+  - `division` (mandatory) — the name of the division whose active RSVP round to update.
+  The command MUST locate the `DriverRoundAttendance` row for the identified driver in the
+  active (not yet started) round for that division and update the `rsvp_status` field
+  accordingly, applying the same `accepted_at` management rules as a real button press
+  (FR-022). The RSVP embed MUST be edited in-place to reflect the updated status. The
+  command MUST be rejected with a clear ephemeral error if test mode is not active, if no
+  active RSVP embed exists for the division, or if the driver has no `DriverRoundAttendance`
+  row for the current round.
+
 ### Key Entities *(include if feature involves data)*
 
 - **DriverRoundAttendance** (new): RSVP state per driver per round per division. Records

--- a/specs/032-attendance-rsvp-checkin/spec.md
+++ b/specs/032-attendance-rsvp-checkin/spec.md
@@ -1,0 +1,404 @@
+# Feature Specification: Attendance Module RSVP Check-in & Reserve Distribution
+
+**Feature Branch**: `032-attendance-rsvp-checkin`  
+**Created**: 2026-04-03  
+**Status**: Draft  
+
+## User Scenarios & Testing *(mandatory)*
+
+### User Story 1 — Automated RSVP Embed Posting (Priority: P1)
+
+The bot automatically posts an RSVP embed in the division's configured RSVP channel at the
+correct notice window before a scheduled round. The embed shows the round's title, scheduled
+time, location, and event type, followed by a roster of every driver in the division grouped
+by team. Each driver's RSVP status is shown inline. Three action buttons (Accept, Tentative,
+Decline) appear below the embed for drivers to interact with.
+
+**Why this priority**: Foundational to all subsequent RSVP behaviour — without the embed
+being posted, no driver can respond and no distribution can run.
+
+**Independent Test**: Can be fully tested by configuring a round with a known start time,
+confirming the embed appears in the RSVP channel at the correct moment with all required
+fields, and verifying the three buttons are present.
+
+**Acceptance Scenarios**:
+
+1. **Given** the attendance module is enabled, a division has a configured RSVP channel,
+   and a non-Mystery round is scheduled to start in exactly `rsvp_notice_days` days,
+   **When** the scheduled notice timer fires, **Then** the bot posts an RSVP embed in that
+   division's RSVP channel containing the correct title, timestamp, location, event type,
+   full driver roster with `()` indicators, and three action buttons.
+2. **Given** a Mystery round is scheduled, **When** the notice timer would otherwise fire,
+   **Then** no RSVP embed is posted for that round.
+3. **Given** no RSVP channel is configured for a division at the moment the notice job fires,
+   **When** the job runs, **Then** no embed is posted, no interaction channel error is
+   emitted, and an audit log entry records the skip.
+4. **Given** the bot restarts before a round's notice timer has fired, **When** the bot
+   comes back online, **Then** any still-pending RSVP notice jobs are re-armed and fire at
+   the originally scheduled time.
+
+---
+
+### User Story 2 — Driver RSVP Button Interaction (Priority: P1)
+
+A driver registered in a division presses one of the three buttons on the RSVP embed to
+declare their attendance intention. The embed updates their status indicator in-place and
+the choice is persisted. A driver may change their response as many times as they like until
+their locking threshold is reached. Users not registered in the division are silently
+rejected.
+
+**Why this priority**: Core interactive functionality. Without driver responses, reserve
+distribution has no input and the attendance system cannot function.
+
+**Independent Test**: Can be fully tested by having registered full-time and reserve drivers
+press each button before the deadline, verifying the embed updates and the database records
+the correct status.
+
+**Acceptance Scenarios**:
+
+1. **Given** a full-time driver registered in the division presses Accept before the RSVP
+   deadline, **When** the interaction is processed, **Then** the embed shows `(✅)` next to
+   that driver's name and the persisted status is ACCEPTED.
+2. **Given** a driver presses Tentative, **When** processed, **Then** the embed shows `(❓)`
+   and the status is TENTATIVE.
+3. **Given** a driver presses Decline, **When** processed, **Then** the embed shows `(❌)`
+   and the status is DECLINED.
+4. **Given** a driver previously accepted and now presses Decline before the deadline,
+   **When** processed, **Then** the embed updates to `(❌)` and the stored status changes to
+   DECLINED.
+5. **Given** a driver presses the same button they already have selected (e.g. pressing
+   Accept when already ACCEPTED), **When** processed, **Then** the embed is unchanged and
+   the driver receives an ephemeral acknowledgement; no status change occurs.
+6. **Given** a user who is not a registered full-time or reserve driver in this division
+   presses any button, **When** processed, **Then** they receive an ephemeral error and the
+   embed is unchanged.
+7. **Given** a full-time driver presses any button after the RSVP deadline has passed,
+   **When** processed, **Then** they receive an ephemeral error stating the deadline has
+   passed and the embed is unchanged.
+
+---
+
+### User Story 3 — Reserve RSVP Extended Window (Priority: P2)
+
+Reserve drivers have a broader window to change their RSVP response than full-time drivers,
+allowing last-minute substitution flexibility. A reserve who has not accepted can change
+their status all the way up to the scheduled round start time. However, once a reserve has
+accepted, their choice locks at the RSVP deadline alongside full-time drivers — distribution
+cannot be undone by a late status change.
+
+**Why this priority**: Builds on the basic button interaction (P1). Important for reserve
+management correctness but only relevant after the embed and basic interactions work.
+
+**Independent Test**: Can be tested independently by verifying that a reserve driver who
+has not accepted can still change their status after the full-time RSVP deadline but before
+round start, while a reserve who has accepted is blocked from changing after the deadline.
+
+**Acceptance Scenarios**:
+
+1. **Given** a reserve driver whose current status is Tentative and the RSVP deadline has
+   passed but the round has not yet started, **When** they press Accept, **Then** the embed
+   updates to `(✅)` and the status is ACCEPTED.
+2. **Given** a reserve driver whose current status is Declined and the scheduled round start
+   time has passed, **When** they press any button, **Then** they receive an ephemeral error
+   and the embed is unchanged.
+3. **Given** a reserve driver who has Accepted and the RSVP deadline has passed, **When**
+   they press Decline, **Then** they receive an ephemeral error and their ACCEPTED status is
+   retained.
+
+---
+
+### User Story 4 — Reserve Distribution at RSVP Deadline (Priority: P2)
+
+When the RSVP deadline is reached, the bot automatically distributes accepted reserves to
+the teams that need substitutes, following the defined priority and tie-breaking algorithm.
+A message is posted in the division's RSVP channel announcing team assignments for placed
+reserves and standby status for unplaced reserves.
+
+**Why this priority**: Core downstream outcome of the RSVP process. Provides league
+participants with clear assignments before the round begins.
+
+**Independent Test**: Can be tested independently by setting up a round with known RSVP
+states (accepted full-timers, declined full-timers, accepted reserves) and verifying the
+distribution output matches the expected priority-and-tie-break ordering.
+
+**Acceptance Scenarios**:
+
+1. **Given** the RSVP deadline is reached with accepted reserves available and teams needing
+   substitutes, **When** distribution runs, **Then** reserves are assigned to teams in the
+   correct priority order (NO_RSVP teams first, then DECLINED teams, then TENTATIVE teams)
+   with correct tie-breaking applied.
+2. **Given** two teams are tied on priority and tie-breaker 1 (fewest accepted full-timers),
+   **When** distribution runs, **Then** the team with the lower Constructors' Championship
+   position receives the reserve first.
+3. **Given** no championship standings exist yet for the division, **When** distribution
+   runs and two teams are tied on all criteria, **Then** the teams are ordered alphabetically
+   by team name as a deterministic fallback.
+4. **Given** multiple reserves have accepted, **When** distribution runs, **Then** they are
+   assigned in ascending order of their acceptance timestamp (earliest confirmer gets first
+   pick of available teams).
+5. **Given** a reserve changed their RSVP status to Accepted more than once, **When**
+   distribution runs, **Then** the effective acceptance timestamp is the time of their
+   most recent change to Accepted.
+6. **Given** more accepted reserves exist than available team slots, **When** distribution
+   runs, **Then** the unplaced reserves are classified as on standby.
+7. **Given** distribution has completed, **When** the announcement is posted in the RSVP
+   channel, **Then** the message mentions each assigned reserve and their team, and each
+   standby reserve and their standby status.
+8. **Given** no reserves have accepted at the deadline, **When** distribution runs, **Then**
+   no distribution message is posted in the RSVP channel.
+
+---
+
+### User Story 5 — Last-Notice Ping for Non-Responding Full-Time Drivers (Priority: P2)
+
+At a configurable number of hours before the round, the bot sends a direct mention in the
+division's RSVP channel to every full-time driver who has not yet responded to the RSVP
+embed. Reserve drivers are excluded — they have an extended window and pinging them at
+this point would be inconsistent with their looser deadline. The last-notice ping is
+optional; setting the value to 0 disables it entirely.
+
+**Why this priority**: Provides a timely nudge to drivers who missed the initial embed,
+reducing NO_RSVP counts before the deadline and improving reserve distribution quality.
+Depends on US1 (embed must have been posted) and can operate independently of US3/US4.
+
+**Independent Test**: Can be fully tested by configuring a non-zero `rsvp_last_notice_hours`
+value, advancing time to the trigger threshold, and verifying that only full-time drivers
+with NO_RSVP status receive a mention in the RSVP channel while full-time drivers who have
+already responded and all reserve drivers are not mentioned.
+
+**Acceptance Scenarios**:
+
+1. **Given** `rsvp_last_notice_hours` is non-zero, a non-Mystery round is scheduled, and
+   the last-notice threshold is reached, **When** the job fires, **Then** the bot posts a
+   message in the division's RSVP channel mentioning only the full-time drivers whose RSVP
+   status is still NO_RSVP at that moment.
+2. **Given** all full-time drivers in a division have already responded (no NO_RSVP status)
+   when the last-notice job fires, **When** the job runs, **Then** no message is posted in
+   the RSVP channel for that division.
+3. **Given** `rsvp_last_notice_hours` is set to 0, **When** the round schedule is processed,
+   **Then** no last-notice job is created or armed for any round; no ping is ever sent.
+4. **Given** the bot restarts before a last-notice job has fired, **When** the bot comes
+   back online, **Then** the job is re-armed and fires at the originally scheduled time.
+5. **Given** a full-time driver responds to the embed between the RSVP embed posting and
+   the last-notice threshold, **When** the last-notice job fires, **Then** that driver is
+   NOT mentioned in the ping.
+6. **Given** a reserve driver has not responded at the last-notice threshold, **When** the
+   job fires, **Then** that reserve driver is NOT mentioned in the ping.
+
+---
+
+### Edge Cases
+
+- What happens if the RSVP channel is deleted or becomes inaccessible after the embed is
+  posted but before a driver interacts? Button presses that cannot be acknowledged or whose
+  embed cannot be edited fail gracefully; the bot logs the error but does not crash and does
+  not propagate an unhandled exception.
+- What if a driver is added to the division after the RSVP embed has already been posted?
+  Their name does not appear in the original embed; the embed is not retroactively updated
+  for roster changes after posting. They may still interact with the buttons, but their
+  status will not be visible in the roster display.
+- What if the bot restarts while the RSVP deadline job is pending? The deadline job is
+  re-armed on restart. If the deadline has already passed while the bot was offline,
+  distribution runs immediately on restart for any rounds that missed it.
+- What if a team has no full-time drivers for a round (e.g., all were sacked or unassigned)?
+  That team still appears in the distribution priority with zero accepted drivers and is
+  ranked at the highest priority tier (tied with other teams in the same state).
+- What if no teams require a reserve at all (all full-timers accepted)? Reserve distribution
+  still runs at the deadline but produces no assignments and no announcement message.
+- What if `rsvp_deadline_hours` is 0? The deadline is the scheduled round start time;
+  distribution and full-time locking occur at round start.
+- What if a round is cancelled or amended after the RSVP embed has been posted? Any
+  existing RSVP responses and scheduled deadline jobs for the cancelled/amended round are
+  discarded. If the round is rescheduled with a new time, a new RSVP embed is posted
+  according to the new schedule.
+- What if all full-time drivers respond before the last-notice threshold is reached?
+  The job fires but posts nothing to the RSVP channel, as there are no NO_RSVP full-time
+  drivers to mention.
+- What if the last-notice threshold is reached while the bot was offline? The job is
+  re-armed on restart; if the threshold time has already passed, the job is skipped
+  silently (no retroactive ping is sent — the deadline may already be imminent or past).
+
+## Requirements *(mandatory)*
+
+### Functional Requirements
+
+**RSVP Embed Posting**
+
+- **FR-001**: At exactly `rsvp_notice_days` days before each non-Mystery round's scheduled
+  start time, the bot MUST automatically post an RSVP embed to the division's configured
+  RSVP channel.
+- **FR-002**: For Mystery rounds, no RSVP embed MUST be posted and no RSVP notice job MUST
+  be created or armed.
+- **FR-003**: The RSVP embed title MUST follow the format
+  `Season <N> Round <N> — <Track canonical name>`.
+- **FR-004**: The embed MUST include: the scheduled round datetime as a dynamic Discord
+  timestamp; the round location (track canonical name, or "Mystery" for Mystery rounds);
+  and the event type (Normal, Sprint, Endurance, or Mystery).
+- **FR-005**: The embed MUST display a per-team driver roster covering all teams in the
+  division including the Reserve team. For each team, every assigned driver's display name
+  MUST appear with their current RSVP status indicator inline: `()` for no response,
+  `(✅)` for Accepted, `(❓)` for Tentative, `(❌)` for Declined.
+- **FR-006**: The embed MUST include three action buttons arranged horizontally: Accept
+  (green, ✅), Tentative (grey, ❓), Decline (red, ❌).
+- **FR-007**: RSVP notice jobs MUST be scheduled at season approval time for all non-Mystery
+  rounds whose notice horizon has not yet passed. On bot restart, any pending RSVP notice
+  jobs for future rounds MUST be re-armed before the bot resumes serving interactions.
+- **FR-008**: If no RSVP channel is configured for a division when a notice job fires, the
+  bot MUST skip posting for that division, log an audit entry recording the skip, and
+  continue without error.
+- **FR-009**: `DriverRoundAttendance` rows MUST be created for all full-time and reserve
+  drivers in the division with status NO_RSVP when the RSVP embed is posted, so the roster
+  and downstream operations have a complete, queryable attendance record from the start.
+
+**Driver RSVP Interaction**
+
+- **FR-010**: When a registered driver in the division (full-time or reserve) presses a
+  button, their RSVP status MUST be updated in the embed and persisted in the
+  `DriverRoundAttendance` record for that driver, round, and division.
+- **FR-011**: Only drivers registered as full-time or reserve members of the division for
+  the current season MUST be permitted to interact. All other users MUST receive an
+  ephemeral error; the embed MUST remain unchanged.
+- **FR-012**: The RSVP embed MUST be edited in-place to reflect the updated status; no
+  new message is posted in response to a button press.
+- **FR-013**: A driver pressing the same button they have already selected MUST result in
+  a no-op; the driver receives an ephemeral acknowledgement and no status change occurs.
+
+**RSVP Locking**
+
+- **FR-014**: Full-time driver RSVP choices MUST be locked once the `rsvp_deadline_hours`
+  threshold has passed. Any button press by a full-time driver after this point MUST be
+  rejected with a clear ephemeral error stating that the deadline has passed.
+- **FR-015**: Reserve drivers who have ACCEPTED MUST also be locked at the
+  `rsvp_deadline_hours` threshold (same timing as full-time drivers).
+- **FR-016**: Reserve drivers whose status is NOT ACCEPTED (NO_RSVP, TENTATIVE, or
+  DECLINED) MUST remain able to change their response until the scheduled round start time,
+  after which their response locks.
+- **FR-017**: When `rsvp_deadline_hours` is 0, the deadline is the scheduled round start
+  time; full-time locking, accepted-reserve locking, and non-accepted-reserve locking all
+  occur at the same moment.
+
+**Reserve Distribution**
+
+- **FR-018**: At the `rsvp_deadline_hours` threshold, the bot MUST run the reserve
+  distribution algorithm for every division with an active RSVP embed for the round.
+- **FR-019**: Only reserves whose RSVP status is ACCEPTED at the deadline moment MUST be
+  eligible for distribution.
+- **FR-020**: Teams MUST be ranked as distribution candidates in the following priority
+  order:
+  1. Teams where at least one full-time driver has NO_RSVP status.
+  2. Teams where at least one full-time driver has DECLINED.
+  3. Teams where at least one full-time driver is TENTATIVE.
+  Teams where all full-time drivers have ACCEPTED are not distribution candidates and
+  receive no reserve assignment.
+- **FR-021**: Within each priority tier, ties MUST be broken in order by:
+  1. Number of full-time drivers with ACCEPTED status (ascending; teams with zero
+     accepted full-timers are ranked first).
+  2. Constructors' Championship position in the division (lowest-ranked team first,
+     i.e. last place in the standings gets earliest access to reserves).
+  If championship standings are unavailable (no rounds completed yet), tied teams MUST
+  be ordered alphabetically by team name as a deterministic fallback.
+- **FR-022**: When a reserve sets their RSVP status to Accepted, their acceptance timestamp
+  MUST be recorded. If they change away from Accepted and back, the timestamp MUST be reset
+  to the time of the most recent change to Accepted. Reserves with the earliest acceptance
+  timestamp are distributed first.
+- **FR-023**: Each distribution candidate team receives at most one reserve per full-time
+  driver vacancy (i.e. one reserve per driver who did not accept). A single reserve fills
+  one slot in one team only.
+- **FR-024**: Accepted reserves not placed in any team due to no remaining vacancies MUST
+  be classified as on standby.
+- **FR-025**: After distribution, if any reserves were eligible (accepted at the deadline),
+  the bot MUST post a message in the division's RSVP channel:
+  - Mentioning each assigned reserve by Discord user tag and stating the team they are
+    racing for.
+  - Mentioning each standby reserve by Discord user tag and informing them they are on
+    standby and should be prepared to substitute.
+- **FR-026**: If no reserves have accepted at the deadline, no distribution message MUST
+  be posted.
+- **FR-027**: The deadline distribution job MUST be scheduled at season approval time
+  alongside the notice job and MUST be re-armed on bot restart if the deadline has not
+  yet passed. If the deadline has passed while the bot was offline, distribution MUST run
+  immediately on bot startup for any affected rounds.
+
+**Last-Notice Ping**
+
+- **FR-028**: When `rsvp_last_notice_hours` is non-zero, a last-notice job MUST be
+  scheduled for each non-Mystery round at exactly `rsvp_last_notice_hours` hours before
+  the scheduled round start time. When the job fires, the bot MUST post a single message
+  in the division's configured RSVP channel that mentions (by Discord user tag) every
+  full-time driver whose `DriverRoundAttendance` status for that round is still NO_RSVP
+  at the moment the job runs. Reserve drivers MUST NOT be included in the mention
+  regardless of their RSVP status.
+- **FR-029**: If no full-time driver has a NO_RSVP status when the job fires, no message
+  MUST be posted for that division. Last-notice jobs MUST be scheduled at season approval
+  time alongside the RSVP notice and deadline jobs and MUST be re-armed on bot restart if
+  the threshold time has not yet passed. If the threshold time has already passed when the
+  bot restarts, the job MUST be skipped silently — no retroactive ping is sent.
+- **FR-030**: When `rsvp_last_notice_hours` is 0, no last-notice job MUST be created or
+  armed for any round.
+
+### Key Entities *(include if feature involves data)*
+
+- **DriverRoundAttendance** (new): RSVP state per driver per round per division. Records
+  RSVP status (NO_RSVP / ACCEPTED / TENTATIVE / DECLINED); acceptance timestamp (null
+  until first accepted; reset on each re-accept); round team assignment set by distribution
+  (null if not distributed or not a reserve); standby flag (false by default, set true when
+  classified as standby after distribution); attended flag (null — populated in a future
+  increment when round results are submitted).
+- **Round** (existing): Carries start time, format, division, track reference, and round
+  number within a season. Drives RSVP job scheduling.
+- **SeasonAssignment / TeamSeat** (existing): Determines which drivers are full-time (non-
+  Reserve seat) vs. reserve (Reserve team seat) in a division for the current season.
+- **AttendanceDivisionConfig** (existing): Holds the RSVP channel ID and attendance channel
+  ID per division per server.
+- **AttendanceConfig** (existing): Server-level parameters including `rsvp_notice_days`,
+  `rsvp_deadline_hours`, and `rsvp_last_notice_hours`.
+
+## Assumptions
+
+1. The Constructors' Championship standings used for distribution tie-breaking are derived
+   from the most recent `TeamStandingsSnapshot` for the division. If no such snapshot
+   exists (first round of the season), alphabetical team name order is the deterministic
+   fallback.
+2. Full-time drivers are all drivers assigned to a non-Reserve team seat in the division
+   for the current season. Reserve drivers are those assigned to the Reserve team seat.
+   Unassigned drivers do not appear in the RSVP roster.
+3. The RSVP embed is a single persistent message that is edited in-place when statuses
+   change; it is never deleted and reposted.
+4. The bot persists the Discord message ID of each RSVP embed (associated with its round
+   and division) so the message can be edited on button interactions and after distribution.
+5. Reserve distribution assigns at most one reserve per absent full-time driver slot in a
+   team. If a team has two absent full-timers, it may receive two reserves (if available).
+6. If `rsvp_deadline_hours` is 0, the full-time driver locking, accepted-reserve locking,
+   and distribution all occur at the scheduled round start time.
+7. Round cancellation or amendment after the RSVP embed is posted invalidates all existing
+   RSVP responses and their scheduled jobs; a fresh embed is posted for the rescheduled
+   round if applicable.
+
+## Out of Scope (This Increment)
+
+- Attendance recording from submitted round results
+- Attendance point distribution and pardon workflow
+- Attendance sheet posting to the attendance channel
+- Autoreserve and autosack sanction enforcement
+
+## Success Criteria *(mandatory)*
+
+### Measurable Outcomes
+
+- **SC-001**: Every RSVP embed is posted within a 1-minute window of its scheduled notice
+  time across all configured divisions and active non-Mystery rounds.
+- **SC-002**: Driver status changes (Accept / Tentative / Decline) are reflected in the
+  embed within 3 seconds of a button press.
+- **SC-003**: The reserve distribution algorithm produces a deterministic, reproducible
+  result for any given input state — the same RSVP statuses, timestamps, and standings
+  always yield the same assignment outcome.
+- **SC-004**: The distribution announcement message is posted in the RSVP channel within
+  30 seconds of the deadline for each affected division.
+- **SC-005**: No silent failures — every skipped posting, rejected interaction, or
+  distribution error produces either an ephemeral user-facing message or an audit log
+  entry; no command or scheduled job is silently discarded.
+- **SC-006**: Bot restart results in no missed RSVP notice, last-notice ping, or
+  distribution jobs for any round whose trigger time has not yet passed.
+- **SC-007**: The last-notice ping is delivered to exclusively the correct set of
+  recipients — full-time drivers with NO_RSVP status only; no reserve driver and no
+  driver who has already responded is ever included in a last-notice mention.

--- a/specs/032-attendance-rsvp-checkin/tasks.md
+++ b/specs/032-attendance-rsvp-checkin/tasks.md
@@ -28,8 +28,8 @@
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
 - [ ] T002 Add `DriverRoundAttendance` and `RsvpEmbedMessage` dataclasses to `src/models/attendance.py`
-- [ ] T003 Add `driver_round_attendance` CRUD to `src/services/attendance_service.py`: `bulk_insert_attendance_rows`, `upsert_rsvp_status`, `get_attendance_rows`, `get_attendance_row_for_driver`
-- [ ] T004 Add `rsvp_embed_messages` CRUD to `src/services/attendance_service.py`: `insert_embed_message`, `get_embed_message`, `get_all_active_embed_messages`
+- [ ] T003 Add `driver_round_attendance` CRUD to `src/services/attendance_service.py`: `bulk_insert_attendance_rows`, `upsert_rsvp_status` (must set `accepted_at = utcnow()` when transitioning to ACCEPTED, reset on re-Accept after a non-Accept, set NULL when transitioning away from ACCEPTED — per FR-022), `get_attendance_rows`, `get_attendance_row_for_driver`
+- [ ] T004 Add `rsvp_embed_messages` CRUD to `src/services/attendance_service.py`: `insert_embed_message`, `get_embed_message`, `get_all_embed_messages` (returns all rows unconditionally — locking is enforced at interaction time, not at view re-arm time)
 
 **Checkpoint**: Foundation ready — all data access methods available; user story implementation can begin.
 
@@ -54,7 +54,7 @@ exist with `NO_RSVP` status. Confirm `rsvp_embed_messages` has one row with the 
 - [ ] T007 [US1] Add `schedule_attendance_round(rnd, cfg)` method with `DateTrigger` for notice job and extend `cancel_round` to also remove `rsvp_notice_r{round_id}` in `src/services/scheduler_service.py`
 - [ ] T008 [US1] Implement `run_rsvp_notice(round_id)` in `src/services/rsvp_service.py`: query full-time + reserve roster via `driver_season_assignments → team_seats → team_instances`, call `build_rsvp_embed`, post to RSVP channel, bulk-insert `driver_round_attendance` rows, store `message_id` + `channel_id` in `rsvp_embed_messages`; skip + audit log if no RSVP channel (FR-008); bypass if Mystery round (FR-002)
 - [ ] T009 [US1] Extend `_do_approve` in `src/cogs/season_cog.py` to call `scheduler_service.schedule_attendance_round(rnd, att_cfg)` for each non-Mystery round when attendance module is enabled, following the existing `is_weather_enabled` / `is_results_enabled` guard pattern
-- [ ] T010 [US1] Register `register_rsvp_notice_callback` and add `rsvp_embed_messages` view re-arm loop (`bot.add_view(RsvpView(), message_id=row.message_id)` for all active rows) in `src/bot.py` startup block
+- [ ] T010 [US1] Register `register_rsvp_notice_callback` and add `rsvp_embed_messages` view re-arm loop (`bot.add_view(RsvpView(), message_id=row.message_id)` for all rows from `get_all_embed_messages`) in `src/bot.py` startup block
 
 **Checkpoint**: End-to-end US1 flow works — approval schedules job, job fires, embed posted, rows created.
 
@@ -71,7 +71,7 @@ press Accept, Tentative, and Decline. Verify the embed updates each time. Have a
 user press a button and verify the ephemeral error. Press the same button twice and verify
 the ephemeral acknowledgement and no DB change.
 
-- [ ] T011 [US2] Implement `RsvpView` class (`timeout=None`) with three `discord.ui.Button` components, `custom_id` values `rsvp_accept_r{round_id}`, `rsvp_tentative_r{round_id}`, `rsvp_decline_r{round_id}` in `src/cogs/attendance_cog.py`; extract `round_id` from `custom_id` prefix in each handler
+- [ ] T011 [US2] Implement `RsvpView` class (`timeout=None`) with three `discord.ui.Button` components, `custom_id` values `rsvp_accept_r{round_id}`, `rsvp_tentative_r{round_id}`, `rsvp_decline_r{round_id}` in `src/cogs/attendance_cog.py`; parse `round_id` from the `_r{round_id}` suffix of `custom_id` in each handler
 - [ ] T012 [US2] Add interaction logic to each button handler in `src/cogs/attendance_cog.py`: look up driver by Discord user ID in `driver_season_assignments`, reject non-members with ephemeral error (FR-011); check `rsvp_status` for no-op and reply ephemerally (FR-013); call `attendance_service.upsert_rsvp_status`; fetch message from `rsvp_embed_messages`; rebuild embed with `build_rsvp_embed` and edit message in-place (FR-010, FR-012)
 - [ ] T013 [US2] Add `bot.add_view(RsvpView())` to the persistent-views registration block in `src/bot.py`
 
@@ -107,8 +107,8 @@ then by standings position, and reserve ordering by `accepted_at` timestamp. Ver
 classification when reserves exceed vacancies. Verify no announcement posted when no reserves
 accepted.
 
-- [ ] T015 [P] [US4] Implement `run_reserve_distribution(round_id, division_id)` in `src/services/rsvp_service.py`: query accepted reserves ordered by `accepted_at` ASC; rank candidate teams by priority tier (FR-020) then tie-break by accepted-full-timer count then by `team_standings_snapshots.standing_position` (most recent `round_id` in division, fallback to alphabetical by team name when no snapshot exists, FR-021); assign reserves to vacancies per FR-023; classify unplaced reserves as standby (FR-024); write `assigned_team_id` + `is_standby` to `driver_round_attendance`
-- [ ] T016 [P] [US4] Add `_rsvp_deadline_job(round_id)` module-level async callable and `register_rsvp_deadline_callback` method to `src/services/scheduler_service.py`
+- [ ] T015 [P] [US4] Implement `run_reserve_distribution(round_id, division_id)` in `src/services/rsvp_service.py`: query accepted reserves ordered by `accepted_at` ASC; rank candidate teams by priority tier (FR-020) then tie-break by accepted-full-timer count then by `team_standings_snapshots.standing_position` (most recent `round_id` in division, fallback to alphabetical by team name when no snapshot exists, FR-021); assign reserves to vacancies per FR-023; classify unplaced reserves as standby (FR-024); write `assigned_team_id` + `is_standby` to `driver_round_attendance`; note: only non-Reserve teams are distribution candidates — the Reserve team is the supply pool (`is_reserve = 1`) and MUST NOT appear in the candidate ranking
+- [ ] T016 [P] [US4] Add `_rsvp_deadline_job(round_id)` module-level async callable and `register_rsvp_deadline_callback` method to `src/services/scheduler_service.py` following the same pattern as T006
 - [ ] T017 [US4] Implement `run_rsvp_deadline(round_id)` in `src/services/rsvp_service.py`: call `run_reserve_distribution` per division; fetch `rsvp_embed_messages` rows and edit each embed to remove or disable buttons; post assignment announcement to RSVP channel if any reserves were eligible (FR-025, FR-026)
 - [ ] T018 [US4] Extend `schedule_attendance_round` to add deadline `DateTrigger` job and extend `cancel_round` to also remove `rsvp_deadline_r{round_id}` in `src/services/scheduler_service.py`
 - [ ] T019 [US4] Register `register_rsvp_deadline_callback` and add missed-deadline recovery on startup (run `run_rsvp_deadline` immediately for any round whose deadline has already passed while bot was offline, FR-027) in `src/bot.py`
@@ -138,13 +138,27 @@ is 0.
 
 ---
 
-## Phase 8: Polish & Tests
+## Phase 8: Test Mode Integration
+
+**Purpose**: Wire RSVP jobs into `/test-mode advance` and add `/test-mode rsvp set-status`.
+
+**Dependencies**: Depends on Phase 3 (US1) for T027/T028 (RSVP service callables must exist); depends on Phase 2 (Foundational) for T029 (`upsert_rsvp_status` must exist).
+
+- [ ] T027 Extend `_PHASE_PREFIX_MAP` in `src/services/scheduler_service.py` `get_pending_advance_jobs` to include `rsvp_notice` → phase 5, `rsvp_last_notice` → phase 6, `rsvp_deadline` → phase 7 (per research decision #9)
+- [ ] T028 Extend the `advance` dispatcher in `src/cogs/test_mode_cog.py` to handle phase numbers 5, 6, 7: call `run_rsvp_notice(round_id, bot)`, `run_rsvp_last_notice(round_id, bot)`, `run_rsvp_deadline(round_id, bot)` respectively
+- [ ] T029 Implement `/test-mode rsvp set-status` command in `src/cogs/test_mode_cog.py` (gated on test mode active): parameters `driver_id` (Discord user ID, mandatory), `status` (accepted/tentative/declined, mandatory), `division` (mandatory); locate `DriverRoundAttendance` row for the active round in that division; call `upsert_rsvp_status` with same `accepted_at` rules as a real button press; rebuild and edit the RSVP embed in-place (FR-031)
+
+**Checkpoint**: `/test-mode advance` fires RSVP jobs in correct scheduled order; `/test-mode rsvp set-status` allows fake-driver status management for test validation.
+
+---
+
+## Phase 9: Polish & Tests
 
 **Purpose**: Unit tests and integration validation.
 
 - [ ] T024 [P] Write `tests/unit/test_rsvp_service.py`: distribution algorithm unit tests (priority ordering, tie-breaking with standings, tie-breaking with fallback, accepted_at timestamp ordering, standby classification, no-announcement when no reserves accepted); service method CRUD round-trips
 - [ ] T025 [P] Write `tests/unit/test_rsvp_embed_builder.py`: embed content unit tests (title format, Mystery bypass, status indicator strings for all four statuses, per-team roster grouping)
-- [ ] T026 Run quickstart.md validation end-to-end: apply migration, approve season, fire notice job manually, press buttons, fire last-notice job, fire deadline job; confirm all outputs match quickstart expectations
+- [ ] T026 Run quickstart.md validation end-to-end using test mode: enable test mode, add fake roster via `/test-mode roster add`, approve season, use `/test-mode advance` to fire notice job (phase 5), use `/test-mode rsvp set-status` to set RSVP statuses for fake drivers, use `/test-mode advance` to fire last-notice job (phase 6) and deadline job (phase 7); confirm all outputs match quickstart expectations (FR-031, constitution §XIII test mode clause)
 
 ---
 
@@ -159,7 +173,8 @@ is 0.
 - **Phase 5 (US3)**: Depends on Phase 4 — locking logic amends handlers created in US2
 - **Phase 6 (US4)**: Depends on Phase 2 + Phase 3 (scheduler infrastructure from US1, DRA rows); independent of US2/US3
 - **Phase 7 (US5)**: Depends on Phase 2 + Phase 3 (scheduler infrastructure from US1, DRA rows); independent of US2/US3/US4
-- **Phase 8 (Polish)**: Depends on all user story phases
+- **Phase 8 (Test Mode Integration)**: Depends on Phase 3 (US1) for T027/T028; Phase 2 for T029
+- **Phase 9 (Polish)**: Depends on all user story phases and Phase 8
 
 ### User Story Dependencies
 
@@ -177,6 +192,8 @@ is 0.
 - T015 (rsvp_service.py) and T016 (scheduler_service.py) can run in parallel
 - T020 (scheduler_service.py) and T021 (rsvp_service.py) can run in parallel
 - T024 and T025 (different test files) can run in parallel
+- T018 appends to `cancel_round` and `schedule_attendance_round` as established by T007 — amend those methods, do not rewrite them
+- T022 likewise appends to both as extended by T018 — amend, do not rewrite
 
 ---
 
@@ -223,7 +240,8 @@ T023 bot.py wiring
 
 **MVP scope (Phase 1 → Phase 4)**: The bot posts RSVP embeds and drivers can respond via
 buttons. 18 tasks. Covers US1 + US2, the two P1 stories. Verifiable end-to-end without
-distribution or pings.
+distribution or pings. ⚠️ RSVP locking (FR-014–FR-017) is not enforced until Phase 5
+(US3) — do not deploy against an active season until Phase 5 is complete.
 
 **Full scope (Phase 1 → Phase 7)**: All 23 implementation tasks. US3 adds correct reserve
 locking; US4 adds distribution; US5 adds last-notice pings. US4 and US5 can be developed
@@ -245,7 +263,8 @@ in parallel after US1 is complete.
 | Phase 5 | US3 (P2) | 1 | T014 |
 | Phase 6 | US4 (P2) | 5 | T015–T019 |
 | Phase 7 | US5 (P2) | 4 | T020–T023 |
-| Phase 8 | Polish | 3 | T024–T026 |
-| **Total** | | **26** | |
+| Phase 8 | Test Mode Integration | 3 | T027–T029 |
+| Phase 9 | Polish | 3 | T024–T026 |
+| **Total** | | **29** | |
 
-**Parallel opportunities identified**: 5 (T005/T006, T015/T016, T020/T021, T024/T025, Phase 6+Phase 7 concurrent after US1)
+**Parallel opportunities identified**: 6 (T005/T006, T015/T016, T020/T021, T024/T025, Phase 6+Phase 7 concurrent after US1, T027+T028 concurrent with T029 within Phase 8)

--- a/specs/032-attendance-rsvp-checkin/tasks.md
+++ b/specs/032-attendance-rsvp-checkin/tasks.md
@@ -15,7 +15,7 @@
 
 **Purpose**: Database migration that all subsequent work depends on.
 
-- [ ] T001 Create `src/db/migrations/031_attendance_rsvp.sql` with `driver_round_attendance` and `rsvp_embed_messages` tables per data-model.md
+- [X] T001 Create `src/db/migrations/031_attendance_rsvp.sql` with `driver_round_attendance` and `rsvp_embed_messages` tables per data-model.md
 
 **Checkpoint**: Migration exists and is applied by the migration runner on next bot start.
 
@@ -27,9 +27,9 @@
 
 **⚠️ CRITICAL**: No user story work can begin until this phase is complete.
 
-- [ ] T002 Add `DriverRoundAttendance` and `RsvpEmbedMessage` dataclasses to `src/models/attendance.py`
-- [ ] T003 Add `driver_round_attendance` CRUD to `src/services/attendance_service.py`: `bulk_insert_attendance_rows`, `upsert_rsvp_status` (must set `accepted_at = utcnow()` when transitioning to ACCEPTED, reset on re-Accept after a non-Accept, set NULL when transitioning away from ACCEPTED — per FR-022), `get_attendance_rows`, `get_attendance_row_for_driver`
-- [ ] T004 Add `rsvp_embed_messages` CRUD to `src/services/attendance_service.py`: `insert_embed_message`, `get_embed_message`, `get_all_embed_messages` (returns all rows unconditionally — locking is enforced at interaction time, not at view re-arm time)
+- [X] T002 Add `DriverRoundAttendance` and `RsvpEmbedMessage` dataclasses to `src/models/attendance.py`
+- [X] T003 Add `driver_round_attendance` CRUD to `src/services/attendance_service.py`: `bulk_insert_attendance_rows`, `upsert_rsvp_status` (must set `accepted_at = utcnow()` when transitioning to ACCEPTED, reset on re-Accept after a non-Accept, set NULL when transitioning away from ACCEPTED — per FR-022), `get_attendance_rows`, `get_attendance_row_for_driver`
+- [X] T004 Add `rsvp_embed_messages` CRUD to `src/services/attendance_service.py`: `insert_embed_message`, `get_embed_message`, `get_all_embed_messages` (returns all rows unconditionally — locking is enforced at interaction time, not at view re-arm time)
 
 **Checkpoint**: Foundation ready — all data access methods available; user story implementation can begin.
 
@@ -49,12 +49,12 @@ indicators for all drivers, and three action buttons. Confirm `driver_round_atte
 exist with `NO_RSVP` status. Confirm `rsvp_embed_messages` has one row with the correct
 `message_id`.
 
-- [ ] T005 [P] [US1] Create `src/services/rsvp_service.py` with `build_rsvp_embed` function: title format `Season N Round N — <track>`, Discord timestamp field, location + event type fields, per-team roster with status indicators `()` / `(✅)` / `(❓)` / `(❌)` per FR-003–FR-005
-- [ ] T006 [P] [US1] Add `_rsvp_notice_job(round_id)` module-level async callable and `register_rsvp_notice_callback` method to `src/services/scheduler_service.py` following the `_phase_job` / `_mystery_notice_job` pattern
-- [ ] T007 [US1] Add `schedule_attendance_round(rnd, cfg)` method with `DateTrigger` for notice job and extend `cancel_round` to also remove `rsvp_notice_r{round_id}` in `src/services/scheduler_service.py`
-- [ ] T008 [US1] Implement `run_rsvp_notice(round_id)` in `src/services/rsvp_service.py`: query full-time + reserve roster via `driver_season_assignments → team_seats → team_instances`, call `build_rsvp_embed`, post to RSVP channel, bulk-insert `driver_round_attendance` rows, store `message_id` + `channel_id` in `rsvp_embed_messages`; skip + audit log if no RSVP channel (FR-008); bypass if Mystery round (FR-002)
-- [ ] T009 [US1] Extend `_do_approve` in `src/cogs/season_cog.py` to call `scheduler_service.schedule_attendance_round(rnd, att_cfg)` for each non-Mystery round when attendance module is enabled, following the existing `is_weather_enabled` / `is_results_enabled` guard pattern
-- [ ] T010 [US1] Register `register_rsvp_notice_callback` and add `rsvp_embed_messages` view re-arm loop (`bot.add_view(RsvpView(), message_id=row.message_id)` for all rows from `get_all_embed_messages`) in `src/bot.py` startup block
+- [X] T005 [P] [US1] Create `src/services/rsvp_service.py` with `build_rsvp_embed` function: title format `Season N Round N — <track>`, Discord timestamp field, location + event type fields, per-team roster with status indicators `()` / `(✅)` / `(❓)` / `(❌)` per FR-003–FR-005
+- [X] T006 [P] [US1] Add `_rsvp_notice_job(round_id)` module-level async callable and `register_rsvp_notice_callback` method to `src/services/scheduler_service.py` following the `_phase_job` / `_mystery_notice_job` pattern
+- [X] T007 [US1] Add `schedule_attendance_round(rnd, cfg)` method with `DateTrigger` for notice job and extend `cancel_round` to also remove `rsvp_notice_r{round_id}` in `src/services/scheduler_service.py`
+- [X] T008 [US1] Implement `run_rsvp_notice(round_id)` in `src/services/rsvp_service.py`: query full-time + reserve roster via `driver_season_assignments → team_seats → team_instances`, call `build_rsvp_embed`, post to RSVP channel, bulk-insert `driver_round_attendance` rows, store `message_id` + `channel_id` in `rsvp_embed_messages`; skip + audit log if no RSVP channel (FR-008); bypass if Mystery round (FR-002)
+- [X] T009 [US1] Extend `_do_approve` in `src/cogs/season_cog.py` to call `scheduler_service.schedule_attendance_round(rnd, att_cfg)` for each non-Mystery round when attendance module is enabled, following the existing `is_weather_enabled` / `is_results_enabled` guard pattern
+- [X] T010 [US1] Register `register_rsvp_notice_callback` and add `rsvp_embed_messages` view re-arm loop (`bot.add_view(RsvpView(), message_id=row.message_id)` for all rows from `get_all_embed_messages`) in `src/bot.py` startup block
 
 **Checkpoint**: End-to-end US1 flow works — approval schedules job, job fires, embed posted, rows created.
 
@@ -71,9 +71,9 @@ press Accept, Tentative, and Decline. Verify the embed updates each time. Have a
 user press a button and verify the ephemeral error. Press the same button twice and verify
 the ephemeral acknowledgement and no DB change.
 
-- [ ] T011 [US2] Implement `RsvpView` class (`timeout=None`) with three `discord.ui.Button` components, `custom_id` values `rsvp_accept_r{round_id}`, `rsvp_tentative_r{round_id}`, `rsvp_decline_r{round_id}` in `src/cogs/attendance_cog.py`; parse `round_id` from the `_r{round_id}` suffix of `custom_id` in each handler
-- [ ] T012 [US2] Add interaction logic to each button handler in `src/cogs/attendance_cog.py`: look up driver by Discord user ID in `driver_season_assignments`, reject non-members with ephemeral error (FR-011); check `rsvp_status` for no-op and reply ephemerally (FR-013); call `attendance_service.upsert_rsvp_status`; fetch message from `rsvp_embed_messages`; rebuild embed with `build_rsvp_embed` and edit message in-place (FR-010, FR-012)
-- [ ] T013 [US2] Add `bot.add_view(RsvpView())` to the persistent-views registration block in `src/bot.py`
+- [X] T011 [US2] Implement `RsvpView` class (`timeout=None`) with three `discord.ui.Button` components, `custom_id` values `rsvp_accept_r{round_id}`, `rsvp_tentative_r{round_id}`, `rsvp_decline_r{round_id}` in `src/cogs/attendance_cog.py`; parse `round_id` from the `_r{round_id}` suffix of `custom_id` in each handler
+- [X] T012 [US2] Add interaction logic to each button handler in `src/cogs/attendance_cog.py`: look up driver by Discord user ID in `driver_season_assignments`, reject non-members with ephemeral error (FR-011); check `rsvp_status` for no-op and reply ephemerally (FR-013); call `attendance_service.upsert_rsvp_status`; fetch message from `rsvp_embed_messages`; rebuild embed with `build_rsvp_embed` and edit message in-place (FR-010, FR-012)
+- [X] T013 [US2] Add `bot.add_view(RsvpView())` to the persistent-views registration block in `src/bot.py`
 
 **Checkpoint**: Buttons work for valid members; non-members and no-ops handled correctly.
 
@@ -88,7 +88,7 @@ lock at `rsvp_deadline_hours` threshold. Non-accepted reserves lock only at roun
 rejected), a reserve with ACCEPTED status (must be rejected), and a reserve with TENTATIVE
 status (must succeed until round start). Verify all three cases independently.
 
-- [ ] T014 [US3] Add locking evaluation at the start of each button handler in `src/cogs/attendance_cog.py`: query `round.scheduled_at` + `attendance_config.rsvp_deadline_hours`; if full-time driver and `now ≥ scheduled_at − deadline_hours`, reject with ephemeral error (FR-014); if reserve and ACCEPTED and `now ≥ scheduled_at − deadline_hours`, reject (FR-015); if reserve and NOT ACCEPTED and `now ≥ scheduled_at`, reject (FR-016); if `deadline_hours == 0`, treat all locks as round start (FR-017)
+- [X] T014 [US3] Add locking evaluation at the start of each button handler in `src/cogs/attendance_cog.py`: query `round.scheduled_at` + `attendance_config.rsvp_deadline_hours`; if full-time driver and `now ≥ scheduled_at − deadline_hours`, reject with ephemeral error (FR-014); if reserve and ACCEPTED and `now ≥ scheduled_at − deadline_hours`, reject (FR-015); if reserve and NOT ACCEPTED and `now ≥ scheduled_at`, reject (FR-016); if `deadline_hours == 0`, treat all locks as round start (FR-017)
 
 **Checkpoint**: Locking rules enforced for all driver types; extended reserve window confirmed.
 
@@ -107,11 +107,11 @@ then by standings position, and reserve ordering by `accepted_at` timestamp. Ver
 classification when reserves exceed vacancies. Verify no announcement posted when no reserves
 accepted.
 
-- [ ] T015 [P] [US4] Implement `run_reserve_distribution(round_id, division_id)` in `src/services/rsvp_service.py`: query accepted reserves ordered by `accepted_at` ASC; rank candidate teams by priority tier (FR-020) then tie-break by accepted-full-timer count then by `team_standings_snapshots.standing_position` (most recent `round_id` in division, fallback to alphabetical by team name when no snapshot exists, FR-021); assign reserves to vacancies per FR-023; classify unplaced reserves as standby (FR-024); write `assigned_team_id` + `is_standby` to `driver_round_attendance`; note: only non-Reserve teams are distribution candidates — the Reserve team is the supply pool (`is_reserve = 1`) and MUST NOT appear in the candidate ranking
-- [ ] T016 [P] [US4] Add `_rsvp_deadline_job(round_id)` module-level async callable and `register_rsvp_deadline_callback` method to `src/services/scheduler_service.py` following the same pattern as T006
-- [ ] T017 [US4] Implement `run_rsvp_deadline(round_id)` in `src/services/rsvp_service.py`: call `run_reserve_distribution` per division; fetch `rsvp_embed_messages` rows and edit each embed to remove or disable buttons; post assignment announcement to RSVP channel if any reserves were eligible (FR-025, FR-026)
-- [ ] T018 [US4] Extend `schedule_attendance_round` to add deadline `DateTrigger` job and extend `cancel_round` to also remove `rsvp_deadline_r{round_id}` in `src/services/scheduler_service.py`
-- [ ] T019 [US4] Register `register_rsvp_deadline_callback` and add missed-deadline recovery on startup (run `run_rsvp_deadline` immediately for any round whose deadline has already passed while bot was offline, FR-027) in `src/bot.py`
+- [X] T015 [P] [US4] Implement `run_reserve_distribution(round_id, division_id)` in `src/services/rsvp_service.py`: query accepted reserves ordered by `accepted_at` ASC; rank candidate teams by priority tier (FR-020) then tie-break by accepted-full-timer count then by `team_standings_snapshots.standing_position` (most recent `round_id` in division, fallback to alphabetical by team name when no snapshot exists, FR-021); assign reserves to vacancies per FR-023; classify unplaced reserves as standby (FR-024); write `assigned_team_id` + `is_standby` to `driver_round_attendance`; note: only non-Reserve teams are distribution candidates — the Reserve team is the supply pool (`is_reserve = 1`) and MUST NOT appear in the candidate ranking
+- [X] T016 [P] [US4] Add `_rsvp_deadline_job(round_id)` module-level async callable and `register_rsvp_deadline_callback` method to `src/services/scheduler_service.py` following the same pattern as T006
+- [X] T017 [US4] Implement `run_rsvp_deadline(round_id)` in `src/services/rsvp_service.py`: call `run_reserve_distribution` per division; fetch `rsvp_embed_messages` rows and edit each embed to remove or disable buttons; post assignment announcement to RSVP channel if any reserves were eligible (FR-025, FR-026)
+- [X] T018 [US4] Extend `schedule_attendance_round` to add deadline `DateTrigger` job and extend `cancel_round` to also remove `rsvp_deadline_r{round_id}` in `src/services/scheduler_service.py`
+- [X] T019 [US4] Register `register_rsvp_deadline_callback` and add missed-deadline recovery on startup (run `run_rsvp_deadline` immediately for any round whose deadline has already passed while bot was offline, FR-027) in `src/bot.py`
 
 **Checkpoint**: Deadline job fires and produces correct distribution assignment; announcement posted; no announcement when no reserves.
 
@@ -129,10 +129,10 @@ drivers respond and some not, fire the job, confirm only the non-responding full
 are mentioned. Confirm no message when all have responded. Confirm no job created when value
 is 0.
 
-- [ ] T020 [P] [US5] Add `_rsvp_last_notice_job(round_id)` module-level async callable and `register_rsvp_last_notice_callback` method to `src/services/scheduler_service.py`
-- [ ] T021 [P] [US5] Implement `run_rsvp_last_notice(round_id)` in `src/services/rsvp_service.py`: query `driver_round_attendance` WHERE `rsvp_status = 'NO_RSVP'` joined to `driver_season_assignments → team_seats → team_instances` WHERE `is_reserve = 0`; if none found skip silently (FR-029); otherwise build mention string and post to RSVP channel (FR-028)
-- [ ] T022 [US5] Extend `schedule_attendance_round` to add last-notice `DateTrigger` job only when `rsvp_last_notice_hours > 0` (FR-030), and extend `cancel_round` to also remove `rsvp_last_notice_r{round_id}` in `src/services/scheduler_service.py`
-- [ ] T023 [US5] Register `register_rsvp_last_notice_callback` and add skip-if-past re-arm logic on startup (do NOT fire retroactively if threshold already passed at restart, per FR-029 edge case) in `src/bot.py`
+- [X] T020 [P] [US5] Add `_rsvp_last_notice_job(round_id)` module-level async callable and `register_rsvp_last_notice_callback` method to `src/services/scheduler_service.py`
+- [X] T021 [P] [US5] Implement `run_rsvp_last_notice(round_id)` in `src/services/rsvp_service.py`: query `driver_round_attendance` WHERE `rsvp_status = 'NO_RSVP'` joined to `driver_season_assignments → team_seats → team_instances` WHERE `is_reserve = 0`; if none found skip silently (FR-029); otherwise build mention string and post to RSVP channel (FR-028)
+- [X] T022 [US5] Extend `schedule_attendance_round` to add last-notice `DateTrigger` job only when `rsvp_last_notice_hours > 0` (FR-030), and extend `cancel_round` to also remove `rsvp_last_notice_r{round_id}` in `src/services/scheduler_service.py`
+- [X] T023 [US5] Register `register_rsvp_last_notice_callback` and add skip-if-past re-arm logic on startup (do NOT fire retroactively if threshold already passed at restart, per FR-029 edge case) in `src/bot.py`
 
 **Checkpoint**: Last-notice ping sent only to correct drivers; skipped when all responded; not scheduled when disabled.
 
@@ -144,9 +144,9 @@ is 0.
 
 **Dependencies**: Depends on Phase 3 (US1) for T027/T028 (RSVP service callables must exist); depends on Phase 2 (Foundational) for T029 (`upsert_rsvp_status` must exist).
 
-- [ ] T027 Extend `_PHASE_PREFIX_MAP` in `src/services/scheduler_service.py` `get_pending_advance_jobs` to include `rsvp_notice` → phase 5, `rsvp_last_notice` → phase 6, `rsvp_deadline` → phase 7 (per research decision #9)
-- [ ] T028 Extend the `advance` dispatcher in `src/cogs/test_mode_cog.py` to handle phase numbers 5, 6, 7: call `run_rsvp_notice(round_id, bot)`, `run_rsvp_last_notice(round_id, bot)`, `run_rsvp_deadline(round_id, bot)` respectively
-- [ ] T029 Implement `/test-mode rsvp set-status` command in `src/cogs/test_mode_cog.py` (gated on test mode active): parameters `driver_id` (Discord user ID, mandatory), `status` (accepted/tentative/declined, mandatory), `division` (mandatory); locate `DriverRoundAttendance` row for the active round in that division; call `upsert_rsvp_status` with same `accepted_at` rules as a real button press; rebuild and edit the RSVP embed in-place (FR-031)
+- [X] T027 Extend `_PHASE_PREFIX_MAP` in `src/services/scheduler_service.py` `get_pending_advance_jobs` to include `rsvp_notice` → phase 5, `rsvp_last_notice` → phase 6, `rsvp_deadline` → phase 7 (per research decision #9)
+- [X] T028 Extend the `advance` dispatcher in `src/cogs/test_mode_cog.py` to handle phase numbers 5, 6, 7: call `run_rsvp_notice(round_id, bot)`, `run_rsvp_last_notice(round_id, bot)`, `run_rsvp_deadline(round_id, bot)` respectively
+- [X] T029 Implement `/test-mode rsvp set-status` command in `src/cogs/test_mode_cog.py` (gated on test mode active): parameters `driver_id` (Discord user ID, mandatory), `status` (accepted/tentative/declined, mandatory), `division` (mandatory); locate `DriverRoundAttendance` row for the active round in that division; call `upsert_rsvp_status` with same `accepted_at` rules as a real button press; rebuild and edit the RSVP embed in-place (FR-031)
 
 **Checkpoint**: `/test-mode advance` fires RSVP jobs in correct scheduled order; `/test-mode rsvp set-status` allows fake-driver status management for test validation.
 
@@ -156,8 +156,8 @@ is 0.
 
 **Purpose**: Unit tests and integration validation.
 
-- [ ] T024 [P] Write `tests/unit/test_rsvp_service.py`: distribution algorithm unit tests (priority ordering, tie-breaking with standings, tie-breaking with fallback, accepted_at timestamp ordering, standby classification, no-announcement when no reserves accepted); service method CRUD round-trips
-- [ ] T025 [P] Write `tests/unit/test_rsvp_embed_builder.py`: embed content unit tests (title format, Mystery bypass, status indicator strings for all four statuses, per-team roster grouping)
+- [X] T024 [P] Write `tests/unit/test_rsvp_service.py`: distribution algorithm unit tests (priority ordering, tie-breaking with standings, tie-breaking with fallback, accepted_at timestamp ordering, standby classification, no-announcement when no reserves accepted); service method CRUD round-trips
+- [X] T025 [P] Write `tests/unit/test_rsvp_embed_builder.py`: embed content unit tests (title format, Mystery bypass, status indicator strings for all four statuses, per-team roster grouping)
 - [ ] T026 Run quickstart.md validation end-to-end using test mode: enable test mode, add fake roster via `/test-mode roster add`, approve season, use `/test-mode advance` to fire notice job (phase 5), use `/test-mode rsvp set-status` to set RSVP statuses for fake drivers, use `/test-mode advance` to fire last-notice job (phase 6) and deadline job (phase 7); confirm all outputs match quickstart expectations (FR-031, constitution §XIII test mode clause)
 
 ---

--- a/specs/032-attendance-rsvp-checkin/tasks.md
+++ b/specs/032-attendance-rsvp-checkin/tasks.md
@@ -1,0 +1,251 @@
+# Tasks: Attendance RSVP Check-in & Reserve Distribution
+
+**Input**: Design documents from `specs/032-attendance-rsvp-checkin/`
+**Prerequisites**: plan.md ✅ spec.md ✅ research.md ✅ data-model.md ✅ quickstart.md ✅
+
+## Format: `[ID] [P?] [Story?] Description`
+
+- **[P]**: Can run in parallel (different files, no blocking dependency on concurrent task)
+- **[Story]**: Which user story (US1–US5) — setup/foundational/polish phases have no story label
+- Exact file paths included in all task descriptions
+
+---
+
+## Phase 1: Setup
+
+**Purpose**: Database migration that all subsequent work depends on.
+
+- [ ] T001 Create `src/db/migrations/031_attendance_rsvp.sql` with `driver_round_attendance` and `rsvp_embed_messages` tables per data-model.md
+
+**Checkpoint**: Migration exists and is applied by the migration runner on next bot start.
+
+---
+
+## Phase 2: Foundational (Blocking Prerequisites)
+
+**Purpose**: New dataclasses and CRUD methods needed by every user story.
+
+**⚠️ CRITICAL**: No user story work can begin until this phase is complete.
+
+- [ ] T002 Add `DriverRoundAttendance` and `RsvpEmbedMessage` dataclasses to `src/models/attendance.py`
+- [ ] T003 Add `driver_round_attendance` CRUD to `src/services/attendance_service.py`: `bulk_insert_attendance_rows`, `upsert_rsvp_status`, `get_attendance_rows`, `get_attendance_row_for_driver`
+- [ ] T004 Add `rsvp_embed_messages` CRUD to `src/services/attendance_service.py`: `insert_embed_message`, `get_embed_message`, `get_all_active_embed_messages`
+
+**Checkpoint**: Foundation ready — all data access methods available; user story implementation can begin.
+
+---
+
+## Phase 3: User Story 1 — Automated RSVP Embed Posting (Priority: P1) 🎯 MVP
+
+**Goal**: Season approval schedules the RSVP notice job per non-Mystery round. When the job
+fires, the bot posts the RSVP embed to the division's RSVP channel with the full driver
+roster and three action buttons, creates `DriverRoundAttendance` rows for all division
+drivers, and stores the message ID for future edits.
+
+**Independent Test**: Configure a round with a known `scheduled_at`, set `rsvp_notice_days`
+so the notice threshold is imminent, confirm the embed appears in the RSVP channel with the
+correct title, Discord timestamp, location, event type, full per-team roster with `()`
+indicators for all drivers, and three action buttons. Confirm `driver_round_attendance` rows
+exist with `NO_RSVP` status. Confirm `rsvp_embed_messages` has one row with the correct
+`message_id`.
+
+- [ ] T005 [P] [US1] Create `src/services/rsvp_service.py` with `build_rsvp_embed` function: title format `Season N Round N — <track>`, Discord timestamp field, location + event type fields, per-team roster with status indicators `()` / `(✅)` / `(❓)` / `(❌)` per FR-003–FR-005
+- [ ] T006 [P] [US1] Add `_rsvp_notice_job(round_id)` module-level async callable and `register_rsvp_notice_callback` method to `src/services/scheduler_service.py` following the `_phase_job` / `_mystery_notice_job` pattern
+- [ ] T007 [US1] Add `schedule_attendance_round(rnd, cfg)` method with `DateTrigger` for notice job and extend `cancel_round` to also remove `rsvp_notice_r{round_id}` in `src/services/scheduler_service.py`
+- [ ] T008 [US1] Implement `run_rsvp_notice(round_id)` in `src/services/rsvp_service.py`: query full-time + reserve roster via `driver_season_assignments → team_seats → team_instances`, call `build_rsvp_embed`, post to RSVP channel, bulk-insert `driver_round_attendance` rows, store `message_id` + `channel_id` in `rsvp_embed_messages`; skip + audit log if no RSVP channel (FR-008); bypass if Mystery round (FR-002)
+- [ ] T009 [US1] Extend `_do_approve` in `src/cogs/season_cog.py` to call `scheduler_service.schedule_attendance_round(rnd, att_cfg)` for each non-Mystery round when attendance module is enabled, following the existing `is_weather_enabled` / `is_results_enabled` guard pattern
+- [ ] T010 [US1] Register `register_rsvp_notice_callback` and add `rsvp_embed_messages` view re-arm loop (`bot.add_view(RsvpView(), message_id=row.message_id)` for all active rows) in `src/bot.py` startup block
+
+**Checkpoint**: End-to-end US1 flow works — approval schedules job, job fires, embed posted, rows created.
+
+---
+
+## Phase 4: User Story 2 — Driver RSVP Button Interaction (Priority: P1)
+
+**Goal**: Registered drivers (full-time or reserve) press a button on the RSVP embed, their
+status is persisted in `driver_round_attendance`, and the embed updates in-place. Non-members
+receive an ephemeral error. Pressing the same button twice is a no-op.
+
+**Independent Test**: Have a registered full-time driver and a registered reserve driver each
+press Accept, Tentative, and Decline. Verify the embed updates each time. Have an unregistered
+user press a button and verify the ephemeral error. Press the same button twice and verify
+the ephemeral acknowledgement and no DB change.
+
+- [ ] T011 [US2] Implement `RsvpView` class (`timeout=None`) with three `discord.ui.Button` components, `custom_id` values `rsvp_accept_r{round_id}`, `rsvp_tentative_r{round_id}`, `rsvp_decline_r{round_id}` in `src/cogs/attendance_cog.py`; extract `round_id` from `custom_id` prefix in each handler
+- [ ] T012 [US2] Add interaction logic to each button handler in `src/cogs/attendance_cog.py`: look up driver by Discord user ID in `driver_season_assignments`, reject non-members with ephemeral error (FR-011); check `rsvp_status` for no-op and reply ephemerally (FR-013); call `attendance_service.upsert_rsvp_status`; fetch message from `rsvp_embed_messages`; rebuild embed with `build_rsvp_embed` and edit message in-place (FR-010, FR-012)
+- [ ] T013 [US2] Add `bot.add_view(RsvpView())` to the persistent-views registration block in `src/bot.py`
+
+**Checkpoint**: Buttons work for valid members; non-members and no-ops handled correctly.
+
+---
+
+## Phase 5: User Story 3 — Reserve RSVP Extended Window (Priority: P2)
+
+**Goal**: Locking rules enforced at interaction time. Full-time drivers and accepted reserves
+lock at `rsvp_deadline_hours` threshold. Non-accepted reserves lock only at round start time.
+
+**Independent Test**: Simulate post-deadline interaction for a full-time driver (must be
+rejected), a reserve with ACCEPTED status (must be rejected), and a reserve with TENTATIVE
+status (must succeed until round start). Verify all three cases independently.
+
+- [ ] T014 [US3] Add locking evaluation at the start of each button handler in `src/cogs/attendance_cog.py`: query `round.scheduled_at` + `attendance_config.rsvp_deadline_hours`; if full-time driver and `now ≥ scheduled_at − deadline_hours`, reject with ephemeral error (FR-014); if reserve and ACCEPTED and `now ≥ scheduled_at − deadline_hours`, reject (FR-015); if reserve and NOT ACCEPTED and `now ≥ scheduled_at`, reject (FR-016); if `deadline_hours == 0`, treat all locks as round start (FR-017)
+
+**Checkpoint**: Locking rules enforced for all driver types; extended reserve window confirmed.
+
+---
+
+## Phase 6: User Story 4 — Reserve Distribution at RSVP Deadline (Priority: P2)
+
+**Goal**: Deadline job fires, runs the distribution algorithm against all accepted reserves
+and team RSVP states, writes `assigned_team_id` / `is_standby` to `driver_round_attendance`,
+disables embed buttons, posts assignment announcement to RSVP channel.
+
+**Independent Test**: Seed a round with some teams having NO_RSVP / DECLINED / TENTATIVE /
+ACCEPTED full-timers and multiple accepted reserves. Verify distribution output matches the
+priority order (NO_RSVP → DECLINED → TENTATIVE), tie-breaking by fewest accepted full-timers
+then by standings position, and reserve ordering by `accepted_at` timestamp. Verify standby
+classification when reserves exceed vacancies. Verify no announcement posted when no reserves
+accepted.
+
+- [ ] T015 [P] [US4] Implement `run_reserve_distribution(round_id, division_id)` in `src/services/rsvp_service.py`: query accepted reserves ordered by `accepted_at` ASC; rank candidate teams by priority tier (FR-020) then tie-break by accepted-full-timer count then by `team_standings_snapshots.standing_position` (most recent `round_id` in division, fallback to alphabetical by team name when no snapshot exists, FR-021); assign reserves to vacancies per FR-023; classify unplaced reserves as standby (FR-024); write `assigned_team_id` + `is_standby` to `driver_round_attendance`
+- [ ] T016 [P] [US4] Add `_rsvp_deadline_job(round_id)` module-level async callable and `register_rsvp_deadline_callback` method to `src/services/scheduler_service.py`
+- [ ] T017 [US4] Implement `run_rsvp_deadline(round_id)` in `src/services/rsvp_service.py`: call `run_reserve_distribution` per division; fetch `rsvp_embed_messages` rows and edit each embed to remove or disable buttons; post assignment announcement to RSVP channel if any reserves were eligible (FR-025, FR-026)
+- [ ] T018 [US4] Extend `schedule_attendance_round` to add deadline `DateTrigger` job and extend `cancel_round` to also remove `rsvp_deadline_r{round_id}` in `src/services/scheduler_service.py`
+- [ ] T019 [US4] Register `register_rsvp_deadline_callback` and add missed-deadline recovery on startup (run `run_rsvp_deadline` immediately for any round whose deadline has already passed while bot was offline, FR-027) in `src/bot.py`
+
+**Checkpoint**: Deadline job fires and produces correct distribution assignment; announcement posted; no announcement when no reserves.
+
+---
+
+## Phase 7: User Story 5 — Last-Notice Ping (Priority: P2)
+
+**Goal**: When `rsvp_last_notice_hours > 0`, a last-notice job fires and posts a single
+mention in the RSVP channel naming only full-time drivers still at NO_RSVP. Reserve drivers
+excluded. No message posted if all full-time drivers have responded. Job not created when
+`rsvp_last_notice_hours == 0`. If threshold already passed on restart, job silently skipped.
+
+**Independent Test**: Set `rsvp_last_notice_hours` to a non-zero value, have some full-time
+drivers respond and some not, fire the job, confirm only the non-responding full-time drivers
+are mentioned. Confirm no message when all have responded. Confirm no job created when value
+is 0.
+
+- [ ] T020 [P] [US5] Add `_rsvp_last_notice_job(round_id)` module-level async callable and `register_rsvp_last_notice_callback` method to `src/services/scheduler_service.py`
+- [ ] T021 [P] [US5] Implement `run_rsvp_last_notice(round_id)` in `src/services/rsvp_service.py`: query `driver_round_attendance` WHERE `rsvp_status = 'NO_RSVP'` joined to `driver_season_assignments → team_seats → team_instances` WHERE `is_reserve = 0`; if none found skip silently (FR-029); otherwise build mention string and post to RSVP channel (FR-028)
+- [ ] T022 [US5] Extend `schedule_attendance_round` to add last-notice `DateTrigger` job only when `rsvp_last_notice_hours > 0` (FR-030), and extend `cancel_round` to also remove `rsvp_last_notice_r{round_id}` in `src/services/scheduler_service.py`
+- [ ] T023 [US5] Register `register_rsvp_last_notice_callback` and add skip-if-past re-arm logic on startup (do NOT fire retroactively if threshold already passed at restart, per FR-029 edge case) in `src/bot.py`
+
+**Checkpoint**: Last-notice ping sent only to correct drivers; skipped when all responded; not scheduled when disabled.
+
+---
+
+## Phase 8: Polish & Tests
+
+**Purpose**: Unit tests and integration validation.
+
+- [ ] T024 [P] Write `tests/unit/test_rsvp_service.py`: distribution algorithm unit tests (priority ordering, tie-breaking with standings, tie-breaking with fallback, accepted_at timestamp ordering, standby classification, no-announcement when no reserves accepted); service method CRUD round-trips
+- [ ] T025 [P] Write `tests/unit/test_rsvp_embed_builder.py`: embed content unit tests (title format, Mystery bypass, status indicator strings for all four statuses, per-team roster grouping)
+- [ ] T026 Run quickstart.md validation end-to-end: apply migration, approve season, fire notice job manually, press buttons, fire last-notice job, fire deadline job; confirm all outputs match quickstart expectations
+
+---
+
+## Dependencies & Execution Order
+
+### Phase Dependencies
+
+- **Phase 1 (Setup)**: No dependencies — start immediately
+- **Phase 2 (Foundational)**: Depends on Phase 1 (migration must exist to code against schema)
+- **Phase 3 (US1)**: Depends on Phase 2 — RSVP embed service, scheduler job, and bot wiring
+- **Phase 4 (US2)**: Depends on Phase 3 — buttons need embed message IDs and DRA rows from US1
+- **Phase 5 (US3)**: Depends on Phase 4 — locking logic amends handlers created in US2
+- **Phase 6 (US4)**: Depends on Phase 2 + Phase 3 (scheduler infrastructure from US1, DRA rows); independent of US2/US3
+- **Phase 7 (US5)**: Depends on Phase 2 + Phase 3 (scheduler infrastructure from US1, DRA rows); independent of US2/US3/US4
+- **Phase 8 (Polish)**: Depends on all user story phases
+
+### User Story Dependencies
+
+- **US1 (P1)**: After Foundational — no other story dependency
+- **US2 (P1)**: After US1 — needs embed message IDs and DRA rows
+- **US3 (P2)**: After US2 — amends button handlers
+- **US4 (P2)**: After US1 — independent of US2/US3
+- **US5 (P2)**: After US1 — independent of US2/US3/US4
+
+### Within Each Phase
+
+- Tasks in the same file are sequential
+- Tasks marked [P] are in different files and can proceed concurrently
+- T005 (rsvp_service.py) and T006 (scheduler_service.py) can run in parallel
+- T015 (rsvp_service.py) and T016 (scheduler_service.py) can run in parallel
+- T020 (scheduler_service.py) and T021 (rsvp_service.py) can run in parallel
+- T024 and T025 (different test files) can run in parallel
+
+---
+
+## Parallel Execution Examples
+
+### Phase 3: US1 (after T002–T004 complete)
+
+```
+T005 build_rsvp_embed (rsvp_service.py)          ┐  parallel
+T006 _rsvp_notice_job callable (scheduler.py)    ┘
+    ↓
+T007 schedule_attendance_round (scheduler.py)
+T008 run_rsvp_notice (rsvp_service.py)
+    ↓
+T009 _do_approve extension (season_cog.py)
+T010 bot.py wiring
+```
+
+### Phase 6: US4 (after T010 complete)
+
+```
+T015 distribution algorithm (rsvp_service.py)    ┐  parallel
+T016 _rsvp_deadline_job callable (scheduler.py)  ┘
+    ↓
+T017 run_rsvp_deadline (rsvp_service.py)
+T018 extend schedule_attendance_round (scheduler.py)
+    ↓
+T019 bot.py wiring
+```
+
+### Phase 7: US5 (after T010 complete, can run alongside Phase 6)
+
+```
+T020 _rsvp_last_notice_job callable (scheduler.py) ┐  parallel
+T021 run_rsvp_last_notice (rsvp_service.py)        ┘
+    ↓
+T022 extend schedule_attendance_round (scheduler.py)
+T023 bot.py wiring
+```
+
+---
+
+## Implementation Strategy
+
+**MVP scope (Phase 1 → Phase 4)**: The bot posts RSVP embeds and drivers can respond via
+buttons. 18 tasks. Covers US1 + US2, the two P1 stories. Verifiable end-to-end without
+distribution or pings.
+
+**Full scope (Phase 1 → Phase 7)**: All 23 implementation tasks. US3 adds correct reserve
+locking; US4 adds distribution; US5 adds last-notice pings. US4 and US5 can be developed
+in parallel after US1 is complete.
+
+**Suggested order for solo developer**: Phase 1 → Phase 2 → Phase 3 (US1) → Phase 4 (US2)
+→ Phase 5 (US3) → Phase 6 (US4) → Phase 7 (US5) → Phase 8.
+
+---
+
+## Task Count Summary
+
+| Phase | Story | Tasks | Notes |
+|-------|-------|-------|-------|
+| Phase 1 | Setup | 1 | T001 |
+| Phase 2 | Foundational | 3 | T002–T004 |
+| Phase 3 | US1 (P1) | 6 | T005–T010 |
+| Phase 4 | US2 (P1) | 3 | T011–T013 |
+| Phase 5 | US3 (P2) | 1 | T014 |
+| Phase 6 | US4 (P2) | 5 | T015–T019 |
+| Phase 7 | US5 (P2) | 4 | T020–T023 |
+| Phase 8 | Polish | 3 | T024–T026 |
+| **Total** | | **26** | |
+
+**Parallel opportunities identified**: 5 (T005/T006, T015/T016, T020/T021, T024/T025, Phase 6+Phase 7 concurrent after US1)

--- a/src/bot.py
+++ b/src/bot.py
@@ -122,6 +122,22 @@ async def main() -> None:
 
         bot.scheduler_service.register_result_submission_callback(_result_submission_cb)
 
+        # Register RSVP attendance callbacks
+        from services.rsvp_service import run_rsvp_notice, run_rsvp_last_notice, run_rsvp_deadline
+
+        async def _rsvp_notice_cb(round_id: int) -> None:
+            await run_rsvp_notice(round_id, bot)
+
+        async def _rsvp_last_notice_cb(round_id: int) -> None:
+            await run_rsvp_last_notice(round_id, bot)
+
+        async def _rsvp_deadline_cb(round_id: int) -> None:
+            await run_rsvp_deadline(round_id, bot)
+
+        bot.scheduler_service.register_rsvp_notice_callback(_rsvp_notice_cb)
+        bot.scheduler_service.register_rsvp_last_notice_callback(_rsvp_last_notice_cb)
+        bot.scheduler_service.register_rsvp_deadline_callback(_rsvp_deadline_cb)
+
         # Register season-end callback (stored in _GLOBAL_SERVICE so the
         # module-level _season_end_job can reach it without pickling a closure)
         from services.season_end_service import execute_season_end as _execute_season_end
@@ -184,6 +200,10 @@ async def main() -> None:
 
         # Recover any season-end jobs that were lost during a restart
         await _recover_season_end_jobs(bot)
+
+        # Re-arm persistent RSVP embed views for all stored embed messages (T010)
+        # and run missed RSVP deadline jobs for rounds whose deadline already passed (T019)
+        await _recover_rsvp_views_and_deadlines(bot)
 
         # Wire wizard service bot reference (needed for guild/service access)
         bot.wizard_service.set_bot(bot)  # type: ignore[attr-defined]
@@ -256,6 +276,7 @@ async def main() -> None:
     )
     from cogs.admin_review_cog import AdminReviewView, CorrectionParameterView
     from services.penalty_wizard import PenaltyReviewView, ApprovalView, AppealsReviewView
+    from services.rsvp_service import RsvpView
 
     for _view in (
         SignupButtonView(),
@@ -270,6 +291,7 @@ async def main() -> None:
         PenaltyReviewView(),
         ApprovalView(),
         AppealsReviewView(),
+        RsvpView(),  # stub registration; message_id-specific re-arm done in _recover_rsvp_views_and_deadlines
     ):
         bot.add_view(_view)
 
@@ -354,6 +376,113 @@ async def _recover_season_end_jobs(bot: commands.Bot) -> None:
     could auto-fire execute_season_end for past-due seasons. That behaviour has
     been removed — league managers must explicitly run /season complete.
     """
+
+
+async def _recover_rsvp_views_and_deadlines(bot: commands.Bot) -> None:
+    """Re-arm RsvpView buttons and run missed RSVP deadline jobs on bot restart.
+
+    T010: Re-arm persistent RsvpView for every row in rsvp_embed_messages so
+    button interactions survive bot restarts (FR-007).
+
+    T019: For any round whose rsvp_deadline fire time has already passed but no
+    distribution has run (assessed by absence of assigned_team_id rows), run
+    run_rsvp_deadline immediately (FR-027).
+
+    T023: For any round whose rsvp_last_notice fire time has already passed,
+    silently skip — do NOT fire retroactively (FR-029 edge case).
+    """
+    from services.rsvp_service import RsvpView, run_rsvp_deadline
+    from db.database import get_connection as _gc
+    from datetime import datetime as _dt, timezone as _tz
+
+    # Re-arm all embed views by message_id so persistent buttons survive restarts
+    try:
+        embed_rows = await bot.attendance_service.get_all_embed_messages()  # type: ignore[attr-defined]
+    except Exception:
+        log.exception("_recover_rsvp_views_and_deadlines: failed to fetch embed messages")
+        return
+
+    for row in embed_rows:
+        try:
+            bot.add_view(RsvpView(round_id=row.round_id), message_id=int(row.message_id))
+        except Exception as exc:
+            log.warning(
+                "_recover_rsvp_views_and_deadlines: could not re-arm view for msg %s: %s",
+                row.message_id, exc,
+            )
+
+    # Check for missed deadline jobs
+    now_utc = _dt.now(_tz.utc)
+    try:
+        async with _gc(bot.db_path) as db:  # type: ignore[attr-defined]
+            cur = await db.execute(
+                """
+                SELECT DISTINCT rem.round_id, rem.division_id,
+                       r.scheduled_at,
+                       ac.rsvp_deadline_hours
+                  FROM rsvp_embed_messages rem
+                  JOIN rounds r ON r.id = rem.round_id
+                  JOIN divisions d ON d.id = r.division_id
+                  JOIN seasons s ON s.id = d.season_id
+                  JOIN attendance_config ac ON ac.server_id = s.server_id
+                 WHERE r.status = 'ACTIVE'
+                   AND s.status = 'ACTIVE'
+                """
+            )
+            round_rows = await cur.fetchall()
+    except Exception:
+        log.exception("_recover_rsvp_views_and_deadlines: failed to fetch rounds for deadline check")
+        return
+
+    for rrow in round_rows:
+        scheduled_at_raw = rrow["scheduled_at"]
+        try:
+            if isinstance(scheduled_at_raw, str):
+                scheduled_at = _dt.fromisoformat(scheduled_at_raw)
+            else:
+                scheduled_at = scheduled_at_raw
+            if scheduled_at.tzinfo is None:
+                scheduled_at = scheduled_at.replace(tzinfo=_tz.utc)
+        except (ValueError, TypeError):
+            continue
+
+        deadline_hours = rrow["rsvp_deadline_hours"] or 0
+        from datetime import timedelta as _td
+        deadline_at = scheduled_at - _td(hours=deadline_hours)
+
+        if deadline_at <= now_utc:
+            # Deadline has passed — check if distribution already ran
+            round_id = rrow["round_id"]
+            division_id = rrow["division_id"]
+            try:
+                async with _gc(bot.db_path) as db:
+                    cur = await db.execute(
+                        """
+                        SELECT COUNT(*) AS cnt
+                          FROM driver_round_attendance
+                         WHERE round_id = ?
+                           AND division_id = ?
+                           AND (assigned_team_id IS NOT NULL OR is_standby = 1)
+                        """,
+                        (round_id, division_id),
+                    )
+                    row = await cur.fetchone()
+                already_ran = row is not None and row["cnt"] > 0
+            except Exception:
+                already_ran = False
+
+            if not already_ran:
+                log.info(
+                    "_recover_rsvp_views_and_deadlines: running missed deadline for round %d / division %d",
+                    round_id, division_id,
+                )
+                try:
+                    await run_rsvp_deadline(round_id, bot)
+                except Exception:
+                    log.exception(
+                        "_recover_rsvp_views_and_deadlines: deadline run failed for round %d",
+                        round_id,
+                    )
 
 
 async def _recover_orphaned_submission_channels(bot: commands.Bot) -> None:

--- a/src/cogs/attendance_cog.py
+++ b/src/cogs/attendance_cog.py
@@ -2,7 +2,7 @@
 from __future__ import annotations
 
 import logging
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 
 import discord
 from discord import app_commands
@@ -323,3 +323,206 @@ class AttendanceCog(commands.Cog):
         else:
             msg = f"\u2705 Auto-reserve threshold set to **{value}** point(s)."
         await interaction.followup.send(msg, ephemeral=True)
+
+
+# ── RSVP button interaction handler (T011 / T012 / T014) ─────────────────────
+
+# Status string mapped from button action name
+_ACTION_TO_STATUS = {
+    "accept":   "ACCEPTED",
+    "tentative": "TENTATIVE",
+    "decline":  "DECLINED",
+}
+
+_STATUS_LABELS = {
+    "ACCEPTED":  "✅ Accepted",
+    "TENTATIVE": "❓ Tentative",
+    "DECLINED":  "❌ Declined",
+    "NO_RSVP":   "(no response)",
+}
+
+
+async def handle_rsvp_button(interaction: discord.Interaction, custom_id: str) -> None:
+    """Handle an RSVP button press.
+
+    This function is called by _RsvpButton.callback in rsvp_service.py.
+    It performs all validation, locking, DB updates, and embed refresh.
+    """
+    # Parse action and round_id from custom_id: rsvp_{action}_r{round_id}
+    try:
+        # Strip "rsvp_" prefix, then split off "_r{round_id}" suffix
+        without_prefix = custom_id[len("rsvp_"):]       # e.g. "accept_r42"
+        action_part, round_id_str = without_prefix.rsplit("_r", 1)
+        round_id = int(round_id_str)
+        action = action_part  # "accept" | "tentative" | "decline"
+    except (ValueError, IndexError):
+        log.error("handle_rsvp_button: could not parse custom_id=%r", custom_id)
+        await interaction.response.send_message(
+            "❌ Internal error: invalid button ID.", ephemeral=True
+        )
+        return
+
+    new_status = _ACTION_TO_STATUS.get(action)
+    if new_status is None:
+        await interaction.response.send_message(
+            "❌ Internal error: unknown action.", ephemeral=True
+        )
+        return
+
+    bot = interaction.client
+    discord_user_id = interaction.user.id
+    guild_id: int = interaction.guild_id  # type: ignore[assignment]
+
+    # Look up driver profile by Discord user ID (FR-011)
+    async with get_connection(bot.db_path) as db:  # type: ignore[attr-defined]
+        cur = await db.execute(
+            "SELECT id FROM driver_profiles WHERE server_id = ? AND CAST(discord_user_id AS INTEGER) = ?",
+            (guild_id, discord_user_id),
+        )
+        profile_row = await cur.fetchone()
+
+        if profile_row is None:
+            await interaction.response.send_message(
+                "❌ You are not registered as a driver in this server.", ephemeral=True
+            )
+            return
+        driver_profile_id: int = profile_row["id"]
+
+        # Get round info
+        cur = await db.execute(
+            """
+            SELECT r.division_id, r.scheduled_at, r.format,
+                   ac.rsvp_deadline_hours
+              FROM rounds r
+              JOIN divisions d ON d.id = r.division_id
+              JOIN seasons s ON s.id = d.season_id
+              JOIN attendance_config ac ON ac.server_id = s.server_id
+             WHERE r.id = ?
+            """,
+            (round_id,),
+        )
+        round_row = await cur.fetchone()
+
+    if round_row is None:
+        await interaction.response.send_message(
+            "❌ This round no longer exists.", ephemeral=True
+        )
+        return
+
+    division_id: int = round_row["division_id"]
+
+    # Verify the driver is in this division (full-time or reserve) (FR-011)
+    async with get_connection(bot.db_path) as db:  # type: ignore[attr-defined]
+        cur = await db.execute(
+            """
+            SELECT ti.is_reserve
+              FROM driver_season_assignments dsa
+              JOIN team_seats ts ON ts.driver_profile_id = dsa.driver_profile_id
+              JOIN team_instances ti ON ti.id = ts.team_instance_id
+                                    AND ti.division_id = dsa.division_id
+             WHERE dsa.driver_profile_id = ?
+               AND dsa.division_id = ?
+            """,
+            (driver_profile_id, division_id),
+        )
+        assignment_row = await cur.fetchone()
+
+    if assignment_row is None:
+        await interaction.response.send_message(
+            "❌ You are not a member of this division.", ephemeral=True
+        )
+        return
+
+    is_reserve: bool = bool(assignment_row["is_reserve"])
+
+    # Parse scheduled_at and compute locking (FR-014 / FR-015 / FR-016 / FR-017)
+    scheduled_at_raw = round_row["scheduled_at"]
+    if isinstance(scheduled_at_raw, str):
+        scheduled_at = datetime.fromisoformat(scheduled_at_raw)
+    else:
+        scheduled_at = scheduled_at_raw  # type: ignore[assignment]
+    if scheduled_at.tzinfo is None:
+        scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
+
+    deadline_hours: int = round_row["rsvp_deadline_hours"] or 0
+    now = datetime.now(timezone.utc)
+
+    # Get current rsvp_status for locking check
+    async with get_connection(bot.db_path) as db:  # type: ignore[attr-defined]
+        cur = await db.execute(
+            """
+            SELECT rsvp_status FROM driver_round_attendance
+             WHERE round_id = ? AND division_id = ? AND driver_profile_id = ?
+            """,
+            (round_id, division_id, driver_profile_id),
+        )
+        dra_row = await cur.fetchone()
+
+    current_status: str = dra_row["rsvp_status"] if dra_row is not None else "NO_RSVP"
+
+    # Compute lock threshold
+    if deadline_hours > 0:
+        lock_deadline_at = scheduled_at - timedelta(hours=deadline_hours)
+    else:
+        lock_deadline_at = scheduled_at  # FR-017: treat as round start
+
+    if not is_reserve:
+        # Full-time: locked after deadline (FR-014)
+        if now >= lock_deadline_at:
+            await interaction.response.send_message(
+                "❌ The RSVP deadline has passed. Your response cannot be changed.",
+                ephemeral=True,
+            )
+            return
+    else:
+        if current_status == "ACCEPTED":
+            # Reserve with ACCEPTED: locked after deadline too (FR-015)
+            if now >= lock_deadline_at:
+                await interaction.response.send_message(
+                    "❌ You have already accepted and the RSVP deadline has passed. "
+                    "Your response cannot be changed.",
+                    ephemeral=True,
+                )
+                return
+        else:
+            # Reserve not-ACCEPTED: locked only at round start (FR-016)
+            if now >= scheduled_at:
+                await interaction.response.send_message(
+                    "❌ The round has started. Your response cannot be changed.",
+                    ephemeral=True,
+                )
+                return
+
+    # No-op check (FR-013)
+    if current_status == new_status:
+        label = _STATUS_LABELS.get(new_status, new_status)
+        await interaction.response.send_message(
+            f"ℹ️ You are already marked as **{label}**.", ephemeral=True
+        )
+        return
+
+    # Upsert status
+    await bot.attendance_service.upsert_rsvp_status(  # type: ignore[attr-defined]
+        round_id=round_id,
+        division_id=division_id,
+        driver_profile_id=driver_profile_id,
+        status=new_status,
+    )
+
+    # Rebuild and edit embed in-place (FR-010 / FR-012)
+    from services.rsvp_service import _rebuild_embed_for_round, RsvpView
+    embed_row = await bot.attendance_service.get_embed_message(round_id, division_id)  # type: ignore[attr-defined]
+    if embed_row is not None:
+        channel = bot.get_channel(int(embed_row.channel_id))
+        if channel is not None:
+            try:
+                msg = await channel.fetch_message(int(embed_row.message_id))
+                new_embed = await _rebuild_embed_for_round(round_id, division_id, bot)
+                await msg.edit(embed=new_embed, view=RsvpView(round_id=round_id))
+            except discord.HTTPException as exc:
+                log.error("handle_rsvp_button: failed to edit embed: %s", exc)
+
+    label = _STATUS_LABELS.get(new_status, new_status)
+    await interaction.response.send_message(
+        f"✅ Your RSVP has been updated to **{label}**.", ephemeral=True
+    )

--- a/src/cogs/season_cog.py
+++ b/src/cogs/season_cog.py
@@ -2886,6 +2886,16 @@ class SeasonCog(commands.Cog):
             if server_config is None or not server_config.test_mode_active:
                 self.bot.scheduler_service.schedule_result_submission_jobs(all_rounds)
 
+        if await self.bot.module_service.is_attendance_enabled(cfg.server_id):
+            _att_cfg = await self.bot.attendance_service.get_or_create_config(cfg.server_id)
+            for _rnd in all_rounds:
+                self.bot.scheduler_service.schedule_attendance_round(
+                    _rnd,
+                    notice_days=_att_cfg.rsvp_notice_days,
+                    last_notice_hours=_att_cfg.rsvp_last_notice_hours,
+                    deadline_hours=_att_cfg.rsvp_deadline_hours,
+                )
+
         # Only transition to ACTIVE after scheduling succeeds
         await season_svc.transition_to_active(cfg.season_id)
 

--- a/src/cogs/test_mode_cog.py
+++ b/src/cogs/test_mode_cog.py
@@ -260,6 +260,105 @@ class TestModeCog(commands.Cog):
             asyncio.create_task(run_result_submission_job(entry["round_id"], self.bot))
             return
 
+        # ── RSVP notice (phase_number=5) ─────────────────────────────────────────
+        if phase_number == 5:
+            from services.rsvp_service import run_rsvp_notice
+            if entry["job_id"] is not None:
+                self.bot.scheduler_service.cancel_job(entry["job_id"])  # type: ignore[attr-defined]
+            try:
+                await run_rsvp_notice(entry["round_id"], self.bot)
+            except Exception:
+                log.exception(
+                    "Test mode advance: unhandled error in rsvp_notice for round_id=%d",
+                    entry["round_id"],
+                )
+                await interaction.followup.send(
+                    f"❌ An internal error occurred while firing the RSVP notice for "
+                    f"**{entry['division_name']}** — **Round {entry['round_number']}**. "
+                    "Check the bot logs for details.",
+                    ephemeral=True,
+                )
+                return
+            await interaction.followup.send(
+                f"📨 Fired **RSVP notice** for "
+                f"**{entry['division_name']}** — **Round {entry['round_number']}** "
+                f"(**{entry['track_name']}**). Embed posted to the RSVP channel.",
+                ephemeral=True,
+            )
+            await self.bot.output_router.post_log(
+                interaction.guild_id,
+                f"{interaction.user.display_name} (<@{interaction.user.id}>) | /test-mode advance | Success\n"
+                f"  phase: rsvp_notice\n"
+                f"  division: {entry['division_name']}\n"
+                f"  round: {entry['round_number']}",
+            )
+            return
+
+        # ── RSVP last-notice (phase_number=6) ────────────────────────────────────
+        if phase_number == 6:
+            from services.rsvp_service import run_rsvp_last_notice
+            if entry["job_id"] is not None:
+                self.bot.scheduler_service.cancel_job(entry["job_id"])  # type: ignore[attr-defined]
+            try:
+                await run_rsvp_last_notice(entry["round_id"], self.bot)
+            except Exception:
+                log.exception(
+                    "Test mode advance: unhandled error in rsvp_last_notice for round_id=%d",
+                    entry["round_id"],
+                )
+                await interaction.followup.send(
+                    f"❌ An internal error occurred while firing the RSVP last-notice for "
+                    f"**{entry['division_name']}** — **Round {entry['round_number']}**.",
+                    ephemeral=True,
+                )
+                return
+            await interaction.followup.send(
+                f"⏰ Fired **RSVP last-notice** for "
+                f"**{entry['division_name']}** — **Round {entry['round_number']}**.",
+                ephemeral=True,
+            )
+            await self.bot.output_router.post_log(
+                interaction.guild_id,
+                f"{interaction.user.display_name} (<@{interaction.user.id}>) | /test-mode advance | Success\n"
+                f"  phase: rsvp_last_notice\n"
+                f"  division: {entry['division_name']}\n"
+                f"  round: {entry['round_number']}",
+            )
+            return
+
+        # ── RSVP deadline (phase_number=7) ────────────────────────────────────────
+        if phase_number == 7:
+            from services.rsvp_service import run_rsvp_deadline
+            if entry["job_id"] is not None:
+                self.bot.scheduler_service.cancel_job(entry["job_id"])  # type: ignore[attr-defined]
+            try:
+                await run_rsvp_deadline(entry["round_id"], self.bot)
+            except Exception:
+                log.exception(
+                    "Test mode advance: unhandled error in rsvp_deadline for round_id=%d",
+                    entry["round_id"],
+                )
+                await interaction.followup.send(
+                    f"❌ An internal error occurred while firing the RSVP deadline for "
+                    f"**{entry['division_name']}** — **Round {entry['round_number']}**.",
+                    ephemeral=True,
+                )
+                return
+            await interaction.followup.send(
+                f"🏁 Fired **RSVP deadline** for "
+                f"**{entry['division_name']}** — **Round {entry['round_number']}**. "
+                f"Reserve distribution complete.",
+                ephemeral=True,
+            )
+            await self.bot.output_router.post_log(
+                interaction.guild_id,
+                f"{interaction.user.display_name} (<@{interaction.user.id}>) | /test-mode advance | Success\n"
+                f"  phase: rsvp_deadline\n"
+                f"  division: {entry['division_name']}\n"
+                f"  round: {entry['round_number']}",
+            )
+            return
+
         # ── Normal weather phase dispatch ───────────────────────────────────────
         phase_runners = {1: run_phase1, 2: run_phase2, 3: run_phase3}
         runner = phase_runners[phase_number]
@@ -573,3 +672,159 @@ class TestModeCog(commands.Cog):
             )
 
     # (submit-results removed — use /test-mode advance which now handles result submission)
+
+    # ------------------------------------------------------------------
+    # /test-mode rsvp (subgroup) — T029
+    # ------------------------------------------------------------------
+
+    rsvp = app_commands.Group(
+        name="rsvp",
+        description="Test-mode RSVP utilities.",
+        parent=test_mode,
+        guild_only=True,
+        default_permissions=None,
+    )
+
+    # /test-mode rsvp set-status ------------------------------------------
+
+    @rsvp.command(
+        name="set-status",
+        description="Manually set a driver's RSVP status (test mode only).",
+    )
+    @app_commands.describe(
+        driver_id="Discord user ID of the driver to update.",
+        status="RSVP status to set (accepted / tentative / declined).",
+        division="Division name whose active RSVP round to update.",
+    )
+    @app_commands.choices(status=[
+        app_commands.Choice(name="accepted",  value="ACCEPTED"),
+        app_commands.Choice(name="tentative", value="TENTATIVE"),
+        app_commands.Choice(name="declined",  value="DECLINED"),
+    ])
+    @channel_guard
+    @admin_only
+    async def rsvp_set_status(
+        self,
+        interaction: discord.Interaction,
+        driver_id: str,
+        status: app_commands.Choice[str],
+        division: str,
+    ) -> None:
+        config = await self.bot.config_service.get_server_config(  # type: ignore[attr-defined]
+            interaction.guild_id
+        )
+        if config is None or not config.test_mode_active:
+            await interaction.response.send_message(
+                "ℹ️ Test mode is not active.", ephemeral=True
+            )
+            return
+
+        await interaction.response.defer(ephemeral=True)
+
+        guild_id: int = interaction.guild_id  # type: ignore[assignment]
+        new_status: str = status.value
+
+        # Resolve driver_profile_id from the given Discord user ID
+        try:
+            discord_uid = int(driver_id)
+        except ValueError:
+            await interaction.followup.send(
+                "❌ `driver_id` must be a numeric Discord user ID.", ephemeral=True
+            )
+            return
+
+        from db.database import get_connection as _gc
+
+        async with _gc(self.bot.db_path) as db:  # type: ignore[attr-defined]
+            cur = await db.execute(
+                "SELECT id FROM driver_profiles WHERE server_id = ? AND CAST(discord_user_id AS INTEGER) = ?",
+                (guild_id, discord_uid),
+            )
+            profile_row = await cur.fetchone()
+
+        if profile_row is None:
+            await interaction.followup.send(
+                f"❌ No driver profile found for user ID `{driver_id}`.", ephemeral=True
+            )
+            return
+        driver_profile_id: int = profile_row["id"]
+
+        # Resolve division_id by name in the active season
+        async with _gc(self.bot.db_path) as db:
+            cur = await db.execute(
+                """
+                SELECT d.id AS division_id
+                  FROM divisions d
+                  JOIN seasons s ON s.id = d.season_id
+                 WHERE s.server_id = ? AND s.status = 'ACTIVE'
+                   AND LOWER(d.name) = LOWER(?)
+                """,
+                (guild_id, division),
+            )
+            div_row = await cur.fetchone()
+
+        if div_row is None:
+            await interaction.followup.send(
+                f"❌ Division **{division}** not found in the active season.", ephemeral=True
+            )
+            return
+        division_id: int = div_row["division_id"]
+
+        # Find the active RSVP embed row for this division (a round that has an embed)
+        embed_row = await self.bot.attendance_service.get_all_embed_messages()  # type: ignore[attr-defined]
+        target_embed = next(
+            (r for r in embed_row if r.division_id == division_id),
+            None,
+        )
+        if target_embed is None:
+            await interaction.followup.send(
+                f"❌ No active RSVP embed found for division **{division}**.", ephemeral=True
+            )
+            return
+        round_id: int = target_embed.round_id
+
+        # Verify the driver has a DRA row for this round
+        dra = await self.bot.attendance_service.get_attendance_row_for_driver(  # type: ignore[attr-defined]
+            round_id=round_id,
+            division_id=division_id,
+            driver_profile_id=driver_profile_id,
+        )
+        if dra is None:
+            await interaction.followup.send(
+                f"❌ Driver `{driver_id}` has no attendance row for this round. "
+                "Run `/test-mode advance` to fire the RSVP notice first.",
+                ephemeral=True,
+            )
+            return
+
+        # Apply the status update (same accepted_at logic as a real button press)
+        await self.bot.attendance_service.upsert_rsvp_status(  # type: ignore[attr-defined]
+            round_id=round_id,
+            division_id=division_id,
+            driver_profile_id=driver_profile_id,
+            status=new_status,
+        )
+
+        # Rebuild and edit the RSVP embed in-place
+        from services.rsvp_service import _rebuild_embed_for_round, RsvpView
+        channel = self.bot.get_channel(int(target_embed.channel_id))
+        if channel is not None:
+            try:
+                msg = await channel.fetch_message(int(target_embed.message_id))
+                new_embed = await _rebuild_embed_for_round(round_id, division_id, self.bot)
+                await msg.edit(embed=new_embed, view=RsvpView(round_id=round_id))
+            except Exception as exc:
+                log.warning("rsvp_set_status: failed to edit embed: %s", exc)
+
+        await interaction.followup.send(
+            f"✅ Set RSVP status for `{driver_id}` in **{division}** to **{new_status.lower()}**.",
+            ephemeral=True,
+        )
+        await self.bot.output_router.post_log(
+            interaction.guild_id,
+            f"{interaction.user.display_name} (<@{interaction.user.id}>) | /test-mode rsvp set-status | Success\n"
+            f"  driver_id: {driver_id}\n"
+            f"  division: {division}\n"
+            f"  status: {new_status}\n"
+            f"  round_id: {round_id}",
+        )

--- a/src/db/migrations/031_attendance_rsvp.sql
+++ b/src/db/migrations/031_attendance_rsvp.sql
@@ -1,0 +1,35 @@
+-- Migration 031: Attendance RSVP check-in tables
+-- Creates driver_round_attendance and rsvp_embed_messages tables.
+
+CREATE TABLE IF NOT EXISTS driver_round_attendance (
+    id                 INTEGER PRIMARY KEY AUTOINCREMENT,
+    round_id           INTEGER NOT NULL
+                           REFERENCES rounds(id)
+                           ON DELETE CASCADE,
+    division_id        INTEGER NOT NULL
+                           REFERENCES divisions(id),
+    driver_profile_id  INTEGER NOT NULL
+                           REFERENCES driver_profiles(id),
+    rsvp_status        TEXT    NOT NULL DEFAULT 'NO_RSVP',
+    accepted_at        TEXT,
+    assigned_team_id   INTEGER REFERENCES team_instances(id),
+    is_standby         INTEGER NOT NULL DEFAULT 0,
+    attended           INTEGER,
+    UNIQUE (round_id, division_id, driver_profile_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dra_round_division
+    ON driver_round_attendance (round_id, division_id);
+
+CREATE TABLE IF NOT EXISTS rsvp_embed_messages (
+    id          INTEGER PRIMARY KEY AUTOINCREMENT,
+    round_id    INTEGER NOT NULL
+                    REFERENCES rounds(id)
+                    ON DELETE CASCADE,
+    division_id INTEGER NOT NULL
+                    REFERENCES divisions(id),
+    message_id  TEXT    NOT NULL,
+    channel_id  TEXT    NOT NULL,
+    posted_at   TEXT    NOT NULL,
+    UNIQUE (round_id, division_id)
+);

--- a/src/models/attendance.py
+++ b/src/models/attendance.py
@@ -24,3 +24,26 @@ class AttendanceDivisionConfig:
     server_id: int
     rsvp_channel_id: str | None
     attendance_channel_id: str | None
+
+
+@dataclass
+class DriverRoundAttendance:
+    id: int
+    round_id: int
+    division_id: int
+    driver_profile_id: int
+    rsvp_status: str        # NO_RSVP | ACCEPTED | TENTATIVE | DECLINED
+    accepted_at: str | None
+    assigned_team_id: int | None
+    is_standby: bool
+    attended: bool | None   # None until results submitted (future increment)
+
+
+@dataclass
+class RsvpEmbedMessage:
+    id: int
+    round_id: int
+    division_id: int
+    message_id: str
+    channel_id: str
+    posted_at: str

--- a/src/services/attendance_service.py
+++ b/src/services/attendance_service.py
@@ -1,8 +1,14 @@
 """AttendanceService — read/write attendance module configuration."""
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from db.database import get_connection
-from models.attendance import AttendanceConfig, AttendanceDivisionConfig
+from models.attendance import (
+    AttendanceConfig,
+    AttendanceDivisionConfig,
+    DriverRoundAttendance,
+    RsvpEmbedMessage,
+)
 
 
 def validate_timing_invariant(
@@ -193,3 +199,175 @@ class AttendanceService:
                 (value, server_id),
             )
             await db.commit()
+
+    # ── driver_round_attendance CRUD ───────────────────────────────────────
+
+    async def bulk_insert_attendance_rows(
+        self,
+        round_id: int,
+        division_id: int,
+        driver_profile_ids: list[int],
+    ) -> None:
+        """Insert NO_RSVP rows for every driver in the list (ignore if already exists)."""
+        async with get_connection(self._db_path) as db:
+            await db.executemany(
+                """
+                INSERT OR IGNORE INTO driver_round_attendance
+                    (round_id, division_id, driver_profile_id)
+                VALUES (?, ?, ?)
+                """,
+                [(round_id, division_id, dp_id) for dp_id in driver_profile_ids],
+            )
+            await db.commit()
+
+    async def upsert_rsvp_status(
+        self,
+        round_id: int,
+        division_id: int,
+        driver_profile_id: int,
+        status: str,
+    ) -> None:
+        """Update rsvp_status and manage accepted_at per FR-022.
+
+        - Transitioning TO 'ACCEPTED': set accepted_at to current UTC time.
+        - Re-accepting after a non-ACCEPTED status: reset accepted_at to current UTC time.
+        - Transitioning AWAY from 'ACCEPTED': set accepted_at to NULL.
+        """
+        now_iso = datetime.now(timezone.utc).isoformat()
+        if status == "ACCEPTED":
+            async with get_connection(self._db_path) as db:
+                await db.execute(
+                    """
+                    UPDATE driver_round_attendance
+                       SET rsvp_status = ?,
+                           accepted_at = ?
+                     WHERE round_id = ?
+                       AND division_id = ?
+                       AND driver_profile_id = ?
+                    """,
+                    (status, now_iso, round_id, division_id, driver_profile_id),
+                )
+                await db.commit()
+        else:
+            async with get_connection(self._db_path) as db:
+                await db.execute(
+                    """
+                    UPDATE driver_round_attendance
+                       SET rsvp_status = ?,
+                           accepted_at = NULL
+                     WHERE round_id = ?
+                       AND division_id = ?
+                       AND driver_profile_id = ?
+                    """,
+                    (status, round_id, division_id, driver_profile_id),
+                )
+                await db.commit()
+
+    async def get_attendance_rows(
+        self,
+        round_id: int,
+        division_id: int,
+    ) -> list[DriverRoundAttendance]:
+        """Return all DRA rows for a (round, division) pair."""
+        async with get_connection(self._db_path) as db:
+            cursor = await db.execute(
+                "SELECT * FROM driver_round_attendance WHERE round_id = ? AND division_id = ?",
+                (round_id, division_id),
+            )
+            rows = await cursor.fetchall()
+        return [_dra_from_row(r) for r in rows]
+
+    async def get_attendance_row_for_driver(
+        self,
+        round_id: int,
+        division_id: int,
+        driver_profile_id: int,
+    ) -> DriverRoundAttendance | None:
+        """Return the DRA row for a specific driver, or None if not found."""
+        async with get_connection(self._db_path) as db:
+            cursor = await db.execute(
+                """
+                SELECT * FROM driver_round_attendance
+                 WHERE round_id = ? AND division_id = ? AND driver_profile_id = ?
+                """,
+                (round_id, division_id, driver_profile_id),
+            )
+            row = await cursor.fetchone()
+        return _dra_from_row(row) if row is not None else None
+
+    # ── rsvp_embed_messages CRUD ───────────────────────────────────────────
+
+    async def insert_embed_message(
+        self,
+        round_id: int,
+        division_id: int,
+        message_id: str,
+        channel_id: str,
+    ) -> None:
+        """Store (or replace) the RSVP embed message IDs for a (round, division) pair."""
+        now_iso = datetime.now(timezone.utc).isoformat()
+        async with get_connection(self._db_path) as db:
+            await db.execute(
+                """
+                INSERT INTO rsvp_embed_messages (round_id, division_id, message_id, channel_id, posted_at)
+                VALUES (?, ?, ?, ?, ?)
+                ON CONFLICT(round_id, division_id)
+                DO UPDATE SET message_id = excluded.message_id,
+                              channel_id = excluded.channel_id,
+                              posted_at  = excluded.posted_at
+                """,
+                (round_id, division_id, message_id, channel_id, now_iso),
+            )
+            await db.commit()
+
+    async def get_embed_message(
+        self,
+        round_id: int,
+        division_id: int,
+    ) -> RsvpEmbedMessage | None:
+        """Return the embed message row for a (round, division) pair, or None."""
+        async with get_connection(self._db_path) as db:
+            cursor = await db.execute(
+                "SELECT * FROM rsvp_embed_messages WHERE round_id = ? AND division_id = ?",
+                (round_id, division_id),
+            )
+            row = await cursor.fetchone()
+        return _rem_from_row(row) if row is not None else None
+
+    async def get_all_embed_messages(self) -> list[RsvpEmbedMessage]:
+        """Return all rsvp_embed_messages rows unconditionally.
+
+        Locking is enforced at interaction time, not at view re-arm time.
+        """
+        async with get_connection(self._db_path) as db:
+            cursor = await db.execute("SELECT * FROM rsvp_embed_messages")
+            rows = await cursor.fetchall()
+        return [_rem_from_row(r) for r in rows]
+
+
+# ── Row-to-dataclass helpers ───────────────────────────────────────────────
+
+
+def _dra_from_row(row: object) -> DriverRoundAttendance:
+    return DriverRoundAttendance(
+        id=row["id"],
+        round_id=row["round_id"],
+        division_id=row["division_id"],
+        driver_profile_id=row["driver_profile_id"],
+        rsvp_status=row["rsvp_status"],
+        accepted_at=row["accepted_at"],
+        assigned_team_id=row["assigned_team_id"],
+        is_standby=bool(row["is_standby"]),
+        attended=bool(row["attended"]) if row["attended"] is not None else None,
+    )
+
+
+def _rem_from_row(row: object) -> RsvpEmbedMessage:
+    return RsvpEmbedMessage(
+        id=row["id"],
+        round_id=row["round_id"],
+        division_id=row["division_id"],
+        message_id=row["message_id"],
+        channel_id=row["channel_id"],
+        posted_at=row["posted_at"],
+    )

--- a/src/services/rsvp_service.py
+++ b/src/services/rsvp_service.py
@@ -1,0 +1,718 @@
+"""RSVP service — notice dispatch, last-notice, deadline, distribution, embed builder."""
+from __future__ import annotations
+
+import logging
+from datetime import datetime, timezone
+
+import discord
+
+from db.database import get_connection
+from models.round import RoundFormat
+
+log = logging.getLogger(__name__)
+
+# ── Status indicator strings ──────────────────────────────────────────────────
+
+_STATUS_INDICATOR = {
+    "NO_RSVP":   "()",
+    "ACCEPTED":  "(✅)",
+    "TENTATIVE": "(❓)",
+    "DECLINED":  "(❌)",
+}
+
+
+# ── Embed builder ─────────────────────────────────────────────────────────────
+
+
+def build_rsvp_embed(
+    season_number: int,
+    round_number: int,
+    track_name: str | None,
+    scheduled_at: datetime,
+    round_format: RoundFormat,
+    teams: list[dict],
+) -> discord.Embed:
+    """Build the RSVP embed for a round.
+
+    Args:
+        season_number: Integer season number for the embed title.
+        round_number:  Integer round number for the embed title.
+        track_name:    Canonical track name, or None for Mystery rounds.
+        scheduled_at:  Round start datetime (UTC-aware).
+        round_format:  RoundFormat enum value.
+        teams:         Ordered list of dicts with keys:
+                           - name (str): team display name
+                           - is_reserve (bool): True for the Reserve team
+                           - drivers (list of dict):
+                               - display_str (str): mention or test name
+                               - rsvp_status (str): NO_RSVP/ACCEPTED/TENTATIVE/DECLINED
+
+    Returns:
+        A discord.Embed ready to be posted or used to edit an existing message.
+    """
+    track_display = track_name or "Mystery"
+    title = f"Season {season_number} Round {round_number} — {track_display}"
+
+    # Dynamic Discord timestamp (full date + time format)
+    if scheduled_at.tzinfo is None:
+        scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
+    unix_ts = int(scheduled_at.timestamp())
+    timestamp_str = f"<t:{unix_ts}:F>"
+
+    format_labels = {
+        RoundFormat.NORMAL:    "Normal",
+        RoundFormat.SPRINT:    "Sprint",
+        RoundFormat.ENDURANCE: "Endurance",
+        RoundFormat.MYSTERY:   "Mystery",
+    }
+    event_type = format_labels.get(round_format, str(round_format))
+
+    embed = discord.Embed(title=title, color=discord.Color.red())
+    embed.add_field(name="📅 Date", value=timestamp_str, inline=True)
+    embed.add_field(name="📍 Location", value=track_display, inline=True)
+    embed.add_field(name="🏁 Event Type", value=event_type, inline=True)
+
+    # Per-team roster section
+    roster_lines: list[str] = []
+    for team in teams:
+        team_name = team["name"]
+        prefix = "*(Reserve)* " if team.get("is_reserve") else ""
+        roster_lines.append(f"**{prefix}{team_name}**")
+        drivers = team.get("drivers", [])
+        if drivers:
+            for d in drivers:
+                indicator = _STATUS_INDICATOR.get(d["rsvp_status"], "()")
+                roster_lines.append(f"  {d['display_str']} {indicator}")
+        else:
+            roster_lines.append("  *(no drivers)*")
+
+    if roster_lines:
+        embed.add_field(name="🧑‍🤝‍🧑 Driver Roster", value="\n".join(roster_lines), inline=False)
+
+    return embed
+
+
+class RsvpView(discord.ui.View):
+    """Persistent RSVP view — three action buttons (Accept / Tentative / Decline).
+
+    custom_id values embed the round_id so handlers can identify the target round
+    without querying an extra DB table.  Timeout=None keeps the view alive across
+    bot restarts when re-registered via bot.add_view().
+    """
+
+    def __init__(self, round_id: int = 0) -> None:
+        super().__init__(timeout=None)
+        self._round_id = round_id
+        # Buttons must be added dynamically so custom_ids include the round_id.
+        # discord.py requires custom_id to be set at construction for persistence.
+        self.add_item(_RsvpButton("accept",   round_id, "✅ Accept",   discord.ButtonStyle.success))
+        self.add_item(_RsvpButton("tentative", round_id, "❓ Tentative", discord.ButtonStyle.secondary))
+        self.add_item(_RsvpButton("decline",  round_id, "❌ Decline",  discord.ButtonStyle.danger))
+
+
+class _RsvpButton(discord.ui.Button):
+    def __init__(
+        self,
+        action: str,
+        round_id: int,
+        label: str,
+        style: discord.ButtonStyle,
+    ) -> None:
+        super().__init__(
+            label=label,
+            style=style,
+            custom_id=f"rsvp_{action}_r{round_id}",
+        )
+        self._action = action
+
+    async def callback(self, interaction: discord.Interaction) -> None:
+        # Delegate to the cog that handles RSVP button interactions.
+        # The cog is responsible for validation, DB updates, and embed editing.
+        from cogs.attendance_cog import handle_rsvp_button
+        await handle_rsvp_button(interaction, self.custom_id)
+
+
+# ── Roster query helper ───────────────────────────────────────────────────────
+
+
+async def query_division_roster(db_path: str, division_id: int) -> list[dict]:
+    """Return ordered team-driver roster for a division.
+
+    Returns a list of team dicts (ordered: non-reserve alphabetically, then Reserve last):
+        {
+            "id": int,
+            "name": str,
+            "is_reserve": bool,
+            "drivers": [{"driver_profile_id": int, "discord_user_id": str,
+                         "test_display_name": str | None}, ...]
+        }
+    """
+    async with get_connection(db_path) as db:
+        cursor = await db.execute(
+            """
+            SELECT ti.id        AS team_id,
+                   ti.name      AS team_name,
+                   ti.is_reserve,
+                   dp.id        AS driver_profile_id,
+                   dp.discord_user_id,
+                   dp.test_display_name
+              FROM team_instances ti
+              LEFT JOIN team_seats ts ON ts.team_instance_id = ti.id
+              LEFT JOIN driver_profiles dp ON dp.id = ts.driver_profile_id
+             WHERE ti.division_id = ?
+             ORDER BY ti.is_reserve ASC, ti.name ASC, dp.id ASC
+            """,
+            (division_id,),
+        )
+        rows = await cursor.fetchall()
+
+    teams: dict[int, dict] = {}
+    for row in rows:
+        tid = row["team_id"]
+        if tid not in teams:
+            teams[tid] = {
+                "id": tid,
+                "name": row["team_name"],
+                "is_reserve": bool(row["is_reserve"]),
+                "drivers": [],
+            }
+        if row["driver_profile_id"] is not None:
+            teams[tid]["drivers"].append(
+                {
+                    "driver_profile_id": row["driver_profile_id"],
+                    "discord_user_id": str(row["discord_user_id"]),
+                    "test_display_name": row["test_display_name"],
+                }
+            )
+    # Sort: non-reserve teams first (alphabetical), Reserve last
+    return sorted(teams.values(), key=lambda t: (t["is_reserve"], t["name"].lower()))
+
+
+def _driver_display_str(driver: dict) -> str:
+    """Return a display string for a driver — test name or Discord mention."""
+    if driver.get("test_display_name"):
+        return driver["test_display_name"]
+    return f"<@{driver['discord_user_id']}>"
+
+
+# ── run_rsvp_notice ───────────────────────────────────────────────────────────
+
+
+async def run_rsvp_notice(round_id: int, bot) -> None:  # type: ignore[type-arg]
+    """Post the RSVP embed for *round_id* to all configured RSVP channels.
+
+    Called by the APScheduler job (and by /test-mode advance for phase 5).
+
+    Steps per division:
+    1. Skip if no RSVP channel configured (FR-008) — log audit entry.
+    2. Query roster for division.
+    3. Build embed.
+    4. Post to RSVP channel.
+    5. Bulk-insert driver_round_attendance rows (all drivers NO_RSVP).
+    6. Store message_id + channel_id in rsvp_embed_messages.
+    """
+    async with get_connection(bot.db_path) as db:
+        # Get round details
+        cur = await db.execute(
+            """
+            SELECT r.id, r.division_id, r.round_number, r.format, r.track_name,
+                   r.scheduled_at,
+                   s.season_number,
+                   d.name AS division_name
+              FROM rounds r
+              JOIN divisions d ON d.id = r.division_id
+              JOIN seasons s ON s.id = d.season_id
+             WHERE r.id = ?
+            """,
+            (round_id,),
+        )
+        row = await cur.fetchone()
+
+    if row is None:
+        log.error("run_rsvp_notice: round_id=%d not found", round_id)
+        return
+
+    division_id: int = row["division_id"]
+    division_name: str = row["division_name"]
+    round_number: int = row["round_number"]
+    round_format = RoundFormat(row["format"])
+    track_name: str | None = row["track_name"]
+    season_number: int = row["season_number"]
+    scheduled_at_raw = row["scheduled_at"]
+
+    # Parse scheduled_at (stored as ISO 8601 string in SQLite)
+    if isinstance(scheduled_at_raw, str):
+        scheduled_at = datetime.fromisoformat(scheduled_at_raw)
+    else:
+        scheduled_at = scheduled_at_raw
+    if scheduled_at.tzinfo is None:
+        scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
+
+    # Mystery rounds: skip (FR-002)
+    if round_format == RoundFormat.MYSTERY:
+        log.info("run_rsvp_notice: round %d is MYSTERY — skipping", round_id)
+        return
+
+    # Get division RSVP channel
+    att_div_cfg = await bot.attendance_service.get_division_config(division_id)
+    if att_div_cfg is None or not att_div_cfg.rsvp_channel_id:
+        log.warning(
+            "run_rsvp_notice: no RSVP channel for division %d (%s) — skipping (FR-008)",
+            division_id, division_name,
+        )
+        await bot.output_router.post_log(
+            bot.server_id_for_division(division_id) if hasattr(bot, "server_id_for_division") else 0,
+            f"SYSTEM | run_rsvp_notice | SKIP\n"
+            f"  reason: no rsvp_channel configured\n"
+            f"  division: {division_name} (id={division_id})\n"
+            f"  round: {round_number}",
+        )
+        return
+
+    channel_id_str: str = att_div_cfg.rsvp_channel_id
+    channel = bot.get_channel(int(channel_id_str))
+    if channel is None:
+        log.error(
+            "run_rsvp_notice: RSVP channel %s not found for division %d",
+            channel_id_str, division_id,
+        )
+        return
+
+    # Query roster
+    roster = await query_division_roster(bot.db_path, division_id)
+
+    # Collect driver_profile_ids for bulk DRA insert
+    all_driver_profile_ids: list[int] = [
+        d["driver_profile_id"]
+        for team in roster
+        for d in team["drivers"]
+    ]
+
+    # Build team list for embed (no rsvp_status yet — all NO_RSVP)
+    embed_teams = [
+        {
+            "name": team["name"],
+            "is_reserve": team["is_reserve"],
+            "drivers": [
+                {
+                    "display_str": _driver_display_str(d),
+                    "rsvp_status": "NO_RSVP",
+                }
+                for d in team["drivers"]
+            ],
+        }
+        for team in roster
+    ]
+
+    embed = build_rsvp_embed(
+        season_number=season_number,
+        round_number=round_number,
+        track_name=track_name,
+        scheduled_at=scheduled_at,
+        round_format=round_format,
+        teams=embed_teams,
+    )
+    view = RsvpView(round_id=round_id)
+
+    try:
+        msg = await channel.send(embed=embed, view=view)
+    except discord.HTTPException as exc:
+        log.error(
+            "run_rsvp_notice: failed to post embed for division %d: %s",
+            division_id, exc,
+        )
+        return
+
+    # Bulk-insert DRA rows
+    if all_driver_profile_ids:
+        await bot.attendance_service.bulk_insert_attendance_rows(
+            round_id=round_id,
+            division_id=division_id,
+            driver_profile_ids=all_driver_profile_ids,
+        )
+
+    # Store message reference
+    await bot.attendance_service.insert_embed_message(
+        round_id=round_id,
+        division_id=division_id,
+        message_id=str(msg.id),
+        channel_id=str(msg.channel.id),
+    )
+
+    log.info(
+        "run_rsvp_notice: posted embed for round %d / division %d (msg_id=%s)",
+        round_id, division_id, msg.id,
+    )
+
+
+# ── run_rsvp_last_notice ──────────────────────────────────────────────────────
+
+
+async def run_rsvp_last_notice(round_id: int, bot) -> None:  # type: ignore[type-arg]
+    """Post the last-notice ping for *round_id*.
+
+    Mentions only full-time drivers (is_reserve = 0) with rsvp_status = 'NO_RSVP'.
+    Silently skips if there are no such drivers (FR-029).
+    """
+    async with get_connection(bot.db_path) as db:
+        # Round + division context
+        cur = await db.execute(
+            """
+            SELECT r.division_id, r.round_number,
+                   d.name AS division_name
+              FROM rounds r
+              JOIN divisions d ON d.id = r.division_id
+             WHERE r.id = ?
+            """,
+            (round_id,),
+        )
+        row = await cur.fetchone()
+
+    if row is None:
+        log.error("run_rsvp_last_notice: round_id=%d not found", round_id)
+        return
+
+    division_id: int = row["division_id"]
+
+    # Find full-time drivers still at NO_RSVP
+    async with get_connection(bot.db_path) as db:
+        cur = await db.execute(
+            """
+            SELECT dp.discord_user_id, dp.test_display_name
+              FROM driver_round_attendance dra
+              JOIN driver_profiles dp ON dp.id = dra.driver_profile_id
+              JOIN driver_season_assignments dsa
+                   ON dsa.driver_profile_id = dra.driver_profile_id
+                  AND dsa.division_id = dra.division_id
+              JOIN team_seats ts ON ts.driver_profile_id = dsa.driver_profile_id
+              JOIN team_instances ti ON ti.id = ts.team_instance_id
+                                    AND ti.division_id = dra.division_id
+             WHERE dra.round_id = ?
+               AND dra.division_id = ?
+               AND dra.rsvp_status = 'NO_RSVP'
+               AND ti.is_reserve = 0
+            """,
+            (round_id, division_id),
+        )
+        no_rsvp_rows = await cur.fetchall()
+
+    if not no_rsvp_rows:
+        log.info(
+            "run_rsvp_last_notice: no non-responding full-time drivers for round %d / division %d — skipping",
+            round_id, division_id,
+        )
+        return
+
+    att_div_cfg = await bot.attendance_service.get_division_config(division_id)
+    if att_div_cfg is None or not att_div_cfg.rsvp_channel_id:
+        log.warning("run_rsvp_last_notice: no RSVP channel for division %d — skipping", division_id)
+        return
+
+    channel = bot.get_channel(int(att_div_cfg.rsvp_channel_id))
+    if channel is None:
+        log.error("run_rsvp_last_notice: RSVP channel not found for division %d", division_id)
+        return
+
+    mentions: list[str] = []
+    for r in no_rsvp_rows:
+        if r["test_display_name"]:
+            mentions.append(r["test_display_name"])
+        else:
+            mentions.append(f"<@{r['discord_user_id']}>")
+
+    content = (
+        f"⏰ **RSVP Reminder** — please confirm your attendance:\n"
+        + " ".join(mentions)
+    )
+    try:
+        await channel.send(content)
+    except discord.HTTPException as exc:
+        log.error("run_rsvp_last_notice: failed to post for division %d: %s", division_id, exc)
+
+
+# ── run_rsvp_deadline ─────────────────────────────────────────────────────────
+
+
+async def run_rsvp_deadline(round_id: int, bot) -> None:  # type: ignore[type-arg]
+    """Run reserve distribution and close the RSVP embed for *round_id*."""
+    async with get_connection(bot.db_path) as db:
+        cur = await db.execute(
+            "SELECT division_id FROM rounds WHERE id = ?",
+            (round_id,),
+        )
+        row = await cur.fetchone()
+
+    if row is None:
+        log.error("run_rsvp_deadline: round_id=%d not found", round_id)
+        return
+
+    division_id: int = row["division_id"]
+
+    await run_reserve_distribution(round_id, division_id, bot)
+
+    # Disable the RSVP embed buttons
+    embed_row = await bot.attendance_service.get_embed_message(round_id, division_id)
+    if embed_row is not None:
+        channel = bot.get_channel(int(embed_row.channel_id))
+        if channel is not None:
+            try:
+                msg = await channel.fetch_message(int(embed_row.message_id))
+            except discord.HTTPException:
+                msg = None
+            if msg is not None:
+                # Rebuild embed with current statuses and no view (buttons removed)
+                embed = await _rebuild_embed_for_round(round_id, division_id, bot)
+                try:
+                    await msg.edit(embed=embed, view=None)
+                except discord.HTTPException as exc:
+                    log.error("run_rsvp_deadline: failed to disable embed buttons for round %d: %s", round_id, exc)
+
+    # Post assignment announcement
+    await _post_distribution_announcement(round_id, division_id, bot)
+
+
+async def run_reserve_distribution(round_id: int, division_id: int, bot) -> None:  # type: ignore[type-arg]
+    """Compute and write reserve-to-team distribution for *round_id* in *division_id*.
+
+    Algorithm (FR-018 – FR-024):
+    1. Collect accepted reserves ordered by accepted_at ASC.
+    2. Rank non-Reserve candidate teams by priority tier (FR-020), then tie-break (FR-021).
+    3. Assign reserves to vacancies one-by-one; remaining reserves become standby.
+    """
+    async with get_connection(bot.db_path) as db:
+        # Accepted reserves ordered by accepted_at ASC (FR-022 / FR-019)
+        cur = await db.execute(
+            """
+            SELECT dra.id         AS dra_id,
+                   dra.driver_profile_id,
+                   dra.accepted_at
+              FROM driver_round_attendance dra
+              JOIN team_seats ts ON ts.driver_profile_id = dra.driver_profile_id
+              JOIN team_instances ti ON ti.id = ts.team_instance_id
+                                    AND ti.division_id = dra.division_id
+             WHERE dra.round_id = ?
+               AND dra.division_id = ?
+               AND dra.rsvp_status = 'ACCEPTED'
+               AND ti.is_reserve = 1
+             ORDER BY dra.accepted_at ASC
+            """,
+            (round_id, division_id),
+        )
+        accepted_reserves = await cur.fetchall()
+
+    if not accepted_reserves:
+        log.info("run_reserve_distribution: no accepted reserves for round %d / division %d", round_id, division_id)
+        return
+
+    async with get_connection(bot.db_path) as db:
+        # Candidate teams: non-Reserve teams in division (FR-020)
+        # Priority tier:
+        #   1 = has at least one NO_RSVP full-time driver
+        #   2 = all full-time drivers DECLINED
+        #   3 = all full-time drivers TENTATIVE
+        #   (teams where all full-time drivers ACCEPTED are not vacancies)
+        cur = await db.execute(
+            """
+            SELECT ti.id                AS team_id,
+                   ti.name              AS team_name,
+                   ti.max_seats,
+                   COUNT(CASE WHEN dra.rsvp_status = 'NO_RSVP'   THEN 1 END) AS no_rsvp_count,
+                   COUNT(CASE WHEN dra.rsvp_status = 'DECLINED'  THEN 1 END) AS declined_count,
+                   COUNT(CASE WHEN dra.rsvp_status = 'TENTATIVE' THEN 1 END) AS tentative_count,
+                   COUNT(CASE WHEN dra.rsvp_status = 'ACCEPTED'  THEN 1 END) AS accepted_count,
+                   COUNT(dra.id) AS total_drivers,
+                   MIN(tss.standing_position) AS standing_position
+              FROM team_instances ti
+              JOIN team_seats ts ON ts.team_instance_id = ti.id
+              JOIN driver_round_attendance dra
+                   ON dra.driver_profile_id = ts.driver_profile_id
+                  AND dra.round_id = ?
+                  AND dra.division_id = ?
+              LEFT JOIN team_standings_snapshots tss
+                   ON tss.team_instance_id = ti.id
+                  AND tss.round_id = (
+                      SELECT MAX(r2.id) FROM rounds r2
+                       WHERE r2.division_id = ? AND r2.id < ?
+                  )
+             WHERE ti.division_id = ?
+               AND ti.is_reserve = 0
+             GROUP BY ti.id, ti.name, ti.max_seats
+            """,
+            (round_id, division_id, division_id, round_id, division_id),
+        )
+        team_rows = await cur.fetchall()
+
+    def _team_sort_key(t) -> tuple:
+        # FR-020: priority tier
+        if t["no_rsvp_count"] > 0:
+            tier = 1
+        elif t["declined_count"] > 0:
+            tier = 2
+        elif t["tentative_count"] > 0:
+            tier = 3
+        else:
+            tier = 99  # no vacancies (all accepted)
+        # FR-021 tie-break 1: fewest accepted full-time drivers
+        accepted = t["accepted_count"]
+        # FR-021 tie-break 2: standings position (lower = better → higher priority = lower number)
+        pos = t["standing_position"] if t["standing_position"] is not None else 9999
+        # FR-021 tie-break 3: alphabetical by team name
+        name = t["team_name"].lower()
+        return (tier, accepted, pos, name)
+
+    candidate_teams = sorted(team_rows, key=_team_sort_key)
+    # Only teams with actual vacancies (tier < 99)
+    candidate_teams = [t for t in candidate_teams if _team_sort_key(t)[0] < 99]
+
+    # Determine seats available per team (max_seats - accepted_count as proxy for vacancy count)
+    # We assign at most one reserve per full-time vacant slot (FR-023)
+    team_vacancy: dict[int, int] = {}
+    for t in candidate_teams:
+        vacancies = t["no_rsvp_count"] + t["declined_count"] + t["tentative_count"]
+        team_vacancy[t["team_id"]] = vacancies
+
+    # Assign reserves to vacancies
+    assignments: list[tuple[int, int]] = []  # (dra_id, team_id)
+    standby_ids: list[int] = []
+
+    team_index = 0
+    for reserve in accepted_reserves:
+        dra_id = reserve["dra_id"]
+        # Advance past full teams
+        while team_index < len(candidate_teams) and team_vacancy[candidate_teams[team_index]["team_id"]] <= 0:
+            team_index += 1
+        if team_index < len(candidate_teams):
+            team_id = candidate_teams[team_index]["team_id"]
+            assignments.append((dra_id, team_id))
+            team_vacancy[team_id] -= 1
+        else:
+            standby_ids.append(dra_id)
+
+    # Write results
+    async with get_connection(bot.db_path) as db:
+        for dra_id, team_id in assignments:
+            await db.execute(
+                "UPDATE driver_round_attendance SET assigned_team_id = ?, is_standby = 0 WHERE id = ?",
+                (team_id, dra_id),
+            )
+        for dra_id in standby_ids:
+            await db.execute(
+                "UPDATE driver_round_attendance SET is_standby = 1 WHERE id = ?",
+                (dra_id,),
+            )
+        await db.commit()
+
+    log.info(
+        "run_reserve_distribution: round %d / division %d — %d assigned, %d standby",
+        round_id, division_id, len(assignments), len(standby_ids),
+    )
+
+
+# ── Internal helpers ──────────────────────────────────────────────────────────
+
+
+async def _rebuild_embed_for_round(round_id: int, division_id: int, bot) -> discord.Embed:  # type: ignore[type-arg]
+    """Rebuild the RSVP embed using current DB state for *round_id* / *division_id*."""
+    async with get_connection(bot.db_path) as db:
+        cur = await db.execute(
+            """
+            SELECT r.round_number, r.format, r.track_name, r.scheduled_at,
+                   s.season_number
+              FROM rounds r
+              JOIN divisions d ON d.id = r.division_id
+              JOIN seasons s ON s.id = d.season_id
+             WHERE r.id = ?
+            """,
+            (round_id,),
+        )
+        row = await cur.fetchone()
+
+    if row is None:
+        return discord.Embed(title="RSVP", color=discord.Color.red())
+
+    dra_rows = await bot.attendance_service.get_attendance_rows(round_id, division_id)
+    status_map: dict[int, str] = {r.driver_profile_id: r.rsvp_status for r in dra_rows}
+
+    roster = await query_division_roster(bot.db_path, division_id)
+
+    embed_teams = [
+        {
+            "name": team["name"],
+            "is_reserve": team["is_reserve"],
+            "drivers": [
+                {
+                    "display_str": _driver_display_str(d),
+                    "rsvp_status": status_map.get(d["driver_profile_id"], "NO_RSVP"),
+                }
+                for d in team["drivers"]
+            ],
+        }
+        for team in roster
+    ]
+
+    scheduled_at_raw = row["scheduled_at"]
+    if isinstance(scheduled_at_raw, str):
+        scheduled_at = datetime.fromisoformat(scheduled_at_raw)
+    else:
+        scheduled_at = scheduled_at_raw
+
+    return build_rsvp_embed(
+        season_number=row["season_number"],
+        round_number=row["round_number"],
+        track_name=row["track_name"],
+        scheduled_at=scheduled_at,
+        round_format=RoundFormat(row["format"]),
+        teams=embed_teams,
+    )
+
+
+async def _post_distribution_announcement(round_id: int, division_id: int, bot) -> None:  # type: ignore[type-arg]
+    """Post the reserve distribution assignment announcement (FR-025 / FR-026)."""
+    async with get_connection(bot.db_path) as db:
+        cur = await db.execute(
+            """
+            SELECT dra.assigned_team_id,
+                   dra.is_standby,
+                   dp.discord_user_id,
+                   dp.test_display_name,
+                   ti.name AS team_name
+              FROM driver_round_attendance dra
+              JOIN driver_profiles dp ON dp.id = dra.driver_profile_id
+              JOIN team_seats ts ON ts.driver_profile_id = dra.driver_profile_id
+              JOIN team_instances src_ti ON src_ti.id = ts.team_instance_id
+                                       AND src_ti.division_id = dra.division_id
+              LEFT JOIN team_instances ti ON ti.id = dra.assigned_team_id
+             WHERE dra.round_id = ?
+               AND dra.division_id = ?
+               AND dra.rsvp_status = 'ACCEPTED'
+               AND src_ti.is_reserve = 1
+            """,
+            (round_id, division_id),
+        )
+        eligible_rows = await cur.fetchall()
+
+    if not eligible_rows:
+        return  # FR-026: no announcement if no eligible reserves
+
+    att_div_cfg = await bot.attendance_service.get_division_config(division_id)
+    if att_div_cfg is None or not att_div_cfg.rsvp_channel_id:
+        return
+
+    channel = bot.get_channel(int(att_div_cfg.rsvp_channel_id))
+    if channel is None:
+        return
+
+    lines = ["📋 **Reserve Distribution Results**"]
+    for row in eligible_rows:
+        driver_str = row["test_display_name"] if row["test_display_name"] else f"<@{row['discord_user_id']}>"
+        if row["is_standby"]:
+            lines.append(f"  {driver_str} — **Standby** (no vacancy available)")
+        elif row["assigned_team_id"] is not None:
+            lines.append(f"  {driver_str} → **{row['team_name']}**")
+        else:
+            lines.append(f"  {driver_str} — no assignment")
+
+    try:
+        await channel.send("\n".join(lines))
+    except discord.HTTPException as exc:
+        log.error("_post_distribution_announcement: failed for division %d: %s", division_id, exc)

--- a/src/services/scheduler_service.py
+++ b/src/services/scheduler_service.py
@@ -156,6 +156,58 @@ async def _result_submission_job_wrapper(round_id: int) -> None:
     await cb(round_id)
 
 
+async def _rsvp_notice_job(round_id: int) -> None:
+    """Top-level APScheduler callable for RSVP notice jobs.
+
+    Follows the same module-level pattern as ``_mystery_notice_job`` to avoid
+    closure pickling issues with SQLAlchemyJobStore.
+    """
+    if _GLOBAL_SERVICE is None:
+        log.warning(
+            "_rsvp_notice_job fired but _GLOBAL_SERVICE is None "
+            "(round=%s) — skipping",
+            round_id,
+        )
+        return
+    cb = _GLOBAL_SERVICE._rsvp_notice_callback
+    if cb is None:
+        log.warning("No RSVP notice callback registered; skipping round %s.", round_id)
+        return
+    await cb(round_id)
+
+
+async def _rsvp_last_notice_job(round_id: int) -> None:
+    """Top-level APScheduler callable for RSVP last-notice jobs."""
+    if _GLOBAL_SERVICE is None:
+        log.warning(
+            "_rsvp_last_notice_job fired but _GLOBAL_SERVICE is None "
+            "(round=%s) — skipping",
+            round_id,
+        )
+        return
+    cb = _GLOBAL_SERVICE._rsvp_last_notice_callback
+    if cb is None:
+        log.warning("No RSVP last-notice callback registered; skipping round %s.", round_id)
+        return
+    await cb(round_id)
+
+
+async def _rsvp_deadline_job(round_id: int) -> None:
+    """Top-level APScheduler callable for RSVP deadline jobs."""
+    if _GLOBAL_SERVICE is None:
+        log.warning(
+            "_rsvp_deadline_job fired but _GLOBAL_SERVICE is None "
+            "(round=%s) — skipping",
+            round_id,
+        )
+        return
+    cb = _GLOBAL_SERVICE._rsvp_deadline_callback
+    if cb is None:
+        log.warning("No RSVP deadline callback registered; skipping round %s.", round_id)
+        return
+    await cb(round_id)
+
+
 class SchedulerService:
     def __init__(self, db_path: str) -> None:
         self._db_path = db_path
@@ -177,6 +229,10 @@ class SchedulerService:
         self._forecast_cleanup_callback: "Callable | None" = None
         # Result submission callback injected after bot starts
         self._result_submission_callback: "Callable | None" = None
+        # RSVP callbacks injected after bot starts
+        self._rsvp_notice_callback: "Callable | None" = None
+        self._rsvp_last_notice_callback: "Callable | None" = None
+        self._rsvp_deadline_callback: "Callable | None" = None
 
     def register_callbacks(
         self,
@@ -220,6 +276,30 @@ class SchedulerService:
         Called from bot.py on_ready after the scheduler is started.
         """
         self._result_submission_callback = callback
+
+    def register_rsvp_notice_callback(self, callback: Callable) -> None:
+        """Register the async callable invoked when an RSVP notice job fires.
+
+        The callable must accept ``(round_id: int)``.
+        Called from bot.py on_ready after the scheduler is started.
+        """
+        self._rsvp_notice_callback = callback
+
+    def register_rsvp_last_notice_callback(self, callback: Callable) -> None:
+        """Register the async callable invoked when an RSVP last-notice job fires.
+
+        The callable must accept ``(round_id: int)``.
+        Called from bot.py on_ready after the scheduler is started.
+        """
+        self._rsvp_last_notice_callback = callback
+
+    def register_rsvp_deadline_callback(self, callback: Callable) -> None:
+        """Register the async callable invoked when an RSVP deadline job fires.
+
+        The callable must accept ``(round_id: int)``.
+        Called from bot.py on_ready after the scheduler is started.
+        """
+        self._rsvp_deadline_callback = callback
 
     def start(self) -> None:
         global _GLOBAL_SERVICE
@@ -334,8 +414,88 @@ class SchedulerService:
         )
         log.info("Scheduled %s at %s", results_job_id, scheduled_at.isoformat())
 
+    def schedule_attendance_round(
+        self,
+        rnd: Round,
+        *,
+        notice_days: int,
+        last_notice_hours: int,
+        deadline_hours: int,
+    ) -> None:
+        """Register RSVP DateTrigger jobs for *rnd* (attendance module).
+
+        Jobs are only created for non-Mystery rounds whose fire time is in the future.
+        ``replace_existing=True`` makes re-scheduling amended rounds safe.
+
+        Args:
+            notice_days:       Days before round to post RSVP embed.
+            last_notice_hours: Hours before round for last-notice ping (0 = disabled, FR-030).
+            deadline_hours:    Hours before round for distribution deadline.
+        """
+        if rnd.format == RoundFormat.MYSTERY:
+            return  # FR-002: no RSVP jobs for Mystery rounds
+
+        scheduled_at = rnd.scheduled_at
+        if scheduled_at.tzinfo is None:
+            scheduled_at = scheduled_at.replace(tzinfo=timezone.utc)
+
+        now = datetime.now(timezone.utc)
+
+        # Notice job
+        notice_fire_at = scheduled_at - timedelta(days=notice_days)
+        notice_job_id = f"rsvp_notice_r{rnd.id}"
+        if notice_fire_at > now:
+            self._scheduler.add_job(
+                _rsvp_notice_job,
+                trigger=DateTrigger(run_date=notice_fire_at, timezone="UTC"),
+                id=notice_job_id,
+                replace_existing=True,
+                name=f"RSVP notice for round {rnd.id}",
+                kwargs={"round_id": rnd.id},
+            )
+            log.info("Scheduled %s at %s", notice_job_id, notice_fire_at.isoformat())
+        else:
+            log.info("Skipping %s — fire time %s is in the past", notice_job_id, notice_fire_at.isoformat())
+
+        # Last-notice job (FR-030: only when last_notice_hours > 0)
+        if last_notice_hours > 0:
+            last_notice_fire_at = scheduled_at - timedelta(hours=last_notice_hours)
+            last_notice_job_id = f"rsvp_last_notice_r{rnd.id}"
+            if last_notice_fire_at > now:
+                self._scheduler.add_job(
+                    _rsvp_last_notice_job,
+                    trigger=DateTrigger(run_date=last_notice_fire_at, timezone="UTC"),
+                    id=last_notice_job_id,
+                    replace_existing=True,
+                    name=f"RSVP last-notice for round {rnd.id}",
+                    kwargs={"round_id": rnd.id},
+                )
+                log.info("Scheduled %s at %s", last_notice_job_id, last_notice_fire_at.isoformat())
+            else:
+                log.info(
+                    "Skipping %s — fire time %s is in the past",
+                    last_notice_job_id, last_notice_fire_at.isoformat(),
+                )
+
+        # Deadline job
+        deadline_hours_actual = deadline_hours if deadline_hours > 0 else 0
+        deadline_fire_at = scheduled_at - timedelta(hours=deadline_hours_actual)
+        deadline_job_id = f"rsvp_deadline_r{rnd.id}"
+        if deadline_fire_at > now:
+            self._scheduler.add_job(
+                _rsvp_deadline_job,
+                trigger=DateTrigger(run_date=deadline_fire_at, timezone="UTC"),
+                id=deadline_job_id,
+                replace_existing=True,
+                name=f"RSVP deadline for round {rnd.id}",
+                kwargs={"round_id": rnd.id},
+            )
+            log.info("Scheduled %s at %s", deadline_job_id, deadline_fire_at.isoformat())
+        else:
+            log.info("Skipping %s — fire time %s is in the past", deadline_job_id, deadline_fire_at.isoformat())
+
     def cancel_round(self, round_id: int) -> None:
-        """Remove all phase jobs, the mystery-notice job, and the cleanup job for *round_id*."""
+        """Remove all phase jobs, the mystery-notice job, the cleanup job, and RSVP jobs for *round_id*."""
         for job_id in (
             f"phase1_r{round_id}",
             f"phase2_r{round_id}",
@@ -343,6 +503,9 @@ class SchedulerService:
             f"mystery_r{round_id}",
             f"cleanup_r{round_id}",
             f"results_r{round_id}",
+            f"rsvp_notice_r{round_id}",
+            f"rsvp_last_notice_r{round_id}",
+            f"rsvp_deadline_r{round_id}",
         ):
             try:
                 self._scheduler.remove_job(job_id)
@@ -432,10 +595,13 @@ class SchedulerService:
         # (rounds_with_results fallback) so that past-dated results_r jobs
         # that already auto-fired don't block or double-trigger the wizard.
         _PHASE_PREFIX_MAP = {
-            "mystery": 0,
-            "phase1":  1,
-            "phase2":  2,
-            "phase3":  3,
+            "mystery":          0,
+            "phase1":           1,
+            "phase2":           2,
+            "phase3":           3,
+            "rsvp_notice":      5,
+            "rsvp_last_notice": 6,
+            "rsvp_deadline":    7,
         }
         result: list[dict] = []
         for job in self._scheduler.get_jobs():

--- a/tests/unit/test_mystery_notice.py
+++ b/tests/unit/test_mystery_notice.py
@@ -80,23 +80,25 @@ def _mystery_round(round_id: int = 42) -> Round:
 
 class TestScheduleRoundMystery:
 
-    def test_schedules_exactly_one_job(self):
+    def test_schedules_exactly_two_jobs(self):
+        # Mystery rounds schedule mystery notice + results submission
         svc = _make_scheduler_no_db()
         svc.schedule_round(_mystery_round())
-        assert svc._scheduler.add_job.call_count == 1
+        assert svc._scheduler.add_job.call_count == 2
 
     def test_job_id_is_mystery_r(self):
         svc = _make_scheduler_no_db()
         svc.schedule_round(_mystery_round(round_id=42))
-        job_id = svc._scheduler.add_job.call_args.kwargs.get("id")
+        # First call is the mystery notice job
+        job_id = svc._scheduler.add_job.call_args_list[0].kwargs.get("id")
         assert job_id == "mystery_r42"
 
     def test_no_phase_jobs_created(self):
         svc = _make_scheduler_no_db()
         svc.schedule_round(_mystery_round())
-        job_id = svc._scheduler.add_job.call_args.kwargs.get("id", "")
-        assert job_id.startswith("mystery_r")
-        assert "phase" not in job_id
+        job_ids = [c.kwargs.get("id", "") for c in svc._scheduler.add_job.call_args_list]
+        assert any(jid.startswith("mystery_r") for jid in job_ids)
+        assert not any("phase" in jid for jid in job_ids)
 
 
 # ---------------------------------------------------------------------------
@@ -119,11 +121,12 @@ class TestCancelRoundIncludesMystery:
         assert "phase2_r7" in removed
         assert "phase3_r7" in removed
 
-    def test_removes_four_job_ids_total(self):
+    def test_removes_nine_job_ids_total(self):
         svc = _make_scheduler_no_db()
         svc.cancel_round(7)
-        # phase1, phase2, phase3, mystery, cleanup, results = 6 job IDs
-        assert svc._scheduler.remove_job.call_count == 6
+        # phase1, phase2, phase3, mystery, cleanup, results,
+        # rsvp_notice, rsvp_last_notice, rsvp_deadline = 9 job IDs
+        assert svc._scheduler.remove_job.call_count == 9
 
 
 # ---------------------------------------------------------------------------

--- a/tests/unit/test_rsvp_embed_builder.py
+++ b/tests/unit/test_rsvp_embed_builder.py
@@ -1,0 +1,264 @@
+"""Unit tests for the RSVP embed builder — T025.
+
+Covers:
+  1. Title format: "Season N Round N — <track_name>"
+  2. Mystery track shows "Mystery" in title and Location field
+  3. Status indicator strings for all four statuses (NO_RSVP, ACCEPTED, TENTATIVE, DECLINED)
+  4. Per-team roster grouping (Reserve team prefixed with "(Reserve)")
+  5. Discord timestamp format <t:{unix}:F>
+  6. Event type label from RoundFormat
+  7. Non-reserve teams appear before the Reserve team
+  8. Teams with no drivers show "(no drivers)" placeholder
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+import discord
+
+from models.round import RoundFormat
+from services.rsvp_service import build_rsvp_embed, _STATUS_INDICATOR
+
+
+_FIXED_DT = datetime(2025, 7, 20, 18, 0, 0, tzinfo=timezone.utc)
+_FIXED_UNIX = int(_FIXED_DT.timestamp())
+
+
+def _build(
+    season_number: int = 3,
+    round_number: int = 7,
+    track_name: str | None = "Monza",
+    scheduled_at: datetime = _FIXED_DT,
+    round_format: RoundFormat = RoundFormat.NORMAL,
+    teams: list[dict] | None = None,
+) -> discord.Embed:
+    if teams is None:
+        teams = []
+    return build_rsvp_embed(
+        season_number=season_number,
+        round_number=round_number,
+        track_name=track_name,
+        scheduled_at=scheduled_at,
+        round_format=round_format,
+        teams=teams,
+    )
+
+
+def _roster_field(embed: discord.Embed) -> str | None:
+    for f in embed.fields:
+        if "Driver Roster" in f.name:
+            return f.value
+    return None
+
+
+# ---------------------------------------------------------------------------
+# 1. Title format
+# ---------------------------------------------------------------------------
+
+class TestTitleFormat:
+    def test_contains_season_number(self):
+        embed = _build(season_number=5, round_number=2, track_name="Spa")
+        assert "Season 5" in embed.title
+
+    def test_contains_round_number(self):
+        embed = _build(season_number=1, round_number=12, track_name="Spa")
+        assert "Round 12" in embed.title
+
+    def test_contains_track_name(self):
+        embed = _build(track_name="Silverstone")
+        assert "Silverstone" in embed.title
+
+    def test_title_format_exact(self):
+        embed = _build(season_number=3, round_number=7, track_name="Monza")
+        assert embed.title == "Season 3 Round 7 — Monza"
+
+
+# ---------------------------------------------------------------------------
+# 2. Mystery round
+# ---------------------------------------------------------------------------
+
+
+class TestMysteryTrack:
+    def test_none_track_name_shows_mystery_in_title(self):
+        embed = _build(track_name=None)
+        assert "Mystery" in embed.title
+
+    def test_none_track_name_shows_mystery_in_location_field(self):
+        embed = _build(track_name=None)
+        location_field = next((f for f in embed.fields if "Location" in f.name), None)
+        assert location_field is not None
+        assert location_field.value == "Mystery"
+
+
+# ---------------------------------------------------------------------------
+# 3. Status indicator strings
+# ---------------------------------------------------------------------------
+
+
+class TestStatusIndicators:
+    def test_no_rsvp_indicator(self):
+        assert _STATUS_INDICATOR["NO_RSVP"] == "()"
+
+    def test_accepted_indicator(self):
+        assert _STATUS_INDICATOR["ACCEPTED"] == "(✅)"
+
+    def test_tentative_indicator(self):
+        assert _STATUS_INDICATOR["TENTATIVE"] == "(❓)"
+
+    def test_declined_indicator(self):
+        assert _STATUS_INDICATOR["DECLINED"] == "(❌)"
+
+    def test_all_four_appear_in_roster(self):
+        teams = [
+            {
+                "name": "TeamA",
+                "is_reserve": False,
+                "drivers": [
+                    {"display_str": "Alice", "rsvp_status": "NO_RSVP"},
+                    {"display_str": "Bob",   "rsvp_status": "ACCEPTED"},
+                    {"display_str": "Carol", "rsvp_status": "TENTATIVE"},
+                    {"display_str": "Dave",  "rsvp_status": "DECLINED"},
+                ],
+            }
+        ]
+        embed = _build(teams=teams)
+        roster = _roster_field(embed)
+        assert roster is not None
+        assert "()" in roster
+        assert "(✅)" in roster
+        assert "(❓)" in roster
+        assert "(❌)" in roster
+
+
+# ---------------------------------------------------------------------------
+# 4. Per-team roster grouping
+# ---------------------------------------------------------------------------
+
+
+class TestTeamRosterGrouping:
+    def test_team_name_appears_as_bold_header(self):
+        teams = [{"name": "Red Bull", "is_reserve": False, "drivers": []}]
+        embed = _build(teams=teams)
+        roster = _roster_field(embed)
+        assert "**Red Bull**" in roster
+
+    def test_reserve_team_prefixed(self):
+        teams = [{"name": "Reserve", "is_reserve": True, "drivers": []}]
+        embed = _build(teams=teams)
+        roster = _roster_field(embed)
+        assert "*(Reserve)*" in roster
+
+    def test_non_reserve_team_not_prefixed(self):
+        teams = [{"name": "Ferrari", "is_reserve": False, "drivers": []}]
+        embed = _build(teams=teams)
+        roster = _roster_field(embed)
+        assert "*(Reserve)*" not in roster
+
+    def test_driver_display_str_present(self):
+        teams = [
+            {
+                "name": "Mercedes",
+                "is_reserve": False,
+                "drivers": [{"display_str": "<@123456789>", "rsvp_status": "NO_RSVP"}],
+            }
+        ]
+        embed = _build(teams=teams)
+        roster = _roster_field(embed)
+        assert "<@123456789>" in roster
+
+    def test_test_display_name_present(self):
+        teams = [
+            {
+                "name": "McLaren",
+                "is_reserve": False,
+                "drivers": [{"display_str": "TestDriver1", "rsvp_status": "ACCEPTED"}],
+            }
+        ]
+        embed = _build(teams=teams)
+        roster = _roster_field(embed)
+        assert "TestDriver1" in roster
+
+    def test_no_drivers_shows_placeholder(self):
+        teams = [{"name": "TeamEmpty", "is_reserve": False, "drivers": []}]
+        embed = _build(teams=teams)
+        roster = _roster_field(embed)
+        assert "*(no drivers)*" in roster
+
+    def test_non_reserve_before_reserve_in_roster(self):
+        """Assuming caller passes teams already ordered: non-reserve first, reserve last."""
+        teams = [
+            {"name": "Aston Martin", "is_reserve": False, "drivers": []},
+            {"name": "Reserve",       "is_reserve": True,  "drivers": []},
+        ]
+        embed = _build(teams=teams)
+        roster = _roster_field(embed)
+        aston_pos   = roster.index("**Aston Martin**")
+        reserve_pos = roster.index("*(Reserve)*")
+        assert aston_pos < reserve_pos
+
+    def test_multiple_teams_all_appear(self):
+        teams = [
+            {"name": "AlphA", "is_reserve": False, "drivers": []},
+            {"name": "BetaB", "is_reserve": False, "drivers": []},
+        ]
+        embed = _build(teams=teams)
+        roster = _roster_field(embed)
+        assert "AlphA" in roster
+        assert "BetaB" in roster
+
+
+# ---------------------------------------------------------------------------
+# 5. Discord timestamp format
+# ---------------------------------------------------------------------------
+
+
+class TestDiscordTimestamp:
+    def test_timestamp_field_present(self):
+        embed = _build()
+        date_field = next((f for f in embed.fields if "Date" in f.name), None)
+        assert date_field is not None
+
+    def test_timestamp_full_format(self):
+        embed = _build(scheduled_at=_FIXED_DT)
+        date_field = next(f for f in embed.fields if "Date" in f.name)
+        assert f"<t:{_FIXED_UNIX}:F>" in date_field.value
+
+    def test_naive_datetime_treated_as_utc(self):
+        naive = datetime(2025, 7, 20, 18, 0, 0)  # no tzinfo
+        embed = _build(scheduled_at=naive)
+        date_field = next(f for f in embed.fields if "Date" in f.name)
+        # The unix timestamp should be same as the UTC-aware version
+        assert f"<t:{_FIXED_UNIX}:F>" in date_field.value
+
+
+# ---------------------------------------------------------------------------
+# 6. Event type label
+# ---------------------------------------------------------------------------
+
+
+class TestEventTypeLabel:
+    def test_normal_label(self):
+        embed = _build(round_format=RoundFormat.NORMAL)
+        et = next(f for f in embed.fields if "Event Type" in f.name)
+        assert et.value == "Normal"
+
+    def test_sprint_label(self):
+        embed = _build(round_format=RoundFormat.SPRINT)
+        et = next(f for f in embed.fields if "Event Type" in f.name)
+        assert et.value == "Sprint"
+
+    def test_endurance_label(self):
+        embed = _build(round_format=RoundFormat.ENDURANCE)
+        et = next(f for f in embed.fields if "Event Type" in f.name)
+        assert et.value == "Endurance"
+
+    def test_mystery_label(self):
+        embed = _build(round_format=RoundFormat.MYSTERY, track_name=None)
+        et = next(f for f in embed.fields if "Event Type" in f.name)
+        assert et.value == "Mystery"

--- a/tests/unit/test_rsvp_service.py
+++ b/tests/unit/test_rsvp_service.py
@@ -1,0 +1,598 @@
+"""Unit tests for rsvp_service — T024.
+
+Covers:
+  1. Distribution priority ordering (tier 1 NO_RSVP > tier 2 DECLINED > tier 3 TENTATIVE)
+  2. Tie-breaking: fewest accepted; standings position; alphabetical team name
+  3. accepted_at timestamp ordering for reserves (first-accepted = highest priority)
+  4. Standby classification (reserves beyond available vacancies)
+  5. No-op when no accepted reserves
+  6. AttendanceService CRUD round-trips (bulk_insert, upsert, get, embed message)
+"""
+from __future__ import annotations
+
+import os
+import sys
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock
+
+import aiosqlite
+import pytest
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "..", "..", "src"))
+
+from services.rsvp_service import run_reserve_distribution
+
+
+# ---------------------------------------------------------------------------
+# Helpers / fixtures
+# ---------------------------------------------------------------------------
+
+_NOW = datetime(2025, 6, 1, 12, 0, 0, tzinfo=timezone.utc)
+_FUTURE = datetime(2025, 6, 8, 14, 0, 0, tzinfo=timezone.utc)
+
+
+async def _make_db(tmp_path) -> str:
+    """Create a minimal SQLite DB with all tables required by run_reserve_distribution."""
+    path = str(tmp_path / "rsvp_test.db")
+    async with aiosqlite.connect(path) as db:
+        db.row_factory = aiosqlite.Row
+        await db.executescript(
+            """
+            CREATE TABLE seasons (
+                id            INTEGER PRIMARY KEY,
+                server_id     INTEGER NOT NULL DEFAULT 1,
+                season_number INTEGER NOT NULL DEFAULT 1,
+                status        TEXT    NOT NULL DEFAULT 'ACTIVE'
+            );
+
+            CREATE TABLE divisions (
+                id        INTEGER PRIMARY KEY,
+                season_id INTEGER NOT NULL,
+                name      TEXT    NOT NULL DEFAULT 'Div1'
+            );
+
+            CREATE TABLE rounds (
+                id              INTEGER PRIMARY KEY,
+                division_id     INTEGER NOT NULL,
+                round_number    INTEGER NOT NULL,
+                format          TEXT    NOT NULL DEFAULT 'NORMAL',
+                track_name      TEXT,
+                scheduled_at    TEXT    NOT NULL
+            );
+
+            CREATE TABLE driver_profiles (
+                id               INTEGER PRIMARY KEY,
+                server_id        INTEGER NOT NULL DEFAULT 1,
+                discord_user_id  TEXT    NOT NULL DEFAULT '0',
+                test_display_name TEXT
+            );
+
+            CREATE TABLE team_instances (
+                id          INTEGER PRIMARY KEY,
+                division_id INTEGER NOT NULL,
+                name        TEXT    NOT NULL,
+                is_reserve  INTEGER NOT NULL DEFAULT 0,
+                max_seats   INTEGER NOT NULL DEFAULT 2
+            );
+
+            CREATE TABLE team_seats (
+                id                INTEGER PRIMARY KEY,
+                team_instance_id  INTEGER NOT NULL,
+                driver_profile_id INTEGER NOT NULL
+            );
+
+            CREATE TABLE driver_round_attendance (
+                id                INTEGER PRIMARY KEY,
+                round_id          INTEGER NOT NULL,
+                division_id       INTEGER NOT NULL,
+                driver_profile_id INTEGER NOT NULL,
+                rsvp_status       TEXT    NOT NULL DEFAULT 'NO_RSVP',
+                accepted_at       TEXT,
+                assigned_team_id  INTEGER,
+                is_standby        INTEGER NOT NULL DEFAULT 0,
+                attended          INTEGER,
+                UNIQUE (round_id, division_id, driver_profile_id)
+            );
+
+            CREATE TABLE team_standings_snapshots (
+                id               INTEGER PRIMARY KEY,
+                team_instance_id INTEGER NOT NULL,
+                round_id         INTEGER NOT NULL,
+                standing_position INTEGER
+            );
+            """
+        )
+        await db.commit()
+    return path
+
+
+def _make_bot(db_path: str) -> MagicMock:
+    bot = MagicMock()
+    bot.db_path = db_path
+    return bot
+
+
+async def _seed_base(db_path: str) -> None:
+    """Insert one season, one division, and one round."""
+    async with aiosqlite.connect(db_path) as db:
+        await db.execute("INSERT INTO seasons (id, season_number) VALUES (1, 1)")
+        await db.execute("INSERT INTO divisions (id, season_id) VALUES (10, 1)")
+        await db.execute(
+            "INSERT INTO rounds (id, division_id, round_number, scheduled_at) VALUES (42, 10, 3, ?)",
+            (_FUTURE.isoformat(),),
+        )
+        await db.commit()
+
+
+async def _insert_driver(db: aiosqlite.Connection, dp_id: int, name: str) -> None:
+    await db.execute(
+        "INSERT INTO driver_profiles (id, test_display_name) VALUES (?, ?)",
+        (dp_id, name),
+    )
+
+
+async def _insert_team(db: aiosqlite.Connection, team_id: int, div_id: int, name: str, is_reserve: int = 0) -> None:
+    await db.execute(
+        "INSERT INTO team_instances (id, division_id, name, is_reserve, max_seats) VALUES (?, ?, ?, ?, 2)",
+        (team_id, div_id, name, is_reserve),
+    )
+
+
+async def _add_driver_to_team(db: aiosqlite.Connection, team_id: int, dp_id: int) -> None:
+    await db.execute(
+        "INSERT INTO team_seats (team_instance_id, driver_profile_id) VALUES (?, ?)",
+        (team_id, dp_id),
+    )
+
+
+async def _insert_dra(
+    db: aiosqlite.Connection,
+    round_id: int,
+    div_id: int,
+    dp_id: int,
+    status: str,
+    accepted_at: str | None = None,
+) -> int:
+    cur = await db.execute(
+        "INSERT INTO driver_round_attendance (round_id, division_id, driver_profile_id, rsvp_status, accepted_at)"
+        " VALUES (?, ?, ?, ?, ?)",
+        (round_id, div_id, dp_id, status, accepted_at),
+    )
+    return cur.lastrowid  # type: ignore[return-value]
+
+
+async def _get_dra(db: aiosqlite.Connection, dra_id: int) -> aiosqlite.Row:
+    cur = await db.execute("SELECT * FROM driver_round_attendance WHERE id = ?", (dra_id,))
+    row = await cur.fetchone()
+    assert row is not None, f"DRA row {dra_id} not found"
+    return row
+
+
+# ---------------------------------------------------------------------------
+# 1. No-op when no accepted reserves
+# ---------------------------------------------------------------------------
+
+
+class TestNoAcceptedReserves:
+    @pytest.mark.asyncio
+    async def test_no_assignments_made(self, tmp_path):
+        db_path = await _make_db(tmp_path)
+        await _seed_base(db_path)
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            await _insert_driver(db, 1, "Alice")
+            await _insert_driver(db, 2, "Bob (reserve)")
+            await _insert_team(db, 101, 10, "Alpha")
+            await _insert_team(db, 102, 10, "Reserve", is_reserve=1)
+            await _add_driver_to_team(db, 101, 1)
+            await _add_driver_to_team(db, 102, 2)
+            dra1 = await _insert_dra(db, 42, 10, 1, "NO_RSVP")
+            dra2 = await _insert_dra(db, 42, 10, 2, "TENTATIVE")  # reserve but not ACCEPTED
+            await db.commit()
+
+        bot = _make_bot(db_path)
+        # Should return without writing anything
+        await run_reserve_distribution(42, 10, bot)
+
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            row1 = await _get_dra(db, dra1)
+            row2 = await _get_dra(db, dra2)
+
+        assert row1["assigned_team_id"] is None
+        assert row2["assigned_team_id"] is None
+        assert row2["is_standby"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 2. Priority ordering: tier 1 (NO_RSVP) fills before tier 2 (DECLINED)
+# ---------------------------------------------------------------------------
+
+
+class TestPriorityOrdering:
+    @pytest.mark.asyncio
+    async def test_tier1_team_gets_reserve_first(self, tmp_path):
+        """Team with a NO_RSVP driver gets the reserve before a team with only DECLINED drivers."""
+        db_path = await _make_db(tmp_path)
+        await _seed_base(db_path)
+
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            # Regular drivers
+            await _insert_driver(db, 1, "Driver1 (NO_RSVP team)")
+            await _insert_driver(db, 2, "Driver2 (DECLINED team)")
+            # Reserve driver
+            await _insert_driver(db, 3, "ReserveDriver")
+
+            await _insert_team(db, 101, 10, "TeamA_NoRsvp")   # should get tier 1 priority
+            await _insert_team(db, 102, 10, "TeamB_Declined")  # tier 2 priority
+            await _insert_team(db, 103, 10, "Reserve", is_reserve=1)
+
+            await _add_driver_to_team(db, 101, 1)
+            await _add_driver_to_team(db, 102, 2)
+            await _add_driver_to_team(db, 103, 3)
+
+            await _insert_dra(db, 42, 10, 1, "NO_RSVP")
+            await _insert_dra(db, 42, 10, 2, "DECLINED")
+            reserve_dra = await _insert_dra(db, 42, 10, 3, "ACCEPTED", "2025-06-01T10:00:00+00:00")
+            await db.commit()
+
+        bot = _make_bot(db_path)
+        await run_reserve_distribution(42, 10, bot)
+
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            reserve_row = await _get_dra(db, reserve_dra)
+
+        # Reserve should be assigned to TeamA_NoRsvp (tier 1) not TeamB_Declined (tier 2)
+        assert reserve_row["assigned_team_id"] == 101
+        assert reserve_row["is_standby"] == 0
+
+
+# ---------------------------------------------------------------------------
+# 3. Tie-breaking: standings position
+# ---------------------------------------------------------------------------
+
+
+class TestTiebreakerStandings:
+    @pytest.mark.asyncio
+    async def test_lower_standing_position_wins(self, tmp_path):
+        """A team at a lower standings position (= better rank) should receive the reserve first."""
+        db_path = await _make_db(tmp_path)
+        await _seed_base(db_path)
+
+        # Need a prior round to anchor the standings snapshot
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            await db.execute(
+                "INSERT INTO rounds (id, division_id, round_number, scheduled_at) VALUES (41, 10, 2, ?)",
+                (datetime(2025, 5, 25, tzinfo=timezone.utc).isoformat(),),
+            )
+
+            await _insert_driver(db, 1, "D1")
+            await _insert_driver(db, 2, "D2")
+            await _insert_driver(db, 3, "ReserveR")
+
+            await _insert_team(db, 101, 10, "TeamBeta")   # standing_pos=2
+            await _insert_team(db, 102, 10, "TeamAlpha")  # standing_pos=1 — should win
+            await _insert_team(db, 103, 10, "Reserve", is_reserve=1)
+
+            await _add_driver_to_team(db, 101, 1)
+            await _add_driver_to_team(db, 102, 2)
+            await _add_driver_to_team(db, 103, 3)
+
+            # Both teams have a DECLINED driver (same tier 2)
+            await _insert_dra(db, 42, 10, 1, "DECLINED")
+            await _insert_dra(db, 42, 10, 2, "DECLINED")
+            reserve_dra = await _insert_dra(db, 42, 10, 3, "ACCEPTED", "2025-06-01T10:00:00+00:00")
+
+            # Standings: TeamAlpha=pos1, TeamBeta=pos2 (snapshot anchored at round 41)
+            await db.execute(
+                "INSERT INTO team_standings_snapshots (team_instance_id, round_id, standing_position) VALUES (102, 41, 1)"
+            )
+            await db.execute(
+                "INSERT INTO team_standings_snapshots (team_instance_id, round_id, standing_position) VALUES (101, 41, 2)"
+            )
+            await db.commit()
+
+        bot = _make_bot(db_path)
+        await run_reserve_distribution(42, 10, bot)
+
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            reserve_row = await _get_dra(db, reserve_dra)
+
+        assert reserve_row["assigned_team_id"] == 102  # TeamAlpha (pos 1)
+
+
+# ---------------------------------------------------------------------------
+# 4. Tie-breaking: alphabetical team name fallback
+# ---------------------------------------------------------------------------
+
+
+class TestTiebreakerAlphabetical:
+    @pytest.mark.asyncio
+    async def test_alphabetical_fallback(self, tmp_path):
+        """When tier and standings are identical, team name alphabetical order wins."""
+        db_path = await _make_db(tmp_path)
+        await _seed_base(db_path)
+
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            await _insert_driver(db, 1, "D1")
+            await _insert_driver(db, 2, "D2")
+            await _insert_driver(db, 3, "ReserveR")
+
+            await _insert_team(db, 101, 10, "Zeta")   # alphabetically last
+            await _insert_team(db, 102, 10, "Alpha")   # alphabetically first — should win
+            await _insert_team(db, 103, 10, "Reserve", is_reserve=1)
+
+            await _add_driver_to_team(db, 101, 1)
+            await _add_driver_to_team(db, 102, 2)
+            await _add_driver_to_team(db, 103, 3)
+
+            await _insert_dra(db, 42, 10, 1, "DECLINED")
+            await _insert_dra(db, 42, 10, 2, "DECLINED")
+            reserve_dra = await _insert_dra(db, 42, 10, 3, "ACCEPTED", "2025-06-01T10:00:00+00:00")
+            await db.commit()
+
+        bot = _make_bot(db_path)
+        await run_reserve_distribution(42, 10, bot)
+
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            reserve_row = await _get_dra(db, reserve_dra)
+
+        assert reserve_row["assigned_team_id"] == 102  # Alpha
+
+
+# ---------------------------------------------------------------------------
+# 5. accepted_at timestamp ordering
+# ---------------------------------------------------------------------------
+
+
+class TestAcceptedAtOrdering:
+    @pytest.mark.asyncio
+    async def test_earlier_accepted_gets_higher_priority_team(self, tmp_path):
+        """Reserve who accepted earlier should be assigned to the higher-priority team."""
+        db_path = await _make_db(tmp_path)
+        await _seed_base(db_path)
+
+        # Need a prior round for standings
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            await db.execute(
+                "INSERT INTO rounds (id, division_id, round_number, scheduled_at) VALUES (41, 10, 2, ?)",
+                (datetime(2025, 5, 25, tzinfo=timezone.utc).isoformat(),),
+            )
+
+            await _insert_driver(db, 1, "D1")
+            await _insert_driver(db, 2, "D2")
+            await _insert_driver(db, 3, "Reserve_Early")   # accepted first
+            await _insert_driver(db, 4, "Reserve_Late")    # accepted later
+
+            await _insert_team(db, 101, 10, "TeamTop")    # standing pos=1 (best vacancy)
+            await _insert_team(db, 102, 10, "TeamBottom") # standing pos=2
+            await _insert_team(db, 103, 10, "Reserve", is_reserve=1)
+
+            await _add_driver_to_team(db, 101, 1)
+            await _add_driver_to_team(db, 102, 2)
+            await _add_driver_to_team(db, 103, 3)
+            await _add_driver_to_team(db, 103, 4)
+
+            # Both teams DECLINED (same tier 2)
+            await _insert_dra(db, 42, 10, 1, "DECLINED")
+            await _insert_dra(db, 42, 10, 2, "DECLINED")
+            early_dra = await _insert_dra(db, 42, 10, 3, "ACCEPTED", "2025-06-01T09:00:00+00:00")
+            late_dra  = await _insert_dra(db, 42, 10, 4, "ACCEPTED", "2025-06-01T11:00:00+00:00")
+
+            await db.execute(
+                "INSERT INTO team_standings_snapshots (team_instance_id, round_id, standing_position) VALUES (101, 41, 1)"
+            )
+            await db.execute(
+                "INSERT INTO team_standings_snapshots (team_instance_id, round_id, standing_position) VALUES (102, 41, 2)"
+            )
+            await db.commit()
+
+        bot = _make_bot(db_path)
+        await run_reserve_distribution(42, 10, bot)
+
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            early_row = await _get_dra(db, early_dra)
+            late_row  = await _get_dra(db, late_dra)
+
+        assert early_row["assigned_team_id"] == 101  # TeamTop — best available
+        assert late_row["assigned_team_id"]  == 102  # TeamBottom
+
+
+# ---------------------------------------------------------------------------
+# 6. Standby classification
+# ---------------------------------------------------------------------------
+
+
+class TestStandbyClassification:
+    @pytest.mark.asyncio
+    async def test_excess_reserve_is_standby(self, tmp_path):
+        """When there are more accepted reserves than vacancies, extras become standby."""
+        db_path = await _make_db(tmp_path)
+        await _seed_base(db_path)
+
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            await _insert_driver(db, 1, "D1")         # the only non-reserve driver
+            await _insert_driver(db, 2, "ReserveA")
+            await _insert_driver(db, 3, "ReserveB")   # this one should end up standby
+
+            await _insert_team(db, 101, 10, "SoloTeam")  # one vacancy
+            await _insert_team(db, 102, 10, "Reserve", is_reserve=1)
+
+            await _add_driver_to_team(db, 101, 1)
+            await _add_driver_to_team(db, 102, 2)
+            await _add_driver_to_team(db, 102, 3)
+
+            await _insert_dra(db, 42, 10, 1, "DECLINED")  # one vacancy
+            first_dra  = await _insert_dra(db, 42, 10, 2, "ACCEPTED", "2025-06-01T10:00:00+00:00")
+            second_dra = await _insert_dra(db, 42, 10, 3, "ACCEPTED", "2025-06-01T11:00:00+00:00")
+            await db.commit()
+
+        bot = _make_bot(db_path)
+        await run_reserve_distribution(42, 10, bot)
+
+        async with aiosqlite.connect(db_path) as db:
+            db.row_factory = aiosqlite.Row
+            first_row  = await _get_dra(db, first_dra)
+            second_row = await _get_dra(db, second_dra)
+
+        assert first_row["is_standby"] == 0
+        assert first_row["assigned_team_id"] == 101
+        assert second_row["is_standby"] == 1
+        assert second_row["assigned_team_id"] is None
+
+
+# ---------------------------------------------------------------------------
+# 7. AttendanceService CRUD round-trips
+# ---------------------------------------------------------------------------
+
+
+async def _make_attendance_db(tmp_path) -> str:
+    """Create DB with attendance tables (mirrors migration 031_attendance_rsvp.sql)."""
+    path = str(tmp_path / "att_crud.db")
+    async with aiosqlite.connect(path) as db:
+        await db.executescript(
+            """
+            CREATE TABLE driver_round_attendance (
+                id                INTEGER PRIMARY KEY AUTOINCREMENT,
+                round_id          INTEGER NOT NULL,
+                division_id       INTEGER NOT NULL,
+                driver_profile_id INTEGER NOT NULL,
+                rsvp_status       TEXT    NOT NULL DEFAULT 'NO_RSVP',
+                accepted_at       TEXT,
+                assigned_team_id  INTEGER,
+                is_standby        INTEGER NOT NULL DEFAULT 0,
+                attended          INTEGER,
+                UNIQUE (round_id, division_id, driver_profile_id)
+            );
+
+            CREATE TABLE rsvp_embed_messages (
+                id          INTEGER PRIMARY KEY AUTOINCREMENT,
+                round_id    INTEGER NOT NULL,
+                division_id INTEGER NOT NULL,
+                message_id  TEXT    NOT NULL,
+                channel_id  TEXT    NOT NULL,
+                posted_at   TEXT    NOT NULL,
+                UNIQUE (round_id, division_id)
+            );
+            """
+        )
+        await db.commit()
+    return path
+
+
+class TestAttendanceServiceCrud:
+    @pytest.mark.asyncio
+    async def test_bulk_insert_and_get(self, tmp_path):
+        db_path = await _make_attendance_db(tmp_path)
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+
+        await svc.bulk_insert_attendance_rows(
+            round_id=1, division_id=10, driver_profile_ids=[100, 200, 300]
+        )
+        rows = await svc.get_attendance_rows(round_id=1, division_id=10)
+        assert len(rows) == 3
+        assert all(r.rsvp_status == "NO_RSVP" for r in rows)
+
+    @pytest.mark.asyncio
+    async def test_bulk_insert_idempotent(self, tmp_path):
+        """INSERT OR IGNORE: calling twice should not raise or duplicate."""
+        db_path = await _make_attendance_db(tmp_path)
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+
+        await svc.bulk_insert_attendance_rows(1, 10, [100, 200])
+        await svc.bulk_insert_attendance_rows(1, 10, [100, 200])  # idempotent
+        rows = await svc.get_attendance_rows(round_id=1, division_id=10)
+        assert len(rows) == 2
+
+    @pytest.mark.asyncio
+    async def test_upsert_sets_accepted_at_for_accepted(self, tmp_path):
+        db_path = await _make_attendance_db(tmp_path)
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+
+        await svc.bulk_insert_attendance_rows(1, 10, [100])
+        await svc.upsert_rsvp_status(1, 10, 100, "ACCEPTED")
+        row = await svc.get_attendance_row_for_driver(1, 10, 100)
+        assert row is not None
+        assert row.rsvp_status == "ACCEPTED"
+        assert row.accepted_at is not None
+
+    @pytest.mark.asyncio
+    async def test_upsert_clears_accepted_at_for_declined(self, tmp_path):
+        db_path = await _make_attendance_db(tmp_path)
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+
+        await svc.bulk_insert_attendance_rows(1, 10, [100])
+        await svc.upsert_rsvp_status(1, 10, 100, "ACCEPTED")
+        await svc.upsert_rsvp_status(1, 10, 100, "DECLINED")
+        row = await svc.get_attendance_row_for_driver(1, 10, 100)
+        assert row is not None
+        assert row.rsvp_status == "DECLINED"
+        assert row.accepted_at is None
+
+    @pytest.mark.asyncio
+    async def test_get_attendance_row_for_driver_returns_none_when_missing(self, tmp_path):
+        db_path = await _make_attendance_db(tmp_path)
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        row = await svc.get_attendance_row_for_driver(99, 10, 999)
+        assert row is None
+
+    @pytest.mark.asyncio
+    async def test_insert_and_get_embed_message(self, tmp_path):
+        db_path = await _make_attendance_db(tmp_path)
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+
+        await svc.insert_embed_message(1, 10, "999000111", "555000222")
+        em = await svc.get_embed_message(round_id=1, division_id=10)
+        assert em is not None
+        assert em.message_id == "999000111"
+        assert em.channel_id == "555000222"
+
+    @pytest.mark.asyncio
+    async def test_insert_embed_message_upserts(self, tmp_path):
+        """Re-inserting same (round, division) should update message_id, not raise."""
+        db_path = await _make_attendance_db(tmp_path)
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+
+        await svc.insert_embed_message(1, 10, "first_msg", "111")
+        await svc.insert_embed_message(1, 10, "second_msg", "111")  # upsert
+        em = await svc.get_embed_message(round_id=1, division_id=10)
+        assert em is not None
+        assert em.message_id == "second_msg"
+
+    @pytest.mark.asyncio
+    async def test_get_embed_message_returns_none_when_missing(self, tmp_path):
+        db_path = await _make_attendance_db(tmp_path)
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+        em = await svc.get_embed_message(round_id=99, division_id=10)
+        assert em is None
+
+    @pytest.mark.asyncio
+    async def test_get_all_embed_messages(self, tmp_path):
+        db_path = await _make_attendance_db(tmp_path)
+        from services.attendance_service import AttendanceService
+        svc = AttendanceService(db_path)
+
+        await svc.insert_embed_message(1, 10, "msg_a", "ch1")
+        await svc.insert_embed_message(2, 10, "msg_b", "ch1")
+        all_msgs = await svc.get_all_embed_messages()
+        assert len(all_msgs) == 2
+        mids = {m.message_id for m in all_msgs}
+        assert "msg_a" in mids
+        assert "msg_b" in mids


### PR DESCRIPTION
## RSVPing
- Days before a round is scheduled to happen, the exact number of which configured via the "attendance config rsvp-notice", the bot shall post an announcement via an embed, in the configured RSVP channel for the division of the round, asking drivers if they are attending the round.
    - The embed shall be titled "Season <X> Round <X> - <Grand Prix Name of track>
    - The text of the embed shall contain:
        - Time: <Datetime of the event as a dynamic discord timestamp>
        - Location: <Location of the circuit where the event is configured to take place at> - Mystery if event type is Mystery
        - Event type: Normal/Sprint/Mystery/Endurance
        - A mini-list for each one of the teams in the division (plus reserves), containing the display name of the drivers in that team plus an indicator of their RSVP status (if the driver has not checked-in, then it will be just "()").
    - Three buttons distributed horizontally will be placed below the embedded:
        - "Accept" with the green checkmark emoji
        - "Tentative" with default background and the white question mark emoji
        - "Decline" with the red cross mark emoji
- When a driver picks any of the three options above, the RSVP status indicator in the embed shall change:
    - Green checkmark emoji within the brackets if accepted (will race)
    - White question mark emoji within the brackets if tentative (uncertain)
    - Red cross mark emoji within the brackets if declined (won't show up)
- Full-time drivers will be allowed to change their chosen option until the RSVP deadline is met. After that point, the choices are locked.
- Reserve drivers will be allowed to change their chosen option until the time of the round, provided they have NOT accepted the check-in. After that point, the choices are locked.
- RSVP status shall be persisted under the round data entries in the database, as they will be necessary later.

### Distribution of reserves
- Once the RSVP deadline is reached, reserves that have confirmed their presence with "accepted" will be distributed by teams according to the following priority:
    - Teams in which drivers have failed to RSVP;
    - Teams in which drivers have declined the check-in;
    - Teams in which drivers have marked themselves as tentative.
- If there are two or more teams that fit each one of the criteria, the following tie-breakers will be used:
    - Number of drivers that have confirmed with "accept" (first priority is given to those teams that have no drivers participating).
    - Lowest positioned team in the Constructors' Championship of that division.
- Reserves shall be picked according to the time they confirmed their attendance; first ones to accept the check-in shall be the first to be placed in a team.
    - Every time a reserve changes RSVP status to accepted, the time will be updated. So flip-flopping on attendance is bad.
- After distribution of reserves, any reserves that have confirmed attendance but remain without a seat for the round will be considered as being "on standby".
- After standbys are determined, the post shall post a message on the check-in channel of the division mentioning the Discord users and informing them of the team they are racing for. The standby reserve drivers shall also be informed of their standby status, to be ready to jump into the race in case someone no-shows.